### PR TITLE
backuprestore: rebuild icon db after every Settings restore

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/settings/ui/SettingsActivity.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/settings/ui/SettingsActivity.java
@@ -281,6 +281,7 @@ public class SettingsActivity extends AppCompatActivity implements
                     case "import_prefs":
                         if (checkStoragePermission()) {
                             DumbImportExportTask.importPrefs(getActivity());
+                            LauncherAppState.getInstance().getLauncher().scheduleReloadIcons();
                             LauncherAppState.getInstance().getLauncher().scheduleKill();
                         }
                         break;


### PR DESCRIPTION
The IconCache doesn't clear itself even after killing the Launcher process, leaving the icon shapes unchanged.
Rebuilding icon db fixes it.