### PR TITLE
Added Dock Height Scale slider in preferences

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/DeviceProfile.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/DeviceProfile.java
@@ -183,7 +183,9 @@ public class DeviceProfile {
         dropTargetBarSizePx = res.getDimensionPixelSize(R.dimen.dynamic_grid_drop_target_size);
         workspaceSpringLoadedBottomSpace =
                 res.getDimensionPixelSize(R.dimen.dynamic_grid_min_spring_loaded_space);
-        hotseatBarHeightPx = res.getDimensionPixelSize(R.dimen.dynamic_grid_hotseat_height);
+        float hotseatBaseHeight = res.getDimensionPixelSize(R.dimen.dynamic_grid_hotseat_height);
+        float hotseatScale = Utilities.getPrefs(mContext).getHotseatHeightScale();
+        hotseatBarHeightPx = Math.round(hotseatBaseHeight * hotseatScale);
         hotseatBarTopPaddingPx =
                 res.getDimensionPixelSize(R.dimen.dynamic_grid_hotseat_top_padding);
         hotseatLandGutterPx = res.getDimensionPixelSize(R.dimen.dynamic_grid_hotseat_gutter_width);

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
@@ -126,6 +126,7 @@ interface IPreferenceProvider {
     val iconTextScaleSB: Float
     val iconPackPackage: String
     val hotseatIconScale: Float
+    val hotseatHeightScale: Float
 
     // -----------------
     // GENERAL - BITS

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
@@ -25,6 +25,7 @@ object PreferenceFlags {
     const val KEY_ICON_TEXT_SCALE_SB = "pref_iconTextScaleSB"
     const val KEY_BLUR_RADIUS = "pref_blurRadius"
     const val KEY_PREF_HOTSEAT_ICON_SCALE = "pref_hotseatIconScale"
+    const val KEY_PREF_HOTSEAT_HEIGHT_SCALE = "pref_hotseatHeightScale"
     const val KEY_PREF_ALL_APPS_ICON_SCALE = "pref_allAppsIconScale"
     const val KEY_PREF_ALL_APPS_ICON_TEXT_SCALE = "pref_allAppsIconTextScale"
 

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
@@ -33,6 +33,7 @@ open class PreferenceImpl(context: Context) : IPreferenceProvider {
     }
 
     override val hotseatIconScale by FloatPref(PreferenceFlags.KEY_PREF_HOTSEAT_ICON_SCALE, 1f)
+    override val hotseatHeightScale by FloatPref(PreferenceFlags.KEY_PREF_HOTSEAT_HEIGHT_SCALE, 1f)
     override val allAppsIconScale by FloatPref(PreferenceFlags.KEY_PREF_ALL_APPS_ICON_SCALE, 1f)
     override val allAppsIconTextScale by FloatPref(PreferenceFlags.KEY_PREF_ALL_APPS_ICON_TEXT_SCALE, 1f)
     override val useCustomAllAppsTextColor by BooleanPref(PreferenceFlags.KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR, false)

--- a/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
@@ -109,6 +109,7 @@ public class Settings implements SharedPreferences.OnSharedPreferenceChangeListe
                     break;
                 case PreferenceFlags.KEY_PREF_ICON_SCALE:
                 case PreferenceFlags.KEY_PREF_HOTSEAT_ICON_SCALE:
+                case PreferenceFlags.KEY_PREF_HOTSEAT_HEIGHT_SCALE:
                 case PreferenceFlags.KEY_PREF_ALL_APPS_ICON_SCALE:
                 case PreferenceFlags.KEY_PREF_ICON_TEXT_SCALE:
                 case PreferenceFlags.KEY_PREF_ALL_APPS_ICON_TEXT_SCALE:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -334,6 +334,7 @@
     <string name="num_rows_pref_title">Number of rows</string>
     <string name="num_hotseat_icons_pref_title">Number of icons in dock</string>
     <string name="icon_scale_pref_title">Icon scale</string>
+    <string name="hotseat_height_scale">Height scale</string>
     <string name="icon_text_scale_pref_title">Icon text scale</string>
     <string name="full_width_width_widgets_pref_title">Full width widgets</string>
     <string name="full_width_widgets_pref_summary">Allow widgets to span over the whole width without padding</string>

--- a/app/src/main/res/xml/launcher_ui_preferences.xml
+++ b/app/src/main/res/xml/launcher_ui_preferences.xml
@@ -144,6 +144,16 @@
             app:defaultSeekbarValue="1.0"
             app:steps="120"
             android:persistent="true" />
+
+        <ch.deletescape.lawnchair.preferences.SeekbarPreference
+            android:key="pref_hotseatHeightScale"
+            android:title="@string/hotseat_height_scale"
+            app:minValue="0.5"
+            app:maxValue="1.5"
+            app:summaryFormat="%.0f%%"
+            app:summaryMultiplier="100"
+            app:defaultSeekbarValue="1.0"
+            android:persistent="true" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
This is not necessary for most phones but there are some situations like my wife's Nexus 5 which is designed to have a 4x4 grid. If I set the grid manually to 4x5 the dock takes too much space and it's looking a bit weird. Usually I have a custom build for this phone with different height but this will be helpful for others.
This was also requested on #759 and there was somewhere a bug where if you scale dock icons up/down then the dock height is not adjusted accordingly so this additional slider can help in both cases.