### PR TITLE
Move Color/Integer definitions from styles.xml to color.xml/integers.xml

### DIFF
--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="SettingsTheme" parent="@style/Theme.AppCompat.Light">
-        <item name="android:colorPrimaryDark">#e0e0e0</item>
+        <item name="colorPrimaryDark">@color/color_primary_dark_settings_v23</item>
+        <item name="colorPrimary">@color/color_primary_settings</item>
         <item name="android:colorAccent">@color/accent_material_light</item>
         <item name="android:windowLightStatusBar">true</item>
         <item name="blurTintColor">#45ffffff</item>
+        <item name="android:navigationBarColor">@color/color_navigationbar_settings</item>
     </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -34,12 +34,28 @@
     <color name="quantum_panel_text_color_dark">@color/workspace_icon_text_color</color>
     <color name="quantum_panel_bg_color">#FFF5F5F5</color>
     <color name="quantum_panel_bg_color_dark">#ff212121</color>
+    <color name="quantum_panel_bg_color_black">@android:color/black</color>
 
     <color name="outline_color">#FFFFFFFF</color>
     <color name="all_apps_divider_color">#1E000000</color>
     <color name="all_apps_caret_color">#FFFFFFFF</color>
     <color name="all_apps_caret_shadow_color">#22000000</color>
     <color name="all_apps_container_color">#FFF2F2F2</color>
+    <color name="all_apps_container_color_dark">#ff212121</color>
+    <color name="all_apps_container_color_black">@android:color/black</color>
+    <color name="all_apps_container_color_blur">#00ffffff</color>
+    <color name="all_apps_container_color_blur_dark">#00212121</color>
+    <color name="all_apps_container_color_blur_black">#00000000</color>
+    <color name="all_apps_empty_search_text_color">#212121</color>
+    <color name="all_apps_empty_search_text_color_dark">@android:color/white</color>
+    <color name="all_apps_round_searchbar_bg_color">#10000000</color>
+    <color name="all_apps_round_searchbar_bg_color_dark">#10ffffff</color>
+    <color name="all_apps_round_searchbar_divider_color">#10111111</color>
+    <color name="all_apps_round_searchbar_divider_color_dark">#10eeeeee</color>
+    <color name="all_apps_round_searchbar_hint_color">@color/quantum_panel_text_color</color>
+    <color name="all_apps_round_searchbar_hint_color_dark">@android:color/white</color>
+    <color name="all_apps_round_searchbar_text_color">#4c4c4c</color>
+    <color name="all_apps_round_searchbar_text_color_dark">@android:color/white</color>
     <color name="all_apps_statusbar_color">#28000000</color>
 
     <color name="spring_loaded_panel_color">#40FFFFFF</color>
@@ -55,12 +71,20 @@
 
     <color name="qsb_connector">#fff2f2f2</color>
     <color name="qsb_background">#ffffffff</color>
+    <color name="qsb_background_dark">#ff212121</color>
+    <color name="qsb_background_black">@android:color/black</color>
     <color name="weather_widget_text_color">#ffffffff</color>
     <color name="default_shadow_color_no_alpha">#ff000000</color>
     <color name="popup_header_background_color">#ffeeeeee</color>
+    <color name="popup_header_background_color_dark">#ff101010</color>
+    <color name="popup_header_background_color_black">@android:color/black</color>
     <color name="popup_background_color">#ffffffff</color>
+    <color name="popup_background_color_dark">#ff212121</color>
+    <color name="popup_background_color_black">#ff101010</color>
     <color name="notification_icon_default_color">#ff757575</color>
     <color name="notification_color_beneath">#ffe0e0e0</color>
+    <color name="notification_color_beneath_dark">#ff252525</color>
+    <color name="notification_color_beneath_black">#ff101010</color>
     <color name="badge_color">#fff</color>
     <color name="blue_grey_100">#ffcfd8dc</color>
     <color name="search_bar_text_color">#4c4c4c</color>
@@ -72,8 +96,28 @@
     <color name="drop_target_text_color">#fff</color>
     <color name="overview_button_text_color">#fff</color>
     <color name="plane_color">#fff</color>
+    <color name="folder_name_text_color">#EE777777</color>
+    <color name="folder_name_text_color_dark">#EEEEEEEE</color>
     <color name="folder_name_highlight_color">#ffCCCCCC</color>
     <color name="folder_name_hint_color">#ff808080</color>
     <color name="wallpaper_picker_item_label_text_color">#fff</color>
     <color name="qsb_connector_gradient_end_color">#66ffffff</color>
