### PR TITLE
Icon text scalling fixes

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/DeviceProfile.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/DeviceProfile.java
@@ -279,6 +279,7 @@ public class DeviceProfile {
 
     private void updateIconSize(float workspaceScale, float allAppsScale, float hotseatScale, int workspaceDrawablePadding, int allAppsDrawablePadding,
                                 Resources res, DisplayMetrics dm) {
+        boolean iconLabelsInTwoLines = Utilities.getPrefs(mContext).getIconLabelsInTwoLines();
         iconSizePx = (int) (Utilities.pxFromDp(inv.iconSize, dm) * workspaceScale);
         iconSizePxOriginal = (int) (Utilities.pxFromDp(inv.iconSizeOriginal, dm) * workspaceScale);
         iconTextSizePx = (int) (Utilities.pxFromSp(inv.iconTextSize, dm) * workspaceScale);
@@ -286,10 +287,9 @@ public class DeviceProfile {
         hotseatIconSizePx = (int) (Utilities.pxFromDp(inv.hotseatIconSize, dm) * hotseatScale);
         hotseatIconSizePxOriginal = (int) (Utilities.pxFromDp(inv.hotseatIconSizeOriginal, dm) * hotseatScale);
         allAppsIconSizePx = (int) (Utilities.pxFromDp(inv.allAppsIconSize, dm) * allAppsScale);
-        allAppsIconDrawablePaddingPx = allAppsDrawablePadding;
+        allAppsIconDrawablePaddingPx = iconLabelsInTwoLines ? allAppsDrawablePadding * 2 : allAppsDrawablePadding;
         allAppsIconTextSizePx = (int) (Utilities.pxFromSp(inv.allAppsIconTextSize, dm) * allAppsScale);
 
-        boolean iconLabelsInTwoLines = Utilities.getPrefs(mContext).getIconLabelsInTwoLines();
         cellWidthPx = iconSizePx;
         cellHeightPx = iconSizePx + iconDrawablePaddingPx;
         if (!Utilities.getPrefs(mContext).getHideAppLabels()) {

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
@@ -26,7 +26,7 @@ object PreferenceFlags {
     const val KEY_BLUR_RADIUS = "pref_blurRadius"
     const val KEY_PREF_HOTSEAT_ICON_SCALE = "pref_hotseatIconScale"
     const val KEY_PREF_ALL_APPS_ICON_SCALE = "pref_allAppsIconScale"
-    const val KEY_PREF_ALL_APPS_ICON_TEXT_SCALE = "pref_alllAppsIconTextScale"
+    const val KEY_PREF_ALL_APPS_ICON_TEXT_SCALE = "pref_allAppsIconTextScale"
 
     //Ints
     const val KEY_BLUR_MODE = "pref_blurMode"


### PR DESCRIPTION
Fixes not working app drawer text scalling (typo) and increases padding a bit if 2 lines labels are enabled.
Fixes #750 (at least on 6" emulator in 1080p)