### PR TITLE
Add possibility to configure dock opacity

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/dynamicui/ExtractedColors.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/dynamicui/ExtractedColors.java
@@ -206,6 +206,11 @@ public class ExtractedColors {
                 hotseatColor = ColorUtils.setAlphaComponent(FeatureFlags.INSTANCE.useDarkTheme(FeatureFlags.DARK_ALLAPPS) ? Color.BLACK : Color.WHITE, (int) (0.25f * 255));
             }
         }
+        boolean useCustomOpacity = Utilities.getPrefs(context).getHotseatShouldUseCustomOpacity();
+        if (useCustomOpacity) {
+            float customOpacity = Utilities.getPrefs(context).getHotseatCustomOpacity();
+            hotseatColor = ColorUtils.setAlphaComponent(hotseatColor, (int) (customOpacity * 255));
+        }
         return hotseatColor;
     }
 

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
@@ -129,6 +129,8 @@ interface IPreferenceProvider {
     val iconPackPackage: String
     val hotseatIconScale: Float
     val hotseatHeightScale: Float
+    val hotseatShouldUseCustomOpacity: Boolean
+    val hotseatCustomOpacity: Float
     val enablePhysics: Boolean
     val snowflakeSizeScale: Float
     val snowflakesNum: String

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceFlags.kt
@@ -27,6 +27,7 @@ object PreferenceFlags {
     const val KEY_BLUR_RADIUS = "pref_blurRadius"
     const val KEY_PREF_HOTSEAT_ICON_SCALE = "pref_hotseatIconScale"
     const val KEY_PREF_HOTSEAT_HEIGHT_SCALE = "pref_hotseatHeightScale"
+    const val KEY_PREF_HOTSEAT_CUSTOM_OPACITY = "pref_hotseatCustomOpacity"
     const val KEY_PREF_ALL_APPS_ICON_SCALE = "pref_allAppsIconScale"
     const val KEY_PREF_ALL_APPS_ICON_TEXT_SCALE = "pref_allAppsIconTextScale"
     const val KEY_PREF_ALL_APPS_ICON_PADDING_SCALE = "pref_allAppsIconPaddingScale"
@@ -37,6 +38,7 @@ object PreferenceFlags {
 
     // Boolean
     const val KEY_SHOW_HIDDEN = "pref_showHidden"
+    const val KEY_HOTSEAT_SHOULD_USE_CUSTOM_OPACITY = "pref_hotseatShouldUseCustomOpacity"
     const val KEY_HOTSEAT_SHOULD_USE_EXTRACTED_COLORS = "pref_hotseatShouldUseExtractedColors"
     const val KEY_HOTSEAT_SHOULD_USE_EXTRACTED_COLORS_CACHE = KEY_HOTSEAT_SHOULD_USE_EXTRACTED_COLORS + "_cache"
     const val KEY_LIGHT_STATUS_BAR = "pref_lightStatusBar"

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
@@ -38,9 +38,11 @@ open class PreferenceImpl(context: Context) : IPreferenceProvider {
 
     override val hotseatIconScale by FloatPref(PreferenceFlags.KEY_PREF_HOTSEAT_ICON_SCALE, 1f)
     override val hotseatHeightScale by FloatPref(PreferenceFlags.KEY_PREF_HOTSEAT_HEIGHT_SCALE, 1f)
+    override val hotseatCustomOpacity by FloatPref(PreferenceFlags.KEY_PREF_HOTSEAT_CUSTOM_OPACITY, .5f)
     override val allAppsIconScale by FloatPref(PreferenceFlags.KEY_PREF_ALL_APPS_ICON_SCALE, 1f)
     override val allAppsIconTextScale by FloatPref(PreferenceFlags.KEY_PREF_ALL_APPS_ICON_TEXT_SCALE, 1f)
     override val allAppsIconPaddingScale by FloatPref(PreferenceFlags.KEY_PREF_ALL_APPS_ICON_PADDING_SCALE, 1f)
+    override val hotseatShouldUseCustomOpacity by BooleanPref(PreferenceFlags.KEY_HOTSEAT_SHOULD_USE_CUSTOM_OPACITY, false)
     override val useCustomAllAppsTextColor by BooleanPref(PreferenceFlags.KEY_PREF_DRAWER_CUSTOM_LABEL_COLOR, false)
     override val verticalDrawerLayout by BooleanPref(PreferenceFlags.KEY_PREF_DRAWER_VERTICAL_LAYOUT, false)
     override val iconLabelsInTwoLines by BooleanPref(PreferenceFlags.KEY_ICON_LABELS_IN_TWO_LINES, false)

--- a/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/settings/Settings.java
@@ -106,6 +106,8 @@ public class Settings implements SharedPreferences.OnSharedPreferenceChangeListe
                 case PreferenceFlags.KEY_PREF_ICON_SCALE:
                 case PreferenceFlags.KEY_PREF_HOTSEAT_ICON_SCALE:
                 case PreferenceFlags.KEY_PREF_HOTSEAT_HEIGHT_SCALE:
+                case PreferenceFlags.KEY_PREF_HOTSEAT_CUSTOM_OPACITY:
+                case PreferenceFlags.KEY_HOTSEAT_SHOULD_USE_CUSTOM_OPACITY:
                 case PreferenceFlags.KEY_PREF_ALL_APPS_ICON_SCALE:
                 case PreferenceFlags.KEY_PREF_ALL_APPS_ICON_PADDING_SCALE:
                 case PreferenceFlags.KEY_PREF_ICON_TEXT_SCALE:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,6 +337,8 @@
     <string name="num_hotseat_icons_pref_title">Number of icons in dock</string>
     <string name="icon_scale_pref_title">Icon scale</string>
     <string name="hotseat_height_scale">Height scale</string>
+    <string name="hotseat_custom_opacity">Dock opacity</string>
+    <string name="hotseat_uses_custom_opacity">Dock uses custom opacity</string>
     <string name="icon_text_scale_pref_title">Icon text scale</string>
     <string name="icon_text_padding_scale_pref_title">Icon padding scale</string>
     <string name="full_width_width_widgets_pref_title">Full width widgets</string>

--- a/app/src/main/res/xml/launcher_dock_preferences.xml
+++ b/app/src/main/res/xml/launcher_dock_preferences.xml
@@ -69,4 +69,21 @@
             app:summaryMultiplier="100"
             app:defaultSeekbarValue="1.0"
             android:persistent="true" />
+
+        <SwitchPreference
+            android:key="pref_hotseatShouldUseCustomOpacity"
+            android:title="@string/hotseat_uses_custom_opacity"
+            android:defaultValue="false"
+            android:persistent="true" />
+
+        <ch.deletescape.lawnchair.preferences.SeekbarPreference
+            android:key="pref_hotseatCustomOpacity"
+            android:title="@string/hotseat_custom_opacity"
+            android:dependency="pref_hotseatShouldUseCustomOpacity"
+            app:minValue="0"
+            app:maxValue="1"
+            app:summaryFormat="%.0f%%"
+            app:summaryMultiplier="100"
+            app:defaultSeekbarValue="0.5"
+            android:persistent="true" />
 </android.support.v7.preference.PreferenceScreen>


### PR DESCRIPTION
It's now possible to toggle a manual dock opacity option. The manual configuration is a slider ranging from 0% to 100%. If manual is off, automatic is used and unchanged from previous versions.

#1119 