+
+    <color name="blur_tint_color">#45ffffff</color>
+    <color name="blur_tint_color_dark">#45212121</color>
+    <color name="blur_tint_color_black">#45212121</color>
+    <color name="folder_bg_color_blur">#75FFFFFF</color>
+    <color name="folder_bg_color_blur_dark">#75212121</color>
+    <color name="folder_bg_color_blur_black">#75000000</color>
+
+    <color name="color_primary_settings">#fff5f5f5</color>
+    <color name="color_primary_dark_settings">#757575</color>
+    <color name="color_primary_dark_settings_v23">#e0e0e0</color>
+    <color name="color_primary_settings_dark">#ff2d2d2d</color>
+    <color name="color_primary_dark_settings_dark">#ff242424</color>
+    <color name="color_primary_settings_black">@android:color/black</color>
+    <color name="color_primary_dark_settings_black">@android:color/black</color>
+    <color name="color_navigationbar_settings">#ff000000</color>
+    <color name="color_navigationbar_settings_dark">#ff000000</color>
+    <color name="color_navigationbar_settings_black">#ff000000</color>
 </resources>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -2,4 +2,8 @@
 <resources>
     <integer name="fadeinAnimTime">200</integer>
     <integer name="fadeoutAnimTime">200</integer>
+
+    <integer name="folderBgIntensity">245</integer>
+    <integer name="folderBgIntensityDark">75</integer>
+    <integer name="folderBgIntensityBlack">0</integer>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -43,8 +43,8 @@
 
         <item name="materialPanelBgColor">@color/quantum_panel_bg_color</item>
         <item name="folderIconTextColor">@color/quantum_panel_text_color</item>
-        <item name="folderNameTextColor">#EE777777</item>
-        <item name="folderBgIntensity">245</item>
+        <item name="folderNameTextColor">@color/folder_name_text_color</item>
+        <item name="folderBgIntensity">@integer/folderBgIntensity</item>
         <item name="deepShortcutsHandleColor">?android:textColorSecondary</item>
         <item name="appPopupTextColor">?android:textColorSecondary</item>
         <item name="appPopupHeaderBgColor">@color/popup_header_background_color</item>
@@ -52,15 +52,15 @@
         <item name="popupColorSecondary">#fff5f5f5</item>
         <item name="popupColorTertiary">@color/notification_color_beneath</item>
         <item name="allAppsContainerColor">@color/all_apps_container_color</item>
-        <item name="allAppsContainerColorBlur">#00ffffff</item>
-        <item name="allAppsEmptySearchTextColor">#212121</item>
-        <item name="blurTintColor">#45ffffff</item>
-        <item name="qsbBgColor">@android:color/white</item>
-        <item name="folderBgColorBlur">#75ffffff</item>
-        <item name="roundSearchBarBgColor">#10000000</item>
-        <item name="roundSearchBarDividerColor">#10111111</item>
-        <item name="roundSearchBarHintColor">@color/quantum_panel_text_color</item>
-        <item name="roundSearchBarTextColor">#4c4c4c</item>
+        <item name="allAppsContainerColorBlur">@color/all_apps_container_color_blur</item>
+        <item name="allAppsEmptySearchTextColor">@color/all_apps_empty_search_text_color</item>
+        <item name="blurTintColor">@color/blur_tint_color</item>
+        <item name="qsbBgColor">@color/qsb_background</item>
+        <item name="folderBgColorBlur">@color/folder_bg_color_blur</item>
+        <item name="roundSearchBarBgColor">@color/all_apps_round_searchbar_bg_color</item>
+        <item name="roundSearchBarDividerColor">@color/all_apps_round_searchbar_divider_color</item>
+        <item name="roundSearchBarHintColor">@color/all_apps_round_searchbar_hint_color</item>
+        <item name="roundSearchBarTextColor">@color/all_apps_round_searchbar_text_color</item>
     </style>
 
     <style name="LauncherTheme.Dark" parent="@style/BaseLauncherTheme.Dark">
@@ -71,44 +71,47 @@
         <item name="android:navigationBarColor">#00000000</item>
         <item name="materialPanelBgColor">@color/quantum_panel_bg_color_dark</item>
         <item name="folderIconTextColor">@color/quantum_panel_text_color_dark</item>
-        <item name="folderNameTextColor">#EEEEEEEE</item>
-        <item name="folderBgIntensity">75</item>
+        <item name="folderNameTextColor">@color/folder_name_text_color_dark</item>
+        <item name="folderBgIntensity">@integer/folderBgIntensityDark</item>
         <item name="deepShortcutsHandleColor">?android:textColorSecondary</item>
         <item name="appPopupTextColor">?android:textColorSecondary</item>
-        <item name="appPopupHeaderBgColor">#ff101010</item>
+        <item name="appPopupHeaderBgColor">@color/popup_header_background_color_dark</item>
         <item name="popupColorPrimary">#ff212121</item>
         <item name="popupColorSecondary">#ff424242</item>
         <item name="popupColorTertiary">#ff757575</item>
