### PR TITLE
Try to fix Pill widget when Google Now page disabled (WIP)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,12 @@ pipeline:
     when:
       event: push
       status: success
+  upload:
+    image: lawnchairlauncher/drone-transfer.sh:latest
+    upload: app/build/outputs/apk/debug/app-debug.apk
+    when:
+      event: pull_request
+      status: success
   telegram:
     image: appleboy/drone-telegram:latest
     secrets: [ telegram_token ]
@@ -36,6 +42,7 @@ pipeline:
         Build {{build.number}} failed. Fix me please sir!
       {{/success}}
     when:
+      event: [push, tag, deployment]
       status: [ failure, success ]
 
 branches:

--- a/app/src/main/java/ch/deletescape/lawnchair/Launcher.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Launcher.java
@@ -440,8 +440,8 @@ public class Launcher extends Activity
         IntentFilter filter = new IntentFilter(ACTION_APPWIDGET_HOST_RESET);
         registerReceiver(mUiBroadcastReceiver, filter);
 
-        mLauncherTab = new LauncherTab(this);
         Utilities.showOutdatedLawnfeedPopup(this);
+        mLauncherTab = new LauncherTab(this);
 
         Window window = getWindow();
         WindowManager.LayoutParams attributes = window.getAttributes();

--- a/app/src/main/java/ch/deletescape/lawnchair/LauncherTab.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/LauncherTab.java
@@ -25,7 +25,6 @@ public class LauncherTab {
 
     public LauncherTab(Launcher launcher) {
         mLauncherClient = ILauncherClient.Companion.create(launcher);
-
         launcher.setLauncherOverlay(new LauncherOverlays());
     }
 

--- a/app/src/main/java/ch/deletescape/lawnchair/PagedView.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/PagedView.java
@@ -31,6 +31,7 @@ import android.graphics.RectF;
 import android.os.Bundle;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -44,10 +45,13 @@ import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.animation.Interpolator;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 
+import ch.deletescape.lawnchair.overlay.ILauncherClient;
 import ch.deletescape.lawnchair.pageindicators.PageIndicator;
+import ch.deletescape.lawnchair.preferences.IPreferenceProvider;
 import ch.deletescape.lawnchair.util.LauncherEdgeEffect;
 import ch.deletescape.lawnchair.util.Thunk;
 
@@ -187,8 +191,20 @@ public abstract class PagedView extends ViewGroup implements ViewGroup.OnHierarc
     protected final Rect mInsets = new Rect();
     protected final boolean mIsRtl;
 
-    // Edge effect
-    private final LauncherEdgeEffect mEdgeGlowLeft = new LauncherEdgeEffect();
+    // Edge effect, add swipe-to-left gesture for Lawnfeed
+    private final LauncherEdgeEffect mEdgeGlowLeft = new LauncherEdgeEffect(){
+        @Override
+        public void onRelease() {
+            // Check if user swiped
+            if (mPullDistance > 0) {
+                Utilities.showLawnfeedPopup(getContext());
+            }
+
+            super.onRelease();
+        }
+    };
+
+    // Edge effect for right side
     private final LauncherEdgeEffect mEdgeGlowRight = new LauncherEdgeEffect();
 
     public PagedView(Context context) {

--- a/app/src/main/java/ch/deletescape/lawnchair/PagedView.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/PagedView.java
@@ -31,7 +31,6 @@ import android.graphics.RectF;
 import android.os.Bundle;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -45,13 +44,10 @@ import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.animation.Interpolator;
-import android.widget.Toast;
 
 import java.util.ArrayList;
 
-import ch.deletescape.lawnchair.overlay.ILauncherClient;
 import ch.deletescape.lawnchair.pageindicators.PageIndicator;
-import ch.deletescape.lawnchair.preferences.IPreferenceProvider;
 import ch.deletescape.lawnchair.util.LauncherEdgeEffect;
 import ch.deletescape.lawnchair.util.Thunk;
 

--- a/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
@@ -1083,6 +1083,13 @@ public final class Utilities {
 
     public static void showOutdatedLawnfeedPopup(final Context context) {
         if (!BuildConfig.ENABLE_LAWNFEED || ILauncherClient.Companion.getEnabledState(context) != ILauncherClient.DISABLED_CLIENT_OUTDATED) return;
+
+        // Disable Google Now page setting if the user have enabled Google Now page
+        if (Utilities.getPrefs(context).getShowGoogleNowTab()) {
+            SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
+            settings.edit().putBoolean(PreferenceFlags.KEY_PREF_SHOW_NOW_TAB, false).commit();
+        }
+
         new AlertDialog.Builder(context)
             .setTitle(R.string.lawnfeed_outdated_title)
             .setMessage(R.string.lawnfeed_outdated)

--- a/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
@@ -16,6 +16,7 @@
 
 package ch.deletescape.lawnchair;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.AlertDialog;
@@ -144,6 +145,9 @@ public final class Utilities {
 
     public static final boolean ATLEAST_OREO =
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
+
+    public static final boolean ATLEAST_OREO_M1 =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1;
 
     // An intent extra to indicate the horizontal scroll of the wallpaper.
     public static final String EXTRA_WALLPAPER_OFFSET = "ch.deletescape.lawnchair.WALLPAPER_OFFSET";
@@ -1079,6 +1083,41 @@ public final class Utilities {
         }
 
         return BLACKLISTED_APPLICATIONS.length == 0;
+    }
+
+    public static void showLawnfeedPopup(final Context context) {
+        if (!BuildConfig.ENABLE_LAWNFEED || ILauncherClient.Companion.getEnabledState(context) != ILauncherClient.ENABLED) return;
+        final IPreferenceProvider prefs = getPrefs(context);
+
+        // Don't show anything if the user have selected "Don't show again" or Google Now page is enabled
+        if (prefs.getDisableLawnfeedPopup() || prefs.getShowGoogleNowTab()) {
+            return;
+        }
+
+        // Show a popup about the disabled Google Now page option
+        new AlertDialog.Builder(context)
+                .setTitle(R.string.lawnfeed_not_enabled_title)
+                .setMessage(R.string.lawnfeed_not_enabled)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                    @SuppressLint("ApplySharedPref")
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        // Enable Google Now page setting
+                        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
+                        settings.edit().putBoolean(PreferenceFlags.KEY_PREF_SHOW_NOW_TAB, true).commit();
+
+                        // Restart Lawnchair to enable Lawnfeed
+                        LauncherAppState.getInstanceNoCreate().getLauncher().scheduleKill();
+                    }
+                })
+                .setNeutralButton(R.string.disable_popup, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        prefs.setDisableLawnfeedPopup(true);
+                    }
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
     }
 
     public static void showOutdatedLawnfeedPopup(final Context context) {

--- a/app/src/main/java/ch/deletescape/lawnchair/Workspace.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Workspace.java
@@ -1325,12 +1325,10 @@ public class Workspace extends PagedView
     @Override
     protected void overScroll(float amount) {
         boolean shouldScrollOverlay = mLauncherOverlay != null && mLauncher.isClientConnected() &&
-                ((amount <= 0 && !mIsRtl) || (amount >= 0 && mIsRtl)) &&
-                Utilities.getPrefs(mLauncher).getShowGoogleNowTab();
+                ((amount <= 0 && !mIsRtl) || (amount >= 0 && mIsRtl));
 
         boolean shouldZeroOverlay = mLauncherOverlay != null && mLauncher.isClientConnected() &&
-                mLastOverlaySroll != 0 && ((amount >= 0 && !mIsRtl) || (amount <= 0 && mIsRtl)) &&
-                Utilities.getPrefs(mLauncher).getShowGoogleNowTab();
+                mLastOverlaySroll != 0 && ((amount >= 0 && !mIsRtl) || (amount <= 0 && mIsRtl));
 
         if (shouldScrollOverlay) {
             if (!mStartedSendingScrollEvents && mScrollInteractionBegan) {

--- a/app/src/main/java/ch/deletescape/lawnchair/Workspace.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Workspace.java
@@ -1324,12 +1324,13 @@ public class Workspace extends PagedView
 
     @Override
     protected void overScroll(float amount) {
-
         boolean shouldScrollOverlay = mLauncherOverlay != null && mLauncher.isClientConnected() &&
-                ((amount <= 0 && !mIsRtl) || (amount >= 0 && mIsRtl));
+                ((amount <= 0 && !mIsRtl) || (amount >= 0 && mIsRtl)) &&
+                Utilities.getPrefs(mLauncher).getShowGoogleNowTab();
 
         boolean shouldZeroOverlay = mLauncherOverlay != null && mLauncher.isClientConnected() &&
-                mLastOverlaySroll != 0 && ((amount >= 0 && !mIsRtl) || (amount <= 0 && mIsRtl));
+                mLastOverlaySroll != 0 && ((amount >= 0 && !mIsRtl) || (amount <= 0 && mIsRtl)) &&
+                Utilities.getPrefs(mLauncher).getShowGoogleNowTab();
 
         if (shouldScrollOverlay) {
             if (!mStartedSendingScrollEvents && mScrollInteractionBegan) {

--- a/app/src/main/java/ch/deletescape/lawnchair/config/FeatureFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/config/FeatureFlags.kt
@@ -37,6 +37,8 @@ object FeatureFlags {
     const val KEY_FULL_WIDTH_SEARCHBAR = "pref_fullWidthSearchbar"
     const val KEY_SHOW_PIXEL_BAR = "pref_showPixelBar"
     const val KEY_HOME_OPENS_DRAWER = "pref_homeOpensDrawer"
+    const val KEY_SHOW_SEARCH_PILL = "pref_showSearchPill"
+    const val KEY_SHOW_DATE_OR_WEATHER = "pref_showDateOrWeather"
     const val KEY_SHOW_VOICE_SEARCH_BUTTON = "pref_showMic"
     const val KEY_PREF_PIXEL_STYLE_ICONS = "pref_pixelStyleIcons"
     const val KEY_PREF_HIDE_APP_LABELS = "pref_hideAppLabels"

--- a/app/src/main/java/ch/deletescape/lawnchair/overlay/LawnfeedClient.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/overlay/LawnfeedClient.kt
@@ -42,7 +42,7 @@ class LawnfeedClient(private val launcher: Launcher) : ILauncherClient {
     }
 
     private fun connectProxy() {
-        if (Utilities.checkOutdatedLawnfeed(launcher) || !Utilities.getPrefs(launcher).showGoogleNowTab) {
+        if (Utilities.checkOutdatedLawnfeed(launcher)) {
             return
         }
 
@@ -229,9 +229,11 @@ class LawnfeedClient(private val launcher: Launcher) : ILauncherClient {
     }
 
     fun onQsbClick(intent: Intent, receiver: QsbReceiver) {
-        ifConnected {
-            proxy?.onQsbClick(intent)
-            qsbReceiver = receiver
+        if (isConnected) {
+            try {
+                proxy?.onQsbClick(intent)
+                qsbReceiver = receiver
+            } catch (ignored: RemoteException) {}
         }
     }
 

--- a/app/src/main/java/ch/deletescape/lawnchair/overlay/LawnfeedClient.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/overlay/LawnfeedClient.kt
@@ -42,8 +42,8 @@ class LawnfeedClient(private val launcher: Launcher) : ILauncherClient {
     }
 
     private fun connectProxy() {
-        if (Utilities.checkOutdatedLawnfeed(launcher)) {
-            return
+        if (!Utilities.getPrefs(launcher).showGoogleNowTab) {
+            return;
         }
 
         sProxyConnection = ProxyServiceConnection(PROXY_PACKAGE)
@@ -230,10 +230,8 @@ class LawnfeedClient(private val launcher: Launcher) : ILauncherClient {
 
     fun onQsbClick(intent: Intent, receiver: QsbReceiver) {
         if (isConnected) {
-            try {
-                proxy?.onQsbClick(intent)
-                qsbReceiver = receiver
-            } catch (ignored: RemoteException) {}
+            proxy?.onQsbClick(intent)
+            qsbReceiver = receiver
         }
     }
 

--- a/app/src/main/java/ch/deletescape/lawnchair/pixelify/BaseQsbView.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/pixelify/BaseQsbView.java
@@ -1,6 +1,7 @@
 package ch.deletescape.lawnchair.pixelify;
 
 import android.animation.ObjectAnimator;
+import android.app.SearchManager;
 import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -9,7 +10,9 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Point;
 import android.graphics.Rect;
+import android.os.Bundle;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -129,8 +132,15 @@ public abstract class BaseQsbView extends FrameLayout implements OnClickListener
     public void onClick(View view) {
         if (view.getId() == R.id.mic_icon) {
             startQsbActivity(VOICE_ASSIST);
-        } else if (BuildConfig.ENABLE_LAWNFEED && PackageManagerHelper.isAppEnabled(getContext().getPackageManager(), LawnfeedClient.PROXY_PACKAGE, 0)) {
-            ((LawnfeedClient) mLauncher.getClient()).onQsbClick(bm("com.google.nexuslauncher.FAST_TEXT_SEARCH"), new Receiver(this));
+            return;
+        }
+
+        if (BuildConfig.ENABLE_LAWNFEED) {
+            if (mLauncher.isClientConnected()) {
+                ((LawnfeedClient) mLauncher.getClient()).onQsbClick(bm("com.google.nexuslauncher.FAST_TEXT_SEARCH"), new Receiver(this));
+            } else {
+                startQsbActivity(TEXT_ASSIST);
+            }
         } else {
             getContext().sendOrderedBroadcast(bm("com.google.nexuslauncher.FAST_TEXT_SEARCH"), null, new C0287l(this), null, 0, null, null);
         }

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
@@ -73,6 +73,8 @@ interface IPreferenceProvider {
     val useFullWidthSearchBar: Boolean
     val showVoiceSearchButton: Boolean
     val showPixelBar: Boolean
+    val showSearchPill: Boolean
+    val showDateOrWeather: Boolean
     val homeOpensDrawer: Boolean
     val usePixelIcons: Boolean
     val enableScreenRotation: Boolean

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
@@ -113,6 +113,7 @@ interface IPreferenceProvider {
     fun removeAlternateIcon(key: String)
     var hiddenAppsSet : Set<String>
     var previousBuildNumber : Int
+    var disableLawnfeedPopup: Boolean
     var overrideIconShape: String
     val backportAdaptiveIcons: Boolean
     fun removeOverrideIconShape()

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
@@ -63,6 +63,8 @@ object PreferenceFlags {
     const val KEY_PREF_KEEP_SCROLL_STATE = "pref_keepScrollState"
     const val KEY_FULL_WIDTH_SEARCHBAR = "pref_fullWidthSearchbar"
     const val KEY_SHOW_PIXEL_BAR = "pref_showPixelBar"
+    const val KEY_SHOW_SEARCH_PILL = "pref_showSearchPill"
+    const val KEY_SHOW_DATE_OR_WEATHER = "pref_showDateOrWeather"
     const val KEY_SHOW_VOICE_SEARCH_BUTTON = "pref_showMic"
     const val KEY_PREF_ALL_APPS_OPACITY = "pref_allAppsOpacitySB"
     const val KEY_PREF_SHOW_HIDDEN_APPS = "pref_showHidden"

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
@@ -102,6 +102,7 @@ object PreferenceFlags {
 
     const val KEY_APP_VISIBILITY_PREFIX = "visibility_"
     const val KEY_PREVIOUS_BUILD_NUMBER = "previousBuildNumber"
+    const val KEY_DISABLE_LAWNFEED_POPUP = "disableLawnfeedPopup"
 
     const val KEY_ALTERNATE_ICON_PREFIX = "alternateIcon_"
     const val KEY_ITEM_ALIAS_PREFIX = "alias_"

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
@@ -224,6 +224,8 @@ open class PreferenceImpl(context: Context) : IPreferenceProvider {
     override val useFullWidthSearchBar by BooleanPref(FeatureFlags.KEY_FULL_WIDTH_SEARCHBAR, false)
     override val showVoiceSearchButton by BooleanPref(FeatureFlags.KEY_SHOW_VOICE_SEARCH_BUTTON, false)
     override val showPixelBar by BooleanPref(FeatureFlags.KEY_SHOW_PIXEL_BAR, true)
+    override val showSearchPill by BooleanPref(FeatureFlags.KEY_SHOW_SEARCH_PILL, true)
+    override val showDateOrWeather by BooleanPref(FeatureFlags.KEY_SHOW_DATE_OR_WEATHER, true)
     override val homeOpensDrawer by BooleanPref(FeatureFlags.KEY_HOME_OPENS_DRAWER, true)
     override val usePixelIcons by BooleanPref(FeatureFlags.KEY_PREF_PIXEL_STYLE_ICONS, true)
     override val enableScreenRotation by BooleanPref(FeatureFlags.KEY_PREF_ENABLE_SCREEN_ROTATION, false)

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
@@ -161,6 +161,7 @@ open class PreferenceImpl(context: Context) : IPreferenceProvider {
     override val backportAdaptiveIcons = Utilities.ATLEAST_NOUGAT
     override val weatherProvider by StringPref(PreferenceFlags.KEY_WEATHER_PROVIDER, PreferenceFlags.PREF_WEATHER_PROVIDER_AWARENESS)
     override var previousBuildNumber by MutableIntPref(PreferenceFlags.KEY_PREVIOUS_BUILD_NUMBER, 0)
+    override var disableLawnfeedPopup by MutableBooleanPref(PreferenceFlags.KEY_DISABLE_LAWNFEED_POPUP, false)
 
     override var hiddenAppsSet: Set<String>
         get() {

--- a/app/src/main/java/ch/deletescape/lawnchair/util/LauncherEdgeEffect.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/util/LauncherEdgeEffect.java
@@ -72,7 +72,7 @@ public class LauncherEdgeEffect {
 
     private int mState = STATE_IDLE;
 
-    private float mPullDistance;
+    protected float mPullDistance;
 
     private final Rect mBounds = new Rect();
     private final Paint mPaint = new Paint();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -497,8 +497,12 @@
     <string name="snowflake_size_scale">Snowflake size scale</string>
     <string name="snowflakes_num">Max number of snowflakes</string>
 
+    <!-- Strings for popup dialogs -->
+    <string name="lawnfeed_not_enabled_title">Lawnfeed not enabled</string>
+    <string name="lawnfeed_not_enabled">It looks like you\'re trying to open the Google Now page, but you haven\'t enabled the option in the behavior settings.\n\nDo you want to enable it now?</string>
     <string name="lawnfeed_outdated_title">Lawnfeed update required</string>
     <string name="lawnfeed_outdated">A newer version of Lawnfeed is required in order to work with this version of Lawnchair.\n\nBefore installing the update you will probably need to uninstall the current version of Lawnfeed.\n\nDo you want to download it now?</string>
     <string name="title_storage_permission_required">Storage Permission Required</string>
     <string name="content_storage_permission_required">On Android 8.1 and above the storage permission is required for apps to access the wallpaper. Without said permission Lawnchair might crash or show unexpected behaviours.</string>
+    <string name="disable_popup">Don\'t show again</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -361,6 +361,8 @@
     <string name="debug_pref_summary">Restart or rebuild icon database</string>
     <string name="show_pixel_bar_pref_title">Show Pixel searchbar</string>
     <string name="use_wide_searchbar_pref_title">Use wide searchbar</string>
+    <string name="show_search_pill_title">Show Google Search pill</string>
+    <string name="show_date_or_weather_title">Show date/weather on right side</string>
     <string name="show_mic_pref_title">Show Google Assistant button</string>
     <string name="use_round_searhbar">Use round apps searchbar</string>
     <string name="pixel_style_icons_pref_title">Use Pixel icons</string>

--- a/app/src/main/res/xml/launcher_behavior_preferences.xml
+++ b/app/src/main/res/xml/launcher_behavior_preferences.xml
@@ -75,5 +75,5 @@
         android:key="pref_showGoogleNowTab"
         android:persistent="true"
         android:title="@string/show_google_now_tab_pref_title"
-        android:defaultValue="true" />
+        android:defaultValue="false" />
 </android.support.v7.preference.PreferenceScreen>

--- a/app/src/main/res/xml/launcher_desktop_preferences.xml
+++ b/app/src/main/res/xml/launcher_desktop_preferences.xml
@@ -17,9 +17,24 @@
     <SwitchPreference
         android:defaultValue="false"
         android:dependency="pref_showPixelBar"
+        android:disableDependentsState="true"
         android:key="pref_fullWidthSearchbar"
         android:persistent="true"
         android:title="@string/use_wide_searchbar_pref_title" />
+
+    <SwitchPreference
+        android:defaultValue="true"
+        android:dependency="pref_fullWidthSearchbar"
+        android:key="pref_showSearchPill"
+        android:persistent="true"
+        android:title="@string/show_search_pill_title" />
+
+    <SwitchPreference
+        android:defaultValue="true"
+        android:dependency="pref_fullWidthSearchbar"
+        android:key="pref_showDateOrWeather"
+        android:persistent="true"
+        android:title="@string/show_date_or_weather_title" />
 
     <SwitchPreference
         android:defaultValue="false"

--- a/lawnfeed/src/main/AndroidManifest.xml
+++ b/lawnfeed/src/main/AndroidManifest.xml
@@ -3,11 +3,11 @@
     package="ch.deletescape.lawnchair.lawnfeed">
 
     <!-- Let's break some rules... -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
         android:allowBackup="true"

--- a/lawnfeed/src/main/AndroidManifest.xml
+++ b/lawnfeed/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
         android:allowBackup="true"

--- a/lawnfeed/src/main/java/ch/deletescape/lawnchair/lawnfeed/updater/Updater.java
+++ b/lawnfeed/src/main/java/ch/deletescape/lawnchair/lawnfeed/updater/Updater.java
@@ -37,7 +37,7 @@ public class Updater {
 
     public static final String PREFERENCES_CACHED_UPDATE = "cached_update";
 
-    private static final long SIX_HOURS = 21600000;
+    private static final long TWELVE_HOURS = 43200000;
 
     private static final String TAG = "Updater";
 
@@ -101,8 +101,8 @@ public class Updater {
 
         // Don't check for updates if last update check was not longer than 6 hours ago
         long lastChecked = prefs.getLong(PREFERENCES_LAST_CHECKED, 0);
-        if (lastChecked + SIX_HOURS >= System.currentTimeMillis()) {
-            Log.i(TAG, "Last update check was earlier than 6 hours ago, using cached info");
+        if (lastChecked + TWELVE_HOURS >= System.currentTimeMillis()) {
+            Log.i(TAG, "Last update check was earlier than 12 hours ago, using cached info");
 
             task.onPostExecute(Update.fromString(prefs.getString(PREFERENCES_CACHED_UPDATE, "")));
             return;

--- a/lawnfeed/src/main/java/ch/deletescape/lawnchair/lawnfeed/updater/Updater.java
+++ b/lawnfeed/src/main/java/ch/deletescape/lawnchair/lawnfeed/updater/Updater.java
@@ -1,7 +1,7 @@
 package ch.deletescape.lawnchair.lawnfeed.updater;
 
 import android.app.Activity;
-import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -11,6 +11,8 @@ import android.content.pm.PackageManager;
 import android.media.RingtoneManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Build;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 import org.json.simple.JSONObject;
@@ -39,8 +41,17 @@ public class Updater {
 
     private static final String TAG = "Updater";
 
+    public static final String CHANNEL_ID = "lawnfeed_updater";
+
     public static void checkUpdate(final Context context) {
         final SharedPreferences prefs = context.getSharedPreferences(PREFERENCES_NAME, Activity.MODE_PRIVATE);
+
+        // Create notification channel on Android O
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
+                    context.getResources().getString(R.string.lawnfeed_updates), NotificationManager.IMPORTANCE_DEFAULT);
+            context.getSystemService(NotificationManager.class).createNotificationChannel(channel);
+        }
 
         UpdaterTask task = new UpdaterTask(context, VERSION_URL, new UpdateListener() {
             @Override
@@ -61,7 +72,7 @@ public class Updater {
 
                 // Build notification
                 PendingIntent pendingIntent = PendingIntent.getBroadcast(context,0, intentAction, PendingIntent.FLAG_UPDATE_CURRENT);
-                Notification.Builder builder = new Notification.Builder(context)
+                NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
                         .setContentTitle(context.getResources().getString(R.string.update_available_title))
                         .setContentText(context.getResources().getString(R.string.update_available))
                         .setSmallIcon(R.drawable.ic_lawnchair)

--- a/lawnfeed/src/main/res/values/strings.xml
+++ b/lawnfeed/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="update_available">A new version of Lawnfeed is available to download!</string>
     <string name="downloading_toast">Downloading...</string>
     <string name="download_file_error">Error downloading file</string>
+    <string name="lawnfeed_updates">Lawnfeed Updates</string>
 </resources>


### PR DESCRIPTION
Signed-off-by: David Sn <divad.nnamtdeis@gmail.com>

To summarize, here is what I'm doing right now:
- [x] Google Pill widget should work regardless of Lawnfeed enabled/installed (search on tap)
- [x] mLauncher should be only connected **if** the user has Google Now enabled
- [ ] ~~Fix animation being not shown on Play Store version~~
- [x] Make parts of the widget toggleable, like the pill, edge or weather/date (not wide bar)
