### PR TITLE
Add option in preferences to animate alternative clock apps

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/BubbleTextView.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/BubbleTextView.java
@@ -244,7 +244,7 @@ public class BubbleTextView extends TextView
 
     private void applyClockIcon(ComponentName componentName) {
         if (Utilities.getPrefs(getContext()).getAnimatedClockIcon() &&
-                Utilities.isComponentClock(componentName, !Utilities.getPrefs(getContext()).getAnimateClockIconAlternativeClockApps())) {
+                Utilities.isComponentClock(componentName, !Utilities.getPrefs(getContext()).getAnimatedClockIconAlternativeClockApps())) {
             setIcon(ClockIconDrawable.Companion.create(getContext()));
         }
     }

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
@@ -91,7 +91,7 @@ interface IPreferenceProvider {
     val showWeather: Boolean
     val lockDesktop: Boolean
     val animatedClockIcon: Boolean
-    val animateClockIconAlternativeClockApps: Boolean
+    val animatedClockIconAlternativeClockApps: Boolean
     val iconLabelsInTwoLines: Boolean
 
     val pulldownAction: String

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
@@ -39,6 +39,7 @@ object PreferenceFlags {
     const val KEY_CENTER_WALLPAPER = "pref_centerWallpaper"
     const val KEY_POPUP_CARD_THEME = "pref_popupCardTheme"
     const val KEY_ICON_LABELS_IN_TWO_LINES = "pref_iconLabelsInTwoLines"
+    const val KEY_ANIMATED_CLOCK_ICON_ALTERNATIVE_CLOCK_APPS = "pref_animatedClockIconAlternativeClockApps"
 
     // Various
     const val KEY_PREF_WS_LABEL_COLOR = "pref_workspaceLabelColor"

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
@@ -38,9 +38,7 @@ open class PreferenceImpl(context: Context) : IPreferenceProvider {
     override val useCustomAllAppsTextColor by BooleanPref(PreferenceFlags.KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR, false)
     override val verticalDrawerLayout by BooleanPref(PreferenceFlags.KEY_PREF_DRAWER_VERTICAL_LAYOUT, false)
     override val iconLabelsInTwoLines by BooleanPref(PreferenceFlags.KEY_ICON_LABELS_IN_TWO_LINES, false)
-
-    override val animateClockIconAlternativeClockApps: Boolean
-        get() = false
+    override val animatedClockIconAlternativeClockApps by BooleanPref(PreferenceFlags.KEY_ANIMATED_CLOCK_ICON_ALTERNATIVE_CLOCK_APPS, false)
 
     override fun lightStatusBarKeyCache(default: Boolean): Boolean {
         return getBoolean(PreferenceFlags.KEY_LIGHT_STATUS_BAR, default)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -440,6 +440,8 @@
     <string name="icon_shape_circle">Circle</string>
     <string name="icon_shape_teardrop">Teardrop</string>
     <string name="animated_clock_icon_title">Animated clock icon</string>
+    <string name="animated_clock_icon_alternative_clock_apps_title">Animate alternative clock apps</string>
+    <string name="animated_clock_icon_alternative_clock_apps_summary">Enable this if you don\'t use Google Clock as your default clock app</string>
     <string name="about_summary_title">Summary</string>
     <string name="about_version">Version</string>
     <string name="about_icon_designer">App Icon Designer</string>

--- a/app/src/main/res/xml/launcher_pixel_style_preferences.xml
+++ b/app/src/main/res/xml/launcher_pixel_style_preferences.xml
@@ -45,6 +45,14 @@
             android:defaultValue="false"
             android:persistent="true" />
 
+        <SwitchPreference
+            android:key="pref_animatedClockIconAlternativeClockApps"
+            android:title="@string/animated_clock_icon_alternative_clock_apps_title"
+            android:summary="@string/animated_clock_icon_alternative_clock_apps_summary"
+            android:defaultValue="false"
+            android:dependency="pref_animatedClockIcon"
+            android:persistent="true" />
+
         <ch.deletescape.lawnchair.preferences.GoogleNowPreference
             android:key="pref_showGoogleNowTab"
             android:persistent="true"


### PR DESCRIPTION
This should finally allow users to enable this "hidden" option when they're using stock OEM apps.
Now it should animate the clock app on Samsung and Xiaomi devices as well.

TODO: Find a regex or way to add all clock apps (maybe by looking up clock providers?)