### PR TITLE
build.gradle: use implementation instead of compile

### DIFF
--- a/launcherclient/build.gradle
+++ b/launcherclient/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }
 repositories {
     mavenCentral()


### PR DESCRIPTION
Fix: "Configuration 'compile' in project ':launcherclient' is deprecated. Use 'implementation' instead."