### PR TITLE
Fix Search Apps hint on SDK < 24

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
@@ -678,6 +678,16 @@ public final class Utilities {
                 size, metrics));
     }
 
+    public static Paint.FontMetricsInt fontMetricsIntFromFontMetrics(Paint.FontMetrics fontMetrics) {
+        Paint.FontMetricsInt fontMetricsInt = new Paint.FontMetricsInt();
+        fontMetricsInt.ascent = Math.round(fontMetrics.ascent);
+        fontMetricsInt.bottom = Math.round(fontMetrics.bottom);
+        fontMetricsInt.descent = Math.round(fontMetrics.descent);
+        fontMetricsInt.leading = Math.round(fontMetrics.leading);
+        fontMetricsInt.top = Math.round(fontMetrics.top);
+        return fontMetricsInt;
+    }
+
     public static String createDbSelectionQuery(String columnName, Iterable<?> values) {
         return String.format(Locale.ENGLISH, "%s IN (%s)", columnName, TextUtils.join(", ", values));
     }

--- a/app/src/main/java/ch/deletescape/lawnchair/graphics/TintedDrawableSpan.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/graphics/TintedDrawableSpan.java
@@ -22,6 +22,8 @@ import android.graphics.Paint.FontMetricsInt;
 import android.graphics.drawable.Drawable;
 import android.text.style.DynamicDrawableSpan;
 
+import ch.deletescape.lawnchair.Utilities;
+
 /**
  * {@link DynamicDrawableSpan} which draws a drawable tinted with the current paint color.
  */
@@ -39,6 +41,8 @@ public class TintedDrawableSpan extends DynamicDrawableSpan {
     @Override
     public int getSize(Paint paint, CharSequence text, int start, int end, FontMetricsInt fm) {
         fm = fm == null ? paint.getFontMetricsInt() : fm;
+        if (!Utilities.isNycOrAbove())
+            fm = Utilities.fontMetricsIntFromFontMetrics(paint.getFontMetrics());
         int iconSize = fm.bottom - fm.top;
         mDrawable.setBounds(0, 0, iconSize, iconSize);
         return super.getSize(paint, text, start, end, fm);


### PR DESCRIPTION
On phones on Android SDK < 24, getFontMetricsInt returns erroneous values, leading to the hint text being moved downwards, like shown in this [video](https://drive.google.com/file/d/0B7NA3219RnozYlRoWTBhOG5YRGM/view?usp=sharing). This fixes that.