### PR TITLE
Improve weather widget time for the UK

### DIFF
--- a/app/src/main/res/values-en-rGB/donottranslate.xml
+++ b/app/src/main/res/values-en-rGB/donottranslate.xml
@@ -1,0 +1,22 @@
+<!--
+      Copyright (C) 2017 The MoKee Open Source Project
+ 
+      This program is free software: you can redistribute it and/or modify
+      it under the terms of the GNU General Public License as published by
+      the Free Software Foundation, either version 3 of the License, or
+      (at your option) any later version.
+ 
+      This program is distributed in the hope that it will be useful,
+      but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+      GNU General Public License for more details.
+ 
+      You should have received a copy of the GNU General Public License
+      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+ 
+ <resources>
+     <!-- Time format for Weather Widget -->
+     <string name="full_wday_month_day_no_year">EEEE, d MMMM</string>
+ </resources>
+ 


### PR DESCRIPTION
UK dates are written, e.g. "Monday, 31 July" instead of "Monday, July 31".