### PR TITLE
Organize homescreen layout to match Pixel, plus minor cleanup

### DIFF
--- a/app/src/main/res/xml/default_workspace_5x5.xml
+++ b/app/src/main/res/xml/default_workspace_5x5.xml
@@ -23,18 +23,8 @@
         launcher:screen="0"
         launcher:x="0"
         launcher:y="-1">
-        <favorite launcher:uri="#Intent;action=android.intent.action.MAIN;category=android.intent.category.APP_EMAIL;end" />
-        <favorite launcher:uri="mailto:" />
-
-    </resolve>
-
-    <resolve
-        launcher:screen="0"
-        launcher:x="1"
-        launcher:y="-1">
-        <favorite launcher:uri="#Intent;action=android.intent.action.MAIN;category=android.intent.category.APP_GALLERY;end" />
-        <favorite launcher:uri="#Intent;type=images/*;end" />
-
+        <favorite launcher:uri="#Intent;action=android.intent.action.MAIN;category=android.intent.category.APP_MAPS;end" />
+        <favorite launcher:uri="geo:" />
     </resolve>
 
     <resolve
@@ -42,6 +32,7 @@
         launcher:x="4"
         launcher:y="-1">
         <favorite launcher:uri="#Intent;action=android.intent.action.MAIN;category=android.intent.category.APP_MARKET;end" />
-        <favorite launcher:uri="market://details?id=com.android.launcher" />
+        <favorite launcher:uri="market:" />
     </resolve>
+
 </favorites>

--- a/app/src/main/res/xml/dw_phone_hotseat.xml
+++ b/app/src/main/res/xml/dw_phone_hotseat.xml
@@ -14,16 +14,17 @@
 -->
 
 <favorites xmlns:launcher="http://schemas.android.com/apk/res-auto">
+
     <!-- Hotseat (We use the screen as the position of the item in the hotseat) -->
-    <!-- Dialer, Messaging, Phone, Browser, Camera -->
+    <!-- Dialer, Messaging, Email, Browser, Camera -->
     <resolve
         launcher:container="-101"
         launcher:screen="0"
         launcher:x="0"
         launcher:y="0">
         <favorite launcher:uri="#Intent;action=android.intent.action.DIAL;end" />
-        <favorite launcher:uri="tel:123" />
         <favorite launcher:uri="#Intent;action=android.intent.action.CALL_BUTTON;end" />
+        <favorite launcher:uri="tel:" />
     </resolve>
 
     <resolve
@@ -43,8 +44,8 @@
         launcher:screen="2"
         launcher:x="2"
         launcher:y="0">
-        <favorite launcher:uri="#Intent;action=android.media.action.STILL_IMAGE_CAMERA;end" />
-        <favorite launcher:uri="#Intent;action=android.intent.action.CAMERA_BUTTON;end" />
+        <favorite launcher:uri="#Intent;action=android.intent.action.MAIN;category=android.intent.category.APP_EMAIL;end" />
+        <favorite launcher:uri="mailto:" />
     </resolve>
 
     <resolve
@@ -53,7 +54,7 @@
         launcher:x="3"
         launcher:y="0">
         <favorite launcher:uri="#Intent;action=android.intent.action.MAIN;category=android.intent.category.APP_BROWSER;end" />
-        <favorite launcher:uri="http://www.example.com/" />
+        <favorite launcher:uri="http:" />
     </resolve>
 
     <resolve
@@ -61,8 +62,8 @@
         launcher:screen="4"
         launcher:x="4"
         launcher:y="0">
-        <favorite launcher:uri="#Intent;action=android.intent.action.MAIN;category=android.intent.category.APP_MARKET;end" />
-        <favorite launcher:uri="market://details?id=com.android.launcher" />
+        <favorite launcher:uri="#Intent;action=android.media.action.STILL_IMAGE_CAMERA;end" />
+        <favorite launcher:uri="#Intent;action=android.intent.action.CAMERA_BUTTON;end" />
     </resolve>
 
 </favorites>


### PR DESCRIPTION
Todo: figure out why web browsers aren't showing up

After a bit of searching, I found out how to find intent categories with the use of APKTool. For example, in order to find Maps, after decompiling the APK, I looked into AndroidManifest and found that APP_MAPS belongs to it.

Doing so allowed me to rearrange the homescreen layout to match the default layout seen on a Google Pixel.

The only problem left is figuring out why any web browser (Chrome, PA Browser) doesn't show up in the blank area of the hotseat shown in the screenshot.

![screenshot_20171015-231840](https://user-images.githubusercontent.com/5095812/31594765-ffb86e66-b204-11e7-9b83-6593adab8826.png)

These are the intent categories in Chrome's AndroidManifest:

>
            <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <category android:name="android.intent.category.APP_BROWSER"/>
                 <category android:name="android.intent.category.NOTIFICATION_PREFERENCES"/>
             </intent-filter>

I'm leaving these here in case anyone can solve this.
