### PR TITLE
Allow icon labels to use 2 lines

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/BubbleTextView.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/BubbleTextView.java
@@ -31,6 +31,7 @@ import android.graphics.Rect;
 import android.graphics.Region;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Property;
 import android.util.SparseArray;
@@ -162,6 +163,12 @@ public class BubbleTextView extends TextView
         mIconSize = a.getDimensionPixelSize(R.styleable.BubbleTextView_iconSizeOverride,
                 defaultIconSize);
         a.recycle();
+
+        if (Utilities.getPrefs(context).getIconLabelsInTwoLines()) {
+            setMaxLines(2);
+            setEllipsize(TextUtils.TruncateAt.END);
+            setHorizontallyScrolling(false);
+        }
 
         if (mCustomShadowsEnabled) {
             // Draw the background itself as the parent is drawn twice.

--- a/app/src/main/java/ch/deletescape/lawnchair/DeviceProfile.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/DeviceProfile.java
@@ -289,24 +289,25 @@ public class DeviceProfile {
         allAppsIconDrawablePaddingPx = allAppsDrawablePadding;
         allAppsIconTextSizePx = (int) (Utilities.pxFromSp(inv.allAppsIconTextSize, dm) * allAppsScale);
 
+        boolean iconLabelsInTwoLines = Utilities.getPrefs(mContext).getIconLabelsInTwoLines();
         cellWidthPx = iconSizePx;
         cellHeightPx = iconSizePx + iconDrawablePaddingPx;
         if (!Utilities.getPrefs(mContext).getHideAppLabels()) {
-            cellHeightPx += Utilities.calculateTextHeight(iconTextSizePx);
+            cellHeightPx += Utilities.calculateTextHeight(iconTextSizePx, iconLabelsInTwoLines);
         }
         allAppsCellWidthPx = allAppsIconSizePx;
         allAppsCellHeightPx = allAppsIconSizePx + allAppsIconDrawablePaddingPx;
         if (!Utilities.getPrefs(mContext).getHideAllAppsAppLabels()) {
-            allAppsCellHeightPx += Utilities.calculateTextHeight(allAppsIconTextSizePx);
+            allAppsCellHeightPx += Utilities.calculateTextHeight(allAppsIconTextSizePx, iconLabelsInTwoLines);
         }
         cellHeightPx = iconSizePx;
         if (!Utilities.getPrefs(mContext).getHideAppLabels()) {
-            cellHeightPx += iconDrawablePaddingPx + Utilities.calculateTextHeight(iconTextSizePx);
+            cellHeightPx += iconDrawablePaddingPx + Utilities.calculateTextHeight(iconTextSizePx, iconLabelsInTwoLines);
         }
         allAppsCellWidthPx = allAppsIconSizePx;
         allAppsCellHeightPx = allAppsIconSizePx;
         if (!Utilities.getPrefs(mContext).getHideAllAppsAppLabels()) {
-            allAppsCellHeightPx += allAppsIconDrawablePaddingPx + Utilities.calculateTextHeight(allAppsIconTextSizePx);
+            allAppsCellHeightPx += allAppsIconDrawablePaddingPx + Utilities.calculateTextHeight(allAppsIconTextSizePx, iconLabelsInTwoLines);
         }
 
         // Hotseat
@@ -329,12 +330,12 @@ public class DeviceProfile {
         int cellPaddingX = res.getDimensionPixelSize(R.dimen.folder_cell_x_padding);
         int cellPaddingY = res.getDimensionPixelSize(R.dimen.folder_cell_y_padding);
         final int folderChildTextSize =
-                Utilities.calculateTextHeight(res.getDimension(R.dimen.folder_child_text_size));
+                Utilities.calculateTextHeight(res.getDimension(R.dimen.folder_child_text_size), iconLabelsInTwoLines);
 
         final int folderBottomPanelSize =
                 res.getDimensionPixelSize(R.dimen.folder_label_padding_top)
                         + res.getDimensionPixelSize(R.dimen.folder_label_padding_bottom)
-                        + Utilities.calculateTextHeight(res.getDimension(R.dimen.folder_label_text_size));
+                        + Utilities.calculateTextHeight(res.getDimension(R.dimen.folder_label_text_size), iconLabelsInTwoLines);
 
         // Don't let the folder get too close to the edges of the screen.
         folderCellWidthPx = Math.min(iconSizePx + 2 * cellPaddingX,

--- a/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
@@ -641,11 +641,12 @@ public final class Utilities {
     /**
      * Calculates the height of a given string at a specific text size.
      */
-    public static int calculateTextHeight(float textSizePx) {
+    public static int calculateTextHeight(float textSizePx, boolean twoLines) {
         Paint p = new Paint();
         p.setTextSize(textSizePx);
         Paint.FontMetrics fm = p.getFontMetrics();
-        return (int) Math.ceil(fm.bottom - fm.top);
+        int result = (int) Math.ceil(fm.bottom - fm.top);
+        return twoLines ? result * 2 : result;
     }
 
     public static boolean isRtl(Resources res) {

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
@@ -92,6 +92,7 @@ interface IPreferenceProvider {
     val lockDesktop: Boolean
     val animatedClockIcon: Boolean
     val animateClockIconAlternativeClockApps: Boolean
+    val iconLabelsInTwoLines: Boolean
 
     val pulldownAction: String
 

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
@@ -38,6 +38,7 @@ object PreferenceFlags {
     const val KEY_LIGHT_STATUS_BAR = "pref_lightStatusBar"
     const val KEY_CENTER_WALLPAPER = "pref_centerWallpaper"
     const val KEY_POPUP_CARD_THEME = "pref_popupCardTheme"
+    const val KEY_ICON_LABELS_IN_TWO_LINES = "pref_iconLabelsInTwoLines"
 
     // Various
     const val KEY_PREF_WS_LABEL_COLOR = "pref_workspaceLabelColor"

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
@@ -37,6 +37,7 @@ open class PreferenceImpl(context: Context) : IPreferenceProvider {
     override val allAppsIconTextScale by FloatPref(PreferenceFlags.KEY_PREF_ALL_APPS_ICON_TEXT_SCALE, 1f)
     override val useCustomAllAppsTextColor by BooleanPref(PreferenceFlags.KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR, false)
     override val verticalDrawerLayout by BooleanPref(PreferenceFlags.KEY_PREF_DRAWER_VERTICAL_LAYOUT, false)
+    override val iconLabelsInTwoLines by BooleanPref(PreferenceFlags.KEY_ICON_LABELS_IN_TWO_LINES, false)
 
     override val animateClockIconAlternativeClockApps: Boolean
         get() = false

--- a/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
@@ -122,6 +122,7 @@ public class Settings implements SharedPreferences.OnSharedPreferenceChangeListe
                     break;
                 case PreferenceFlags.KEY_PREF_ICON_PACK_PACKAGE:
                 case PreferenceFlags.KEY_PREF_PIXEL_STYLE_ICONS:
+                case PreferenceFlags.KEY_ICON_LABELS_IN_TWO_LINES:
                     mLauncher.scheduleReloadIcons();
                     break;
                 case PreferenceFlags.KEY_PREF_HIDE_APP_LABELS:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -323,6 +323,7 @@
     <string name="blur_pref_title">Enable blur</string>
     <string name="blur_pref_summary">Apply blur effect to parts of the interface\nNot compatible with live wallpapers</string>
     <string name="blur_radius_pref_title">Blur radius</string>
+    <string name="pref_iconLabelsInTwoLines">Icon labels in two lines</string>
     <string name="white_google_icon_pref_title">Use white Google icon</string>
     <string name="hide_icon_labels_pref_title">Hide icon labels on home screen</string>
     <string name="hide_all_apps_icon_labels_pref_title">Hide icon labels in drawer</string>

--- a/app/src/main/res/xml/launcher_ui_preferences.xml
+++ b/app/src/main/res/xml/launcher_ui_preferences.xml
@@ -277,5 +277,11 @@
             app:defaultSeekbarValue="75"
             app:summaryFormat="%.0f"
             android:persistent="true" />
+
+        <SwitchPreference
+            android:key="pref_iconLabelsInTwoLines"
+            android:title="@string/pref_iconLabelsInTwoLines"
+            android:defaultValue="false"
+            android:persistent="true" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This fixes #301 

Before
![before](https://user-images.githubusercontent.com/5843854/30777409-1b1e33ea-a0ba-11e7-99ff-6a0ceaff85da.jpg)

After
![after](https://user-images.githubusercontent.com/5843854/30777410-202b1a7e-a0ba-11e7-8ba6-449bca085388.jpg)
