### PR TITLE
dynamic status bar gradient #fixderps

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/config/FeatureFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/config/FeatureFlags.kt
@@ -52,7 +52,6 @@ object FeatureFlags {
     const val KEY_PREF_DARK_THEME = "pref_enableDarkTheme"
     const val KEY_PREF_ROUND_SEARCH_BAR = "pref_useRoundSearchBar"
     const val KEY_PREF_ENABLE_BACKPORT_SHORTCUTS = "pref_enableBackportShortcuts"
-    const val KEY_PREF_SHOW_TOP_SHADOW = "pref_showTopShadow"
     const val KEY_PREF_THEME = "pref_theme"
     const val KEY_PREF_THEME_MODE = "pref_themeMode"
     const val KEY_PREF_HIDE_HOTSEAT = "pref_hideHotseat"

--- a/app/src/main/java/ch/deletescape/lawnchair/dragndrop/DragLayer.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/dragndrop/DragLayer.java
@@ -138,7 +138,6 @@ public class DragLayer extends InsettableFrameLayout {
     public boolean mIsAccesibilityEnabled;
     private boolean mPreventAllApps;
 
-    private final Drawable mTopShadow;
 
     /**
      * Used to create a new DragLayer from XML.
@@ -160,13 +159,6 @@ public class DragLayer extends InsettableFrameLayout {
         mRightHoverDrawableActive = res.getDrawable(R.drawable.page_hover_right_active, null);
         mIsRtl = Utilities.isRtl(res);
         mFocusIndicatorHelper = new ViewGroupFocusHelper(this);
-
-        mTopShadow = getBackground();
-        updateTopShadow();
-    }
-
-    public void updateTopShadow() {
-        setBackground(Utilities.getPrefs(getContext()).getShowTopShadow() ? mTopShadow : null);
     }
 
     public void setup(Launcher launcher, DragController dragController,

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
@@ -88,7 +88,6 @@ interface IPreferenceProvider {
     val useWhiteGoogleIcon: Boolean
     val useRoundSearchBar: Boolean
     val enableBackportShortcuts: Boolean
-    val showTopShadow: Boolean
     val hideHotseat: Boolean
     val enablePlanes: Boolean
     val showWeather: Boolean

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
@@ -188,7 +188,6 @@ open class PreferenceImpl(context: Context) : IPreferenceProvider {
         get() = true
     override val useRoundSearchBar by BooleanPref(FeatureFlags.KEY_PREF_ROUND_SEARCH_BAR, false)
     override val enableBackportShortcuts by BooleanPref(FeatureFlags.KEY_PREF_ENABLE_BACKPORT_SHORTCUTS, false)
-    override val showTopShadow by BooleanPref(FeatureFlags.KEY_PREF_SHOW_TOP_SHADOW, true)
     override val hideHotseat by BooleanPref(FeatureFlags.KEY_PREF_HIDE_HOTSEAT, false)
     override val enablePlanes by BooleanPref(FeatureFlags.KEY_PREF_PLANE, false)
     override val showWeather by BooleanPref(FeatureFlags.KEY_PREF_WEATHER, false)

--- a/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
@@ -139,9 +139,6 @@ public class Settings implements SharedPreferences.OnSharedPreferenceChangeListe
                     } else {
                         mLauncher.scheduleKill();
                     }
-                case PreferenceFlags.KEY_PREF_SHOW_TOP_SHADOW:
-                    mLauncher.getDragLayer().updateTopShadow();
-                    break;
                 case PreferenceFlags.KEY_CENTER_WALLPAPER:
                     mLauncher.getWorkspace().getWallpaperOffset().updateCenterWallpaper();
                 default:

--- a/app/src/main/res/layout-land/launcher.xml
+++ b/app/src/main/res/layout-land/launcher.xml
@@ -25,7 +25,6 @@
         android:id="@+id/drag_layer"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:background="@drawable/workspace_bg"
         android:importantForAccessibility="no"
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/app/src/main/res/layout-sw720dp/launcher.xml
+++ b/app/src/main/res/layout-sw720dp/launcher.xml
@@ -26,7 +26,6 @@
         android:clipChildren="false"
         android:clipToPadding="false"
         android:importantForAccessibility="no"
-        android:background="@drawable/workspace_bg"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/launcher.xml
+++ b/app/src/main/res/layout/launcher.xml
@@ -27,7 +27,6 @@
         android:clipChildren="false"
         android:importantForAccessibility="no"
         android:clipToPadding="false"
-        android:background="@drawable/workspace_bg"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/xml/launcher_behavior_preferences.xml
+++ b/app/src/main/res/xml/launcher_behavior_preferences.xml
@@ -38,12 +38,6 @@
         android:persistent="true" />
 
     <SwitchPreference
-        android:key="pref_showTopShadow"
-        android:title="@string/show_top_shadow_title"
-        android:defaultValue="true"
-        android:persistent="true" />
-
-    <SwitchPreference
         android:key="pref_enableHapticFeedback"
         android:title="@string/haptic_feedback_pref_title"
         android:defaultValue="false"


### PR DESCRIPTION
 This is like a switch to turn ON/OFF the annoying white gradient over the status bar area when a dark/black wallpaper is applied. Especially noticeable on LED Displays
It is replaced by a fully transparent background when a dark/black wall is applied
The gradient is shown when a light/bright wallpaper is applied

-added the algorithm
-fixed derp for lwp 
-removed "Show top shadow" from settings.