### PR TITLE
Unicode insensitive comparison in All Apps search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-awareness:11.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     implementation 'com.pavelsikun:vintage-chroma:1.5'
+    implementation 'org.apache.commons:commons-lang3:3.6'
     implementation project(':launcherclient')
 }
 repositories {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,6 @@ dependencies {
     implementation 'com.google.android.gms:play-services-awareness:11.2.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     implementation 'com.pavelsikun:vintage-chroma:1.5'
-    implementation 'org.apache.commons:commons-lang3:3.6'
     implementation project(':launcherclient')
 }
 repositories {

--- a/app/src/main/java/ch/deletescape/lawnchair/Launcher.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Launcher.java
@@ -100,7 +100,7 @@ import ch.deletescape.lawnchair.accessibility.LauncherAccessibilityDelegate;
 import ch.deletescape.lawnchair.allapps.AllAppsContainerView;
 import ch.deletescape.lawnchair.allapps.AllAppsIconRowView;
 import ch.deletescape.lawnchair.allapps.AllAppsTransitionController;
-import ch.deletescape.lawnchair.allapps.DefaultAppSearchController;
+import ch.deletescape.lawnchair.allapps.UnicodeStrippedAppSearchController;
 import ch.deletescape.lawnchair.blur.BlurWallpaperProvider;
 import ch.deletescape.lawnchair.compat.AppWidgetManagerCompat;
 import ch.deletescape.lawnchair.compat.LauncherAppsCompat;
@@ -1187,7 +1187,7 @@ public class Launcher extends Activity
         // Setup Apps and Widgets
         mAppsView = findViewById(R.id.apps_view);
         mWidgetsView = findViewById(R.id.widgets_view);
-        mAppsView.setSearchBarController(new DefaultAppSearchController());
+        mAppsView.setSearchBarController(new UnicodeStrippedAppSearchController());
 
         // Setup the drag controller (drop targets have to be added in reverse order in priority)
         mDragController.setDragScoller(mWorkspace);

--- a/app/src/main/java/ch/deletescape/lawnchair/allapps/UnicodeStrippedAppSearchAlgorithm.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/allapps/UnicodeStrippedAppSearchAlgorithm.java
@@ -1,0 +1,29 @@
+package ch.deletescape.lawnchair.allapps;
+
+import java.util.List;
+
+import ch.deletescape.lawnchair.AppInfo;
+import ch.deletescape.lawnchair.util.UnicodeFilter;
+
+/**
+ * A search algorithm that changes every non-ascii characters to theirs ascii equivalents and
+ * then performs comparison.
+ */
+public class UnicodeStrippedAppSearchAlgorithm extends DefaultAppSearchAlgorithm {
+    public UnicodeStrippedAppSearchAlgorithm(List<AppInfo> apps) {
+        super(apps);
+    }
+
+    @Override
+    protected boolean matches(AppInfo info, String query) {
+        String title = UnicodeFilter.filter(info.title.toString().toLowerCase());
+        String strippedQuery = UnicodeFilter.filter(query);
+        int queryLength = strippedQuery.length();
+
+        if (title.length() < queryLength || queryLength <= 0) {
+            return false;
+        }
+
+        return title.indexOf(strippedQuery) >= 0;
+    }
+}

--- a/app/src/main/java/ch/deletescape/lawnchair/allapps/UnicodeStrippedAppSearchController.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/allapps/UnicodeStrippedAppSearchController.java
@@ -1,0 +1,11 @@
+package ch.deletescape.lawnchair.allapps;
+
+/**
+ * The unicode stripped search controller.
+ */
+public class UnicodeStrippedAppSearchController extends AllAppsSearchBarController {
+
+    public DefaultAppSearchAlgorithm onInitializeSearch() {
+        return new UnicodeStrippedAppSearchAlgorithm(mApps.getApps());
+    }
+}

--- a/app/src/main/java/ch/deletescape/lawnchair/util/UnicodeFilter.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/util/UnicodeFilter.java
@@ -1,34 +1,31 @@
 package ch.deletescape.lawnchair.util;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.text.Normalizer;
 import java.util.regex.Pattern;
 
 /**
  * Attempts to replace any non-ascii characters to theirs ascii equivalents
+ * by normalizing the character into Unicode NFD form and stripping out diacritic mark characters.
  */
 public class UnicodeFilter {
     private static final Pattern DIACRITICS_PATTERN =
-            Pattern.compile("\\p{InCombiningDiacriticalMarks}");
+            Pattern.compile("\\\\p{InCombiningDiacriticalMarks}+");
 
     public static String filter(String source) {
-        StringBuilder output = new StringBuilder();
-        final int sourceLength = source.length();
+        StringBuilder output = new StringBuilder(Normalizer.normalize(source, Normalizer.Form.NFD));
 
-        for (int i = 0; i < sourceLength; i++) {
-            String s = String.valueOf(source.charAt(i));
-
-            // Try normalizing the character into Unicode NFKD form and
-            // stripping out diacritic mark characters.
-            s = Normalizer.normalize(s, Normalizer.Form.NFKD);
-            s = DIACRITICS_PATTERN.matcher(s).replaceAll("");
-
-            // Replace left over accents away using Apache's StringUtils
-            s = StringUtils.stripAccents(s);
-            output.append(s);
+        // Special case characters that don't get stripped by the above technique.
+        for (int i = 0; i < output.length(); i++) {
+            if (output.charAt(i) == '\u0141') {
+                output.deleteCharAt(i);
+                output.insert(i, 'L');
+            } else if (output.charAt(i) == '\u0142') {
+                output.deleteCharAt(i);
+                output.insert(i, 'l');
+            }
         }
 
-        return output.toString();
+        // Note that ligatures will be left as is
+        return DIACRITICS_PATTERN.matcher(output).replaceAll("");
     }
 }

--- a/app/src/main/java/ch/deletescape/lawnchair/util/UnicodeFilter.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/util/UnicodeFilter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2012-2016 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ch.deletescape.lawnchair.util;
+
+import java.text.Normalizer;
+import java.util.regex.Pattern;
+
+/**
+ * Attempts to substitute characters that cannot be encoded in the limited
+ * GSM 03.38 character set. In many cases this will prevent sending a message
+ * containing characters that would switch the message from 7-bit GSM
+ * encoding (160 char limit) to 16-bit Unicode encoding (70 char limit).
+ */
+public class UnicodeFilter {
+    private static final Pattern DIACRITICS_PATTERN =
+            Pattern.compile("\\p{InCombiningDiacriticalMarks}");
+
+    public static String filter(String source) {
+        StringBuilder output = new StringBuilder();
+        final int sourceLength = source.length();
+
+        for (int i = 0; i < sourceLength; i++) {
+            String s = String.valueOf(source.charAt(i));
+
+            // Try normalizing the character into Unicode NFKD form and
+            // stripping out diacritic mark characters.
+            s = Normalizer.normalize(s, Normalizer.Form.NFKD);
+            s = DIACRITICS_PATTERN.matcher(s).replaceAll("");
+
+            // Special case characters that don't get stripped by the
+            // above technique.
+            s = s.replace("Œ", "OE");
+            s = s.replace("œ", "oe");
+            s = s.replace("Ł", "L");
+            s = s.replace("ł", "l");
+            s = s.replace("Đ", "Dj");
+            s = s.replace("đ", "dj");
+            s = s.replace("Α", "A");
+            s = s.replace("Β", "B");
+            s = s.replace("Ε", "E");
+            s = s.replace("Ζ", "Z");
+            s = s.replace("Η", "H");
+            s = s.replace("Ι", "I");
+            s = s.replace("Κ", "K");
+            s = s.replace("Μ", "M");
+            s = s.replace("Ν", "N");
+            s = s.replace("Ο", "O");
+            s = s.replace("Ρ", "P");
+            s = s.replace("Τ", "T");
+            s = s.replace("Υ", "Y");
+            s = s.replace("Χ", "X");
+            s = s.replace("α", "A");
+            s = s.replace("β", "B");
+            s = s.replace("γ", "Γ");
+            s = s.replace("δ", "Δ");
+            s = s.replace("ε", "E");
+            s = s.replace("ζ", "Z");
+            s = s.replace("η", "H");
+            s = s.replace("θ", "Θ");
+            s = s.replace("ι", "I");
+            s = s.replace("κ", "K");
+            s = s.replace("λ", "Λ");
+            s = s.replace("μ", "M");
+            s = s.replace("ν", "N");
+            s = s.replace("ξ", "Ξ");
+            s = s.replace("ο", "O");
+            s = s.replace("π", "Π");
+            s = s.replace("ρ", "P");
+            s = s.replace("σ", "Σ");
+            s = s.replace("τ", "T");
+            s = s.replace("υ", "Y");
+            s = s.replace("φ", "Φ");
+            s = s.replace("χ", "X");
+            s = s.replace("ψ", "Ψ");
+            s = s.replace("ω", "Ω");
+            s = s.replace("ς", "Σ");
+            output.append(s);
+        }
+
+        return output.toString();
+    }
+}

--- a/app/src/main/java/ch/deletescape/lawnchair/util/UnicodeFilter.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/util/UnicodeFilter.java
@@ -1,29 +1,12 @@
-/*
- * Copyright (C) 2012-2016 The CyanogenMod Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ch.deletescape.lawnchair.util;
+
+import org.apache.commons.lang3.StringUtils;
 
 import java.text.Normalizer;
 import java.util.regex.Pattern;
 
 /**
- * Attempts to substitute characters that cannot be encoded in the limited
- * GSM 03.38 character set. In many cases this will prevent sending a message
- * containing characters that would switch the message from 7-bit GSM
- * encoding (160 char limit) to 16-bit Unicode encoding (70 char limit).
+ * Attempts to replace any non-ascii characters to theirs ascii equivalents
  */
 public class UnicodeFilter {
     private static final Pattern DIACRITICS_PATTERN =
@@ -41,53 +24,8 @@ public class UnicodeFilter {
             s = Normalizer.normalize(s, Normalizer.Form.NFKD);
             s = DIACRITICS_PATTERN.matcher(s).replaceAll("");
 
-            // Special case characters that don't get stripped by the
-            // above technique.
-            s = s.replace("Œ", "OE");
-            s = s.replace("œ", "oe");
-            s = s.replace("Ł", "L");
-            s = s.replace("ł", "l");
-            s = s.replace("Đ", "Dj");
-            s = s.replace("đ", "dj");
-            s = s.replace("Α", "A");
-            s = s.replace("Β", "B");
-            s = s.replace("Ε", "E");
-            s = s.replace("Ζ", "Z");
-            s = s.replace("Η", "H");
-            s = s.replace("Ι", "I");
-            s = s.replace("Κ", "K");
-            s = s.replace("Μ", "M");
-            s = s.replace("Ν", "N");
-            s = s.replace("Ο", "O");
-            s = s.replace("Ρ", "P");
-            s = s.replace("Τ", "T");
-            s = s.replace("Υ", "Y");
-            s = s.replace("Χ", "X");
-            s = s.replace("α", "A");
-            s = s.replace("β", "B");
-            s = s.replace("γ", "Γ");
-            s = s.replace("δ", "Δ");
-            s = s.replace("ε", "E");
-            s = s.replace("ζ", "Z");
-            s = s.replace("η", "H");
-            s = s.replace("θ", "Θ");
-            s = s.replace("ι", "I");
-            s = s.replace("κ", "K");
-            s = s.replace("λ", "Λ");
-            s = s.replace("μ", "M");
-            s = s.replace("ν", "N");
-            s = s.replace("ξ", "Ξ");
-            s = s.replace("ο", "O");
-            s = s.replace("π", "Π");
-            s = s.replace("ρ", "P");
-            s = s.replace("σ", "Σ");
-            s = s.replace("τ", "T");
-            s = s.replace("υ", "Y");
-            s = s.replace("φ", "Φ");
-            s = s.replace("χ", "X");
-            s = s.replace("ψ", "Ψ");
-            s = s.replace("ω", "Ω");
-            s = s.replace("ς", "Σ");
+            // Replace left over accents away using Apache's StringUtils
+            s = StringUtils.stripAccents(s);
             output.append(s);
         }
 


### PR DESCRIPTION
For searching replace any non-ascii characters to theirs ascii equivalents.
E.g. in Polish: "Menadżer telefonu" can now be found using "menadzer" or "menadżer" or "dzer" or "dżer"