### PR TITLE
Fix saving percentage values in preferences

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/SeekbarPreference.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/SeekbarPreference.kt
@@ -20,6 +20,7 @@ class SeekbarPreference @JvmOverloads constructor(context: Context, attrs: Attri
     private var defaultValue: Float = 0.toFloat()
     private var multiplier: Int = 0
     private var format: String? = null
+    private var steps: Int = 100
 
     init {
         layoutResource = R.layout.preference_seekbar
@@ -33,6 +34,7 @@ class SeekbarPreference @JvmOverloads constructor(context: Context, attrs: Attri
         multiplier = ta.getInt(R.styleable.SeekbarPreference_summaryMultiplier, 1)
         format = ta.getString(R.styleable.SeekbarPreference_summaryFormat)
         defaultValue = ta.getFloat(R.styleable.SeekbarPreference_defaultSeekbarValue, min)
+        steps = ta.getInt(R.styleable.SeekbarPreference_steps, 100)
         if (format == null) {
             format = "%.2f"
         }
@@ -43,11 +45,12 @@ class SeekbarPreference @JvmOverloads constructor(context: Context, attrs: Attri
         super.onBindView(view)
         mSeekbar = view.findViewById<SeekBar>(R.id.seekbar)
         mValueText = view.findViewById<TextView>(R.id.txtValue)
+        mSeekbar!!.max = steps
         mSeekbar!!.setOnSeekBarChangeListener(this)
 
         current = getPersistedFloat(defaultValue)
-        val progress = ((current - min) / ((max - min) / 100)).toInt()
-        mSeekbar!!.progress = progress
+        val progress = ((current - min) / ((max - min) / steps))
+        mSeekbar!!.progress = Math.round(progress)
         updateSummary()
     }
 
@@ -56,7 +59,8 @@ class SeekbarPreference @JvmOverloads constructor(context: Context, attrs: Attri
     }
 
     override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
-        current = min + (max - min) / 100 * progress
+        current = min + (max - min) / steps * progress
+        current = Math.round(current * 100f)/100f; //round to .00 places
         updateSummary()
 
         persistFloat(current)

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -124,6 +124,7 @@
         <attr name="summaryFormat" format="string" />
         <attr name="summaryMultiplier" format="integer" />
         <attr name="defaultSeekbarValue" format="float" />
+        <attr name="steps" format="integer" />
     </declare-styleable>
 
     <declare-styleable name="SubPreference">

--- a/app/src/main/res/xml/launcher_ui_preferences.xml
+++ b/app/src/main/res/xml/launcher_ui_preferences.xml
@@ -65,6 +65,7 @@
             app:summaryFormat="%.0f%%"
             app:summaryMultiplier="100"
             app:defaultSeekbarValue="1.0"
+            app:steps="120"
             android:persistent="true" />
 
         <ch.deletescape.lawnchair.preferences.SeekbarPreference
@@ -75,6 +76,7 @@
             app:summaryFormat="%.0f%%"
             app:summaryMultiplier="100"
             app:defaultSeekbarValue="1.0"
+            app:steps="120"
             android:persistent="true" />
 
         <SwitchPreference
@@ -140,6 +142,7 @@
             app:summaryFormat="%.0f%%"
             app:summaryMultiplier="100"
             app:defaultSeekbarValue="1.0"
+            app:steps="120"
             android:persistent="true" />
     </PreferenceCategory>
 
@@ -211,6 +214,7 @@
             app:summaryFormat="%.0f%%"
             app:summaryMultiplier="100"
             app:defaultSeekbarValue="1.0"
+            app:steps="120"
             android:persistent="true" />
 
         <ch.deletescape.lawnchair.preferences.SeekbarPreference
@@ -221,6 +225,7 @@
             app:summaryFormat="%.0f%%"
             app:summaryMultiplier="100"
             app:defaultSeekbarValue="1.0"
+            app:steps="120"
             android:persistent="true" />
     </PreferenceCategory>
 
@@ -276,6 +281,7 @@
             app:maxValue="150"
             app:defaultSeekbarValue="75"
             app:summaryFormat="%.0f"
+            app:steps="140"
             android:persistent="true" />
 
         <SwitchPreference


### PR DESCRIPTION
Fixes #309 
If we have a preference with values from 0.3 to 1.5 and we have a seekbar that has 0-100 discrete values that causes issues with rounding and we are unable to store precisely what user wanted.
If we increase seekbar resolution (max value) to 120 steps (0-120) then we are able to map user values 1:1 as range 30% - 150% requires 120 ticks