-        <item name="allAppsContainerColor">#ff212121</item>
-        <item name="allAppsContainerColorBlur">#00212121</item>
-        <item name="allAppsEmptySearchTextColor">@android:color/white</item>
-        <item name="blurTintColor">#45212121</item>
-        <item name="qsbBgColor">@color/quantum_panel_bg_color_dark</item>
-        <item name="folderBgColorBlur">#75212121</item>
-        <item name="roundSearchBarBgColor">#10ffffff</item>
-        <item name="roundSearchBarDividerColor">#10eeeeee</item>
-        <item name="roundSearchBarHintColor">@android:color/white</item>
-        <item name="roundSearchBarTextColor">@android:color/white</item>
+        <item name="allAppsContainerColor">@color/all_apps_container_color_dark</item>
+        <item name="allAppsContainerColorBlur">@color/all_apps_container_color_blur_dark</item>
+        <item name="allAppsEmptySearchTextColor">@color/all_apps_empty_search_text_color</item>
+        <item name="blurTintColor">@color/blur_tint_color_dark</item>
+        <item name="qsbBgColor">@color/qsb_background_dark</item>
+        <item name="folderBgColorBlur">@color/folder_bg_color_blur_dark</item>
+        <item name="roundSearchBarBgColor">@color/all_apps_round_searchbar_bg_color_dark</item>
+        <item name="roundSearchBarDividerColor">@color/all_apps_round_searchbar_divider_color_dark</item>
+        <item name="roundSearchBarHintColor">@color/all_apps_round_searchbar_hint_color_dark</item>
+        <item name="roundSearchBarTextColor">@color/all_apps_round_searchbar_text_color_dark</item>
     </style>
 
     <style name="LauncherTheme.Black" parent="LauncherTheme.Dark">
-        <item name="materialPanelBgColor">@android:color/black</item>
-        <item name="folderBgIntensity">0</item>
-        <item name="appPopupHeaderBgColor">@android:color/black</item>
+        <item name="materialPanelBgColor">@color/quantum_panel_bg_color_black</item>
+        <item name="folderBgIntensity">@integer/folderBgIntensityBlack</item>
+        <item name="appPopupHeaderBgColor">@color/popup_header_background_color_black</item>
         <item name="popupColorPrimary">#ff000000</item>
         <item name="popupColorSecondary">#ff000000</item>
         <item name="popupColorTertiary">#ff000000</item>
-        <item name="allAppsContainerColor">@android:color/black</item>
-        <item name="allAppsContainerColorBlur">#00000000</item>
-        <item name="blurTintColor">#45000000</item>
-        <item name="qsbBgColor">@android:color/black</item>
-        <item name="folderBgColorBlur">#75000000</item>
+        <item name="allAppsContainerColor">@color/all_apps_container_color_black</item>
+        <item name="allAppsContainerColorBlur">@color/all_apps_container_color_blur_black</item>
+        <item name="blurTintColor">@color/blur_tint_color_black</item>
+        <item name="qsbBgColor">@color/qsb_background_black</item>
+        <item name="folderBgColorBlur">@color/folder_bg_color_blur_black</item>
     </style>
 
     <style name="SettingsTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="colorPrimaryDark">@color/color_primary_dark_settings</item>
+        <item name="colorPrimary">@color/color_primary_settings</item>
         <item name="colorAccent">@color/accent_material_light</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
         <item name="blurTintColor">#45ffffff</item>
+        <item name="android:navigationBarColor">@color/color_navigationbar_settings</item>
         <item name="windowNoTitle">true</item>
     </style>
 
@@ -117,11 +120,12 @@
     </style>
 
     <style name="SettingsTheme.Dark" parent="Theme.AppCompat.NoActionBar">
-        <item name="colorPrimaryDark">#ff242424</item>
-        <item name="colorPrimary">#ff2d2d2d</item>
+        <item name="colorPrimaryDark">@color/color_primary_dark_settings_dark</item>
+        <item name="colorPrimary">@color/color_primary_settings_dark</item>
         <item name="colorAccent">@color/accent_material_light</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
         <item name="blurTintColor">#45212121</item>
+        <item name="android:navigationBarColor">@color/color_navigationbar_settings_dark</item>
         <item name="windowNoTitle">true</item>
     </style>
 
@@ -130,10 +134,11 @@
     </style>
 
     <style name="SettingsTheme.Black" parent="SettingsTheme.Dark">
-        <item name="colorPrimaryDark">@android:color/black</item>
-        <item name="colorPrimary">@android:color/black</item>
+        <item name="colorPrimaryDark">@color/color_primary_dark_settings_black</item>
+        <item name="colorPrimary">@color/color_primary_settings_black</item>
         <item name="android:windowBackground">@android:color/black</item>
         <item name="android:listDivider">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@color/color_navigationbar_settings_black</item>
     </style>
 
     <style name="SettingsHome.Black" parent="SettingsTheme.Black">


### PR DESCRIPTION
This commit makes it easier for substratum themers to theme this app. It is already themeable by overlaying the styles, but moving the resource definitions to their specific files makes basic theming possible without touching the styles.

Theming colors.xml is less "invasive" than theming the styles. Example: My current Overlay using a style overlay works just fine, but after an update of LawnChair there is a chance, that the app stopps working until the user rebuilds the Overlay. Using just a colors Overlay this does not happen.