### PR TITLE
Prepare and fix changelog for Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,8 @@ pipeline:
   changelog:
     image: lawnchairlauncher/drone-changelog:latest
     output: changelog.txt
+    when:
+      event: push
   build:
     image: runmymind/docker-android-sdk:alpine-standalone
     environment:
@@ -10,4 +12,4 @@ pipeline:
       - bash ./gradlew assembleDebug check;
 
 branches:
-  include: [ alpha ]
+  include: alpha

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,13 +1,19 @@
 pipeline:
   changelog:
     image: lawnchairlauncher/drone-changelog:latest
+    environment:
+      - MAJOR_MINOR=alpha
     output: changelog.txt
     when:
       event: push
   build:
     image: runmymind/docker-android-sdk:alpine-standalone
     environment:
-      - MAJOR_MINOR=1.1.0
+      - MAJOR_MINOR=alpha
+      - SEPERATOR='-'
+      - TRAVIS=true
+      - TRAVIS_BUILD_NUMBER=${DRONE_BUILD_NUMBER}
+      - TRAVIS_EVENT_TYPE=${DRONE_BUILD_EVENT}
     commands:
       - bash ./gradlew assembleDebug check;
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,7 @@
 pipeline:
+  changelog:
+    image: lawnchairlauncher/drone-changelog:latest
+    output: changelog.txt
   build:
     image: runmymind/docker-android-sdk:alpine-standalone
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,8 +1,6 @@
 pipeline:
   changelog:
     image: lawnchairlauncher/drone-changelog:latest
-    environment:
-      - MAJOR_MINOR=alpha
     output: changelog.txt
     when:
       event: push

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
    - alpha
 env:
   - MAJOR_MINOR=1.1.0
+  - SEPERATOR='.'
 android:
   components:
     - tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_install:
   - chmod a+x ./scripts/changelog.sh
   - chmod a+x ./scripts/s3-upload.sh
   - git fetch --tags
+before_script:
+  - bash scripts/changelog.sh > changelog.txt
 script:
   - bash ./gradlew assembleDebug check;
   - bash ./gradlew app:assembleRelease check;

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,19 +2,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 def getChangelog = { ->
-    def commitRange = System.getenv("TRAVIS_COMMIT_RANGE")
-    if (commitRange) {
-        if (System.getenv("TRAVIS_TAG")) {
-            def tag = System.getenv("TRAVIS_TAG")
-            commitRange = ('git describe --abbrev=0 --tags ' +  tag + '^').execute().text.trim() + '..' + tag
-        }
-
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'log', '--format=%s', commitRange
-            standardOutput = stdout
-        }
-        return stdout.toString().trim().replace("\n", "\\n").replace("\"", "\\\"")
+    File changelogFile = project.rootProject.file('changelog.txt')
+    if (changelogFile.exists()) {
+        def changelog = changelogFile.text
+        return changelog.trim().replace("\n", "\\n").replace("\"", "\\\"")
     } else {
         return null
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ android {
 
         if (System.getenv("TRAVIS") == "true") {
             versionCode = Integer.valueOf(System.getenv("TRAVIS_BUILD_NUMBER"))
-            versionName = System.getenv("MAJOR_MINOR") + "." + System.getenv("TRAVIS_BUILD_NUMBER")
+            versionName = System.getenv("MAJOR_MINOR") + System.getenv("SEPERATOR") + System.getenv("TRAVIS_BUILD_NUMBER")
         } else {
             versionCode 1
             versionName "dev"


### PR DESCRIPTION
Instead calling git during gradle, we can generate the changelog before the build and read the output from a file which will be generated before, on our buildbot with the `drone-changelog` plugin or on Travis CI by executing the `changelog.sh` script in `before_script`.