### PR TITLE
Added icon padding scale slider

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/DeviceProfile.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/DeviceProfile.java
@@ -289,7 +289,8 @@ public class DeviceProfile {
         hotseatIconSizePx = (int) (Utilities.pxFromDp(inv.hotseatIconSize, dm) * hotseatScale);
         hotseatIconSizePxOriginal = (int) (Utilities.pxFromDp(inv.hotseatIconSizeOriginal, dm) * hotseatScale);
         allAppsIconSizePx = (int) (Utilities.pxFromDp(inv.allAppsIconSize, dm) * allAppsScale);
-        allAppsIconDrawablePaddingPx = iconLabelsInTwoLines ? allAppsDrawablePadding * 2 : allAppsDrawablePadding;
+        float allAppsPaddingScale = Utilities.getPrefs(mContext).getAllAppsIconPaddingScale();
+        allAppsIconDrawablePaddingPx = Math.round(allAppsDrawablePadding * allAppsPaddingScale);
         allAppsIconTextSizePx = (int) (Utilities.pxFromSp(inv.allAppsIconTextSize, dm) * allAppsScale);
 
         cellWidthPx = iconSizePx;

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
@@ -31,6 +31,7 @@ interface IPreferenceProvider {
     val showHidden: Boolean
     val allAppsIconScale: Float
     val allAppsIconTextScale: Float
+    val allAppsIconPaddingScale: Float
     val useCustomAllAppsTextColor: Boolean
     val verticalDrawerLayout: Boolean
 

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
@@ -28,6 +28,7 @@ object PreferenceFlags {
     const val KEY_PREF_HOTSEAT_HEIGHT_SCALE = "pref_hotseatHeightScale"
     const val KEY_PREF_ALL_APPS_ICON_SCALE = "pref_allAppsIconScale"
     const val KEY_PREF_ALL_APPS_ICON_TEXT_SCALE = "pref_allAppsIconTextScale"
+    const val KEY_PREF_ALL_APPS_ICON_PADDING_SCALE = "pref_allAppsIconPaddingScale"
 
     //Ints
     const val KEY_BLUR_MODE = "pref_blurMode"

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
@@ -36,6 +36,7 @@ open class PreferenceImpl(context: Context) : IPreferenceProvider {
     override val hotseatHeightScale by FloatPref(PreferenceFlags.KEY_PREF_HOTSEAT_HEIGHT_SCALE, 1f)
     override val allAppsIconScale by FloatPref(PreferenceFlags.KEY_PREF_ALL_APPS_ICON_SCALE, 1f)
     override val allAppsIconTextScale by FloatPref(PreferenceFlags.KEY_PREF_ALL_APPS_ICON_TEXT_SCALE, 1f)
+    override val allAppsIconPaddingScale by FloatPref(PreferenceFlags.KEY_PREF_ALL_APPS_ICON_PADDING_SCALE, 1f)
     override val useCustomAllAppsTextColor by BooleanPref(PreferenceFlags.KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR, false)
     override val verticalDrawerLayout by BooleanPref(PreferenceFlags.KEY_PREF_DRAWER_VERTICAL_LAYOUT, false)
     override val iconLabelsInTwoLines by BooleanPref(PreferenceFlags.KEY_ICON_LABELS_IN_TWO_LINES, false)

--- a/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
@@ -111,6 +111,7 @@ public class Settings implements SharedPreferences.OnSharedPreferenceChangeListe
                 case PreferenceFlags.KEY_PREF_HOTSEAT_ICON_SCALE:
                 case PreferenceFlags.KEY_PREF_HOTSEAT_HEIGHT_SCALE:
                 case PreferenceFlags.KEY_PREF_ALL_APPS_ICON_SCALE:
+                case PreferenceFlags.KEY_PREF_ALL_APPS_ICON_PADDING_SCALE:
                 case PreferenceFlags.KEY_PREF_ICON_TEXT_SCALE:
                 case PreferenceFlags.KEY_PREF_ALL_APPS_ICON_TEXT_SCALE:
                 case PreferenceFlags.KEY_PREF_ENABLE_BACKPORT_SHORTCUTS:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,6 +336,7 @@
     <string name="icon_scale_pref_title">Icon scale</string>
     <string name="hotseat_height_scale">Height scale</string>
     <string name="icon_text_scale_pref_title">Icon text scale</string>
+    <string name="icon_text_padding_scale_pref_title">Icon padding scale</string>
     <string name="full_width_width_widgets_pref_title">Full width widgets</string>
     <string name="full_width_widgets_pref_summary">Allow widgets to span over the whole width without padding</string>
     <string name="notification_access_pref_title">Notification badges and preview</string>

--- a/app/src/main/res/xml/launcher_ui_preferences.xml
+++ b/app/src/main/res/xml/launcher_ui_preferences.xml
@@ -237,6 +237,17 @@
             app:defaultSeekbarValue="1.0"
             app:steps="120"
             android:persistent="true" />
+
+        <ch.deletescape.lawnchair.preferences.SeekbarPreference
+            android:key="pref_allAppsIconPaddingScale"
+            android:title="@string/icon_text_padding_scale_pref_title"
+            app:minValue="0.1"
+            app:maxValue="2.0"
+            app:summaryFormat="%.0f%%"
+            app:summaryMultiplier="100"
+            app:defaultSeekbarValue="1.0"
+            app:steps="190"
+            android:persistent="true" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Fixes #750 
Ii gives the ability to slightly adjust padding for each phone and to the user preference rather than apply absolute value like 1x or 2x.
On Sony Xperia 80% is very good, on My P10 it's 150% (with 2 lines labels).