### PR TITLE
Full app drawer theming added

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/BaseRecyclerViewFastScrollBar.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/BaseRecyclerViewFastScrollBar.java
@@ -90,7 +90,7 @@ public class BaseRecyclerViewFastScrollBar {
         mTrackPaint = new Paint();
         mTrackPaint.setColor(rv.getFastScrollerTrackColor(Color.BLACK));
         mTrackPaint.setAlpha(MAX_TRACK_ALPHA);
-        mThumbActiveColor = mThumbInactiveColor = Utilities.getDynamicAccent(rv.getContext());
+        mThumbActiveColor = mThumbInactiveColor = Utilities.getThemer().allAppsFastScrollerHandleColor(rv.getContext());
         mThumbPaint = new Paint();
         mThumbPaint.setAntiAlias(true);
         mThumbPaint.setColor(mThumbInactiveColor);

--- a/app/src/main/java/ch/deletescape/lawnchair/BaseRecyclerViewFastScrollPopup.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/BaseRecyclerViewFastScrollPopup.java
@@ -68,17 +68,13 @@ public class BaseRecyclerViewFastScrollPopup {
         mBg.setBounds(0, 0, mBgOriginalSize, mBgOriginalSize);
 
         mTextPaint = new Paint();
-        mTextPaint.setColor(Color.WHITE);
         mTextPaint.setAntiAlias(true);
         mTextPaint.setTextSize(res.getDimensionPixelSize(R.dimen.container_fastscroll_popup_text_size));
 
-        if (Utilities.getPrefs(rv.getContext()).isDynamicUiEnabled()) {
-            int tint = Utilities.getDynamicAccent(rv.getContext());
-            if (tint != -1) {
-                mBg.setTint(tint);
-                mTextPaint.setColor(Utilities.getColor(rv.getContext(), ExtractedColors.VIBRANT_FOREGROUND_INDEX, Color.WHITE));
-            }
+        if (Utilities.getThemer().allAppsFastScrollerPopupTintColor(rv.getContext()) != null) {
+            mBg.setTint(Utilities.getThemer().allAppsFastScrollerPopupTintColor(rv.getContext()));
         }
+        mTextPaint.setColor(Utilities.getThemer().allAppsFastScrollerPopupTextColor(rv.getContext()));
 
         mShadowPaint = new Paint();
         mShadowPaint.setAntiAlias(true);

--- a/app/src/main/java/ch/deletescape/lawnchair/Launcher.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Launcher.java
@@ -2438,10 +2438,7 @@ public class Launcher extends Activity
      * on the home screen.
      */
     public void onClickSettingsButton(View v) {
-        Intent intent = new Intent(Intent.ACTION_APPLICATION_PREFERENCES)
-                .setPackage(getPackageName());
-        intent.setSourceBounds(getViewBounds(v));
-        startActivity(intent, getActivityLaunchOptions(v));
+        Utilities.getPrefs(this).showSettings(this, v);
     }
 
     public View.OnTouchListener getHapticFeedbackTouchListener() {

--- a/app/src/main/java/ch/deletescape/lawnchair/allapps/AllAppsContainerView.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/allapps/AllAppsContainerView.java
@@ -264,10 +264,14 @@ public class AllAppsContainerView extends BaseContainerView implements DragSourc
 
         mSearchContainer = findViewById(R.id.search_container);
         mSearchInput = findViewById(R.id.search_box_input);
-        int accent = Utilities.getDynamicAccent(getContext());
+        int hintAndCursorColor = Utilities.getThemer().allAppsSearchBarHintTextColor(getContext());
         if (!mUseRoundSearchBar)
-            mSearchInput.setHintTextColor(accent);
-        mSearchInput.setCursorColor(accent);
+            mSearchInput.setHintTextColor(hintAndCursorColor);
+        mSearchInput.setCursorColor(hintAndCursorColor);
+
+        if (Utilities.getThemer().allAppsSearchTextColor(getContext()) != null) {
+            mSearchInput.setTextColor(Utilities.getThemer().allAppsSearchTextColor(getContext()));
+        }
 
         // Update the hint to contain the icon.
         // Prefix the original hint with two spaces. The first space gets replaced by the icon
@@ -650,8 +654,8 @@ public class AllAppsContainerView extends BaseContainerView implements DragSourc
         mAllAppsBackground.setBlurOpacity(opacity);
     }
 
-    public void setAppIconTextColor(int color) {
-        mAdapter.setAppIconTextColor(color);
+    public void setAppIconTextStyle(int color, int maxLines) {
+        mAdapter.setAppIconTextStyle(color, maxLines);
         mAdapter.notifyDataSetChanged();
     }
 }

--- a/app/src/main/java/ch/deletescape/lawnchair/allapps/AllAppsGridAdapter.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/allapps/AllAppsGridAdapter.java
@@ -167,6 +167,7 @@ public class AllAppsGridAdapter extends RecyclerView.Adapter<AllAppsGridAdapter.
     private Intent mMarketSearchIntent;
 
     private int mAppIconTextColor;
+    private int mAppIconTextMaxLines;
 
     public AllAppsGridAdapter(Launcher launcher, AlphabeticalAppsList apps, View.OnClickListener
             iconClickListener, View.OnLongClickListener iconLongClickListener) {
@@ -268,7 +269,7 @@ public class AllAppsGridAdapter extends RecyclerView.Adapter<AllAppsGridAdapter.
             case VIEW_TYPE_SEARCH_MARKET:
                 TextView searchMarketView = (TextView) mLayoutInflater.inflate(R.layout.all_apps_search_market,
                         parent, false);
-                searchMarketView.setTextColor(Utilities.getDynamicAccent(mLauncher));
+                searchMarketView.setTextColor(Utilities.getThemer().allAppsSearchBarHintTextColor(mLauncher));
                 searchMarketView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -280,11 +281,13 @@ public class AllAppsGridAdapter extends RecyclerView.Adapter<AllAppsGridAdapter.
                 ImageView divider = (ImageView) mLayoutInflater.inflate(
                         R.layout.all_apps_search_divider, parent, false);
                 if (!Utilities.getPrefs(mLauncher).useRoundSearchBar())
-                    divider.setImageDrawable(new ColorDrawable(Utilities.getDynamicAccent(parent.getContext())));
+                    divider.setImageDrawable(new ColorDrawable(Utilities.getThemer().allAppsSearchBarHintTextColor(mLauncher)));
                 return new ViewHolder(divider);
             case VIEW_TYPE_SEARCH_MARKET_DIVIDER:
-                return new ViewHolder(mLayoutInflater.inflate(
-                        R.layout.all_apps_divider, parent, false));
+                ImageView marketDivider = (ImageView)mLayoutInflater.inflate(
+                        R.layout.all_apps_divider, parent, false);
+                marketDivider.setImageDrawable(new ColorDrawable(Utilities.getThemer().allAppsSearchBarHintTextColor(mLauncher)));
+                return new ViewHolder(marketDivider);
             default:
                 throw new RuntimeException("Unexpected view type");
         }
@@ -299,6 +302,10 @@ public class AllAppsGridAdapter extends RecyclerView.Adapter<AllAppsGridAdapter.
                 icon.applyFromApplicationInfo(info);
                 icon.setAccessibilityDelegate(mLauncher.getAccessibilityDelegate());
                 icon.setTextColor(mAppIconTextColor);
+                // TODO: currently this cuts off the text
+//                icon.setLines(mAppIconTextMaxLines);
+//                icon.setMaxLines(mAppIconTextMaxLines);
+//                icon.setSingleLine(mAppIconTextMaxLines == 1);
                 break;
             }
             case VIEW_TYPE_EMPTY_SEARCH:
@@ -338,7 +345,8 @@ public class AllAppsGridAdapter extends RecyclerView.Adapter<AllAppsGridAdapter.
         return item.viewType;
     }
 
-    public void setAppIconTextColor(int color) {
+    public void setAppIconTextStyle(int color, int maxLines) {
         mAppIconTextColor = color;
+        mAppIconTextMaxLines = maxLines;
     }
 }

--- a/app/src/main/java/ch/deletescape/lawnchair/allapps/AllAppsTransitionController.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/allapps/AllAppsTransitionController.java
@@ -119,19 +119,9 @@ public class AllAppsTransitionController implements TouchController, VerticalPul
 
     public void setAllAppsAlpha(Context context, int allAppsAlpha) {
         this.allAppsAlpha = allAppsAlpha;
-        mAppsView.setAppIconTextColor(getAppIconTextColor(context, allAppsAlpha));
-    }
-
-    private int getAppIconTextColor(Context context, int allAppsAlpha) {
-        if (Utilities.getPrefs(context).useCustomAllAppsTextColor(context)) {
-            return Utilities.getLabelColor(context);
-        } else if (FeatureFlags.INSTANCE.useDarkTheme(FeatureFlags.DARK_ALLAPPS)) {
-            return Color.WHITE;
-        } else if ((allAppsAlpha < 128 && !BlurWallpaperProvider.Companion.isEnabled(BlurWallpaperProvider.BLUR_ALLAPPS)) || allAppsAlpha < 50) {
-            return Color.WHITE;
-        } else {
-            return context.getResources().getColor(R.color.quantum_panel_text_color);
-        }
+        mAppsView.setAppIconTextStyle(
+                Utilities.getThemer().allAppsIconTextColor(context, allAppsAlpha),
+                Utilities.getThemer().allAppsIconTextLines(context));
     }
 
     @Override

--- a/app/src/main/java/ch/deletescape/lawnchair/config/IThemer.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/config/IThemer.kt
@@ -14,4 +14,15 @@ interface IThemer {
 
     fun allAppsBackgroundColor(context: Context) : Int
     fun allAppsBackgroundColorBlur(context: Context) : Int
+    fun allAppsIconTextColor(context: Context, allAppsAlpha: Int) : Int
+    fun allAppsIconTextLines(context: Context) : Int
+    fun allAppsSearchTextColor(context: Context) : Int?
+    /*
+     * this color is also used for the market search button, the market item divider and the search bar divider
+     * currently ignored as hint color for round search bar
+     */
+    fun allAppsSearchBarHintTextColor(context: Context) : Int
+    fun allAppsFastScrollerHandleColor(context: Context) : Int
+    fun allAppsFastScrollerPopupTintColor(context: Context): Int?
+    fun allAppsFastScrollerPopupTextColor(context: Context) : Int
 }

--- a/app/src/main/java/ch/deletescape/lawnchair/config/ThemerImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/config/ThemerImpl.kt
@@ -1,19 +1,73 @@
 package ch.deletescape.lawnchair.preferences
 
 import android.content.Context
+import android.graphics.Color
+import android.support.v4.content.ContextCompat
 import ch.deletescape.lawnchair.R
 import ch.deletescape.lawnchair.Utilities
+import ch.deletescape.lawnchair.blur.BlurWallpaperProvider
 import ch.deletescape.lawnchair.config.FeatureFlags
+import ch.deletescape.lawnchair.dynamicui.ExtractedColors
 
-open class ThemerImpl : IThemer{
+open class ThemerImpl : IThemer {
+    override fun allAppsIconTextLines(context: Context): Int {
+        // TODO: currently only 1 is supported, higher values result in cut off lables
+        return 1
+    }
+
+    override fun allAppsSearchTextColor(context: Context): Int? {
+        return null
+    }
+
+    override fun allAppsSearchBarHintTextColor(context: Context): Int {
+        return Utilities.getDynamicAccent(context)
+    }
+
+    override fun allAppsFastScrollerPopupTintColor(context: Context): Int? {
+        if (Utilities.getPrefs(context).isDynamicUiEnabled()) {
+            val tint = Utilities.getDynamicAccent(context)
+            if (tint != -1) {
+                return tint
+            }
+        }
+        return null
+    }
+
+    override fun allAppsFastScrollerPopupTextColor(context: Context): Int {
+        var color = Color.WHITE
+        if (Utilities.getPrefs(context).isDynamicUiEnabled()) {
+            val tint = Utilities.getDynamicAccent(context)
+            if (tint != -1) {
+                color = Utilities.getColor(context, ExtractedColors.VIBRANT_FOREGROUND_INDEX, Color.WHITE)
+            }
+        }
+        return color
+    }
+
+    override fun allAppsIconTextColor(context: Context, allAppsAlpha: Int): Int {
+        if (Utilities.getPrefs(context).useCustomAllAppsTextColor(context)) {
+            return Utilities.getLabelColor(context)
+        } else if (FeatureFlags.useDarkTheme(FeatureFlags.DARK_ALLAPPS)) {
+            return Color.WHITE
+        } else if (allAppsAlpha < 128 && !BlurWallpaperProvider.isEnabled(BlurWallpaperProvider.BLUR_ALLAPPS) || allAppsAlpha < 50) {
+            return Color.WHITE
+        } else {
+            return ContextCompat.getColor(context, R.color.quantum_panel_text_color)
+        }
+    }
+
+    override fun allAppsFastScrollerHandleColor(context: Context): Int {
+        return Utilities.getDynamicAccent(context)
+    }
+
     override fun allAppsBackgroundColor(context: Context): Int {
         return Utilities
-                .resolveAttributeData(FeatureFlags.applyDarkTheme(context, FeatureFlags.DARK_ALLAPPS), R.attr.allAppsContainerColor);
+                .resolveAttributeData(FeatureFlags.applyDarkTheme(context, FeatureFlags.DARK_ALLAPPS), R.attr.allAppsContainerColor)
     }
 
     override fun allAppsBackgroundColorBlur(context: Context): Int {
         return Utilities
-                .resolveAttributeData(FeatureFlags.applyDarkTheme(context, FeatureFlags.DARK_BLUR), R.attr.allAppsContainerColorBlur);
+                .resolveAttributeData(FeatureFlags.applyDarkTheme(context, FeatureFlags.DARK_BLUR), R.attr.allAppsContainerColorBlur)
     }
 
 }

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
@@ -1,7 +1,10 @@
 package ch.deletescape.lawnchair.preferences
 
+import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
+import android.view.View
+import ch.deletescape.lawnchair.Launcher
 
 interface IPreferenceProvider {
 
@@ -223,9 +226,11 @@ interface IPreferenceProvider {
     fun appsViewShown(value: Boolean, commit: Boolean = false)
 
     // -----------------
-    // LISTENER
+    // LISTENER, FUNCTIONS
     // -----------------
 
     fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener)
     fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener)
+
+    fun showSettings(launcher: Launcher, view: View)
 }

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
@@ -82,6 +82,8 @@ object PreferenceFlags {
     const val KEY_PREF_WEATHER = "pref_weather"
     const val KEY_PREF_ENABLE_EDITING = "pref_enableEditing"
     const val KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR = "pref_allAppsCustomLabelColor"
+    const val KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR_HUE = "pref_allAppsCustomLabelColorHue"
+    const val KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR_VARITATION = "pref_allAppsCustomLabelColorVariation"
 
     const val KEY_APP_VISIBILITY_PREFIX = "visibility_"
     const val KEY_PREVIOUS_BUILD_NUMBER = "previousBuildNumber"

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
@@ -1,13 +1,25 @@
 package ch.deletescape.lawnchair.preferences
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
+import android.view.View
+import ch.deletescape.lawnchair.Launcher
 import ch.deletescape.lawnchair.LauncherFiles
 import ch.deletescape.lawnchair.config.FeatureFlags
 import ch.deletescape.lawnchair.config.PreferenceProvider
 import ch.deletescape.lawnchair.dynamicui.ExtractedColors
 
 open class PreferenceImpl : IPreferenceProvider {
+
+    override fun showSettings(launcher: Launcher, view: View) {
+        val intent = Intent(Intent.ACTION_APPLICATION_PREFERENCES)
+                .setPackage(launcher.getPackageName())
+        intent.sourceBounds = launcher.getViewBounds(view)
+        launcher.startActivity(intent, launcher.getActivityLaunchOptions(view))
+    }
+
     override fun numRowsDrawer(default: String): String {
         return getString(PreferenceFlags.KEY_PREF_NUM_ROWS_DRAWER, default)
     }

--- a/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
@@ -11,9 +11,6 @@ import ch.deletescape.lawnchair.preferences.IPreferenceProvider;
 import ch.deletescape.lawnchair.preferences.PreferenceFlags;
 
 public class Settings implements SharedPreferences.OnSharedPreferenceChangeListener {
-    private static final String KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR = "pref_allAppsCustomLabelColor";
-    private static final String KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR_HUE = "pref_allAppsCustomLabelColorHue";
-    private static final String KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR_VARITATION = "pref_allAppsCustomLabelColorVariation";
     private static Settings instance;
     private Launcher mLauncher;
     private IPreferenceProvider preferences;
@@ -104,9 +101,9 @@ public class Settings implements SharedPreferences.OnSharedPreferenceChangeListe
                 case PreferenceFlags.KEY_PREF_ROUND_SEARCH_BAR:
                 case PreferenceFlags.KEY_SHOW_PIXEL_BAR:
                 case PreferenceFlags.KEY_PREF_HIDE_HOTSEAT:
-                case KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR:
-                case KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR_HUE:
-                case KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR_VARITATION:
+                case PreferenceFlags.KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR:
+                case PreferenceFlags.KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR_HUE:
+                case PreferenceFlags.KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR_VARITATION:
                     mLauncher.scheduleRecreate();
                     break;
                 case PreferenceFlags.KEY_PREF_ICON_SCALE:


### PR DESCRIPTION
Theming for app drawer finished - fully support text, background, hint, handle, popup and popup text colors now

Tried to add a setting for text lines of app drawer items, but this is currently commented out because `BubbleTextView` does cut off the texts if lines are greater than 1...