### PR TITLE
Fix for icon shape 'Do not change' not working properly

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/graphics/IconShapeOverride.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/graphics/IconShapeOverride.kt
@@ -47,7 +47,6 @@ class IconShapeOverride {
     companion object {
 
         const val planeMask = "M21,16V14L13,9V3.5A1.5,1.5 0 0,0 11.5,2A1.5,1.5 0 0,0 10,3.5V9L2,14V16L10,13.5V19L8,20.5V22L11.5,21L15,22V20.5L13,19V13.5L21,16Z"
-        const val defaultMask = "M50 0C77.6 0 100 22.4 100 50C100 77.6 77.6 100 50 100C22.4 100 0 77.6 0 50C0 22.4 22.4 0 50 0Z"
 
         fun isSupported(context: Context): Boolean {
             if (Utilities.ATLEAST_NOUGAT && prefs(context).backportAdaptiveIcons) {
@@ -96,8 +95,6 @@ class IconShapeOverride {
             var iconShape = if (enablePlanes) planeMask else prefs.overrideIconShape
             val savedPref = iconShape
             val useRoundIcon = iconShape != "none"
-            if (!Utilities.ATLEAST_OREO && TextUtils.isEmpty(iconShape))
-                iconShape = defaultMask
             return ShapeInfo(if (iconShape == "none") "" else iconShape, savedPref, if (enablePlanes) 24 else 100, useRoundIcon)
         }
 

--- a/app/src/main/java/ch/deletescape/lawnchair/pixelify/PixelIconProvider.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/pixelify/PixelIconProvider.java
@@ -17,6 +17,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.UserHandle;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.util.Log;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -66,7 +67,7 @@ public class PixelIconProvider {
 
     private int getCorrectShape(Bundle bundle, Resources resources) {
         if (bundle != null) {
-            int roundIcons = bundle.getInt(mShapeInfo.getUseRoundIcon() ?
+            int roundIcons = bundle.getInt((mShapeInfo.getUseRoundIcon() && !TextUtils.isEmpty(mShapeInfo.getSavedPref())) ?
                     "com.google.android.calendar.dynamic_icons_nexus_round" :
                     "com.google.android.calendar.dynamic_icons", 0);
             if (roundIcons != 0) {
@@ -189,7 +190,7 @@ public class PixelIconProvider {
 
     public Drawable getDefaultIcon(LauncherActivityInfoCompat info, int iconDpi, Drawable drawable) {
         boolean isRoundPack = isRoundIconPack(sIconPack);
-        if ((drawable == null && (mBackportAdaptive || mShapeInfo.getUseRoundIcon())) ||
+        if ((drawable == null && (mBackportAdaptive || mShapeInfo.getUseRoundIcon()) && !TextUtils.isEmpty(mShapeInfo.getSavedPref())) ||
                 (isRoundPack && drawable instanceof CustomIconDrawable)) {
             Drawable roundIcon = getRoundIcon(info.getComponentName().getPackageName(), iconDpi);
             if (roundIcon != null)


### PR DESCRIPTION
This fixes #661 
After "Combine Pixel style preference to icon shape on API24+" commit, pixel style override "Do not change" and "Circle" was the same.
Now its as follow:
Do not change - use AOSP icons but with original shapes
None - use system icons (on my Huawei P10 it shows ugly Huawei icons so its fine)
Circle - use AOSP in circle