### PR TITLE
Add support for animated clock icon on MIUI

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
@@ -982,6 +982,7 @@ public final class Utilities {
         ArrayList<String> clockApps = new ArrayList<>();
         clockApps.add("com.google.android.deskclock/com.android.deskclock.DeskClock"); // Stock
         clockApps.add("com.sec.android.app.clockpackage/com.sec.android.app.clockpackage.ClockPackage"); // Samsung
+        clockApps.add("com.android.deskclock/com.android.deskclock.DeskClockTabActivity"); // MIUI
 
         return clockApps.contains(componentName.flattenToString());
     }


### PR DESCRIPTION
Tested on my Redmi Note 3 running MIUI 9 by Xiaomi.eu