### PR TITLE
Exit overview mode when clicking on actions

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/Launcher.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Launcher.java
@@ -1192,6 +1192,7 @@ public class Launcher extends Activity
                 @Override
                 public void onClick(View view) {
                     if (!mWorkspace.isSwitchingState()) {
+                        showWorkspace(false);
                         onClickWallpaperPicker(view);
                     }
                 }
@@ -1209,6 +1210,7 @@ public class Launcher extends Activity
             @Override
             public void onClick(View view) {
                 if (!mWorkspace.isSwitchingState()) {
+                    showWorkspace(false);
                     onClickAddWidgetButton();
                 }
             }
@@ -1222,6 +1224,7 @@ public class Launcher extends Activity
             @Override
             public void onClick(View view) {
                 if (!mWorkspace.isSwitchingState()) {
+                    showWorkspace(false);
                     onClickSettingsButton(view);
                 }
             }


### PR DESCRIPTION
When clicking on action buttons (Settings, Widget and Wallpaper picker) exit from overview mode.