### PR TITLE
Remove whitespace from query when searching

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/allapps/UnicodeStrippedAppSearchAlgorithm.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/allapps/UnicodeStrippedAppSearchAlgorithm.java
@@ -17,7 +17,7 @@ public class UnicodeStrippedAppSearchAlgorithm extends DefaultAppSearchAlgorithm
     @Override
     protected boolean matches(AppInfo info, String query) {
         String title = UnicodeFilter.filter(info.title.toString().toLowerCase());
-        String strippedQuery = UnicodeFilter.filter(query);
+        String strippedQuery = UnicodeFilter.filter(query.trim());
         int queryLength = strippedQuery.length();
 
         if (title.length() < queryLength || queryLength <= 0) {


### PR DESCRIPTION
Fixes the algorithm so when a user accidentally searches for `" Calc"` it will show up results for `"Calc"`.