### PR TITLE
Properly handle storage permission on 8.1+

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/Launcher.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Launcher.java
@@ -50,6 +50,7 @@ import android.graphics.PorterDuff;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -57,6 +58,7 @@ import android.os.StrictMode;
 import android.os.UserHandle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.app.ActivityCompat;
 import android.text.Selection;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -154,11 +156,12 @@ public class Launcher extends Activity
     private static final int REQUEST_RECONFIGURE_APPWIDGET = 12;
 
     private static final int REQUEST_PERMISSION_CALL_PHONE = 13;
+    public static final int REQUEST_PERMISSION_STORAGE_ACCESS = 666;
 
     private static final int REQUEST_EDIT_ICON = 14;
 
     private static final float BOUNCE_ANIMATION_TENSION = 1.3f;
-    
+
     private static final int SOFT_INPUT_MODE_DEFAULT =
             WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN;
     private static final int SOFT_INPUT_MODE_ALL_APPS =
@@ -366,6 +369,11 @@ public class Launcher extends Activity
     protected void onCreate(Bundle savedInstanceState) {
         FeatureFlags.INSTANCE.loadThemePreference(this);
         Utilities.setupPirateLocale(this);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 && !Utilities.hasStoragePermission(this)) {
+            Utilities.requestStoragePermission(this);
+        }
+
         super.onCreate(savedInstanceState);
 
         setScreenOrientation();
@@ -447,6 +455,7 @@ public class Launcher extends Activity
 
         Utilities.showChangelog(this);
     }
+
 
     private void setScreenOrientation() {
         if (Utilities.getPrefs(this).getEnableScreenRotation()) {
@@ -778,6 +787,20 @@ public class Launcher extends Activity
                 // TODO: Show a snack bar with link to settings
                 Toast.makeText(this, getString(R.string.msg_no_phone_permission,
                         getString(R.string.app_name)), Toast.LENGTH_SHORT).show();
+            }
+        }
+        if (requestCode == REQUEST_PERMISSION_STORAGE_ACCESS){
+            if(ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.READ_EXTERNAL_STORAGE)){
+                final Launcher _this = this;
+                DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface di, int i) {
+                        Utilities.requestStoragePermission(_this);
+                    }
+                };
+                new AlertDialog.Builder(this).setTitle(R.string.title_storage_permission_required)
+                        .setMessage(R.string.content_storage_permission_required).setPositiveButton(android.R.string.ok, listener)
+                        .setCancelable(false).show();
             }
         }
     }

--- a/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/Utilities.java
@@ -57,6 +57,8 @@ import android.os.PowerManager;
 import android.os.UserHandle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextUtils;
@@ -849,6 +851,14 @@ public final class Utilities {
 
         packageManager.setComponentEnabledSetting(fakeLauncher, PackageManager.COMPONENT_ENABLED_STATE_DEFAULT, PackageManager.DONT_KILL_APP);
         packageManager.setComponentEnabledSetting(launcher, PackageManager.COMPONENT_ENABLED_STATE_DEFAULT, PackageManager.DONT_KILL_APP);
+    }
+
+    public static boolean hasStoragePermission(Context context) {
+        return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(context, android.Manifest.permission.READ_EXTERNAL_STORAGE);
+    }
+
+    public static void requestStoragePermission(Activity activity) {
+        ActivityCompat.requestPermissions(activity, new String[]{android.Manifest.permission.READ_EXTERNAL_STORAGE}, Launcher.REQUEST_PERMISSION_STORAGE_ACCESS);
     }
 
     /**

--- a/app/src/main/java/ch/deletescape/lawnchair/blur/BlurWallpaperProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/blur/BlurWallpaperProvider.kt
@@ -5,6 +5,7 @@ import android.app.WallpaperManager
 import android.content.Context
 import android.graphics.*
 import android.graphics.drawable.BitmapDrawable
+import android.os.Build
 import android.renderscript.Allocation
 import android.renderscript.Element
 import android.renderscript.RenderScript
@@ -70,6 +71,10 @@ class BlurWallpaperProvider(context: Context) {
 
     private fun updateWallpaper() {
         val launcher = LauncherAppState.getInstance().launcher
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 && !Utilities.hasStoragePermission(context)){
+            Utilities.getPrefs(context).enableBlur(false)
+            return
+        }
         val enabled = mWallpaperManager.wallpaperInfo == null && Utilities.getPrefs(context).enableBlur
         if (enabled != isEnabled || enabledFlag != sEnabledFlag) {
             launcher.scheduleKill()

--- a/app/src/main/java/ch/deletescape/lawnchair/dynamicui/ExtractionUtils.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/dynamicui/ExtractionUtils.java
@@ -57,7 +57,9 @@ public class ExtractionUtils {
      * Starts the {@link ColorExtractionService} without checking the wallpaper id
      */
     public static void startColorExtractionService(Context context) {
-        context.startService(new Intent(context, ColorExtractionService.class));
+        if(Utilities.hasStoragePermission(context)) {
+            context.startService(new Intent(context, ColorExtractionService.class));
+        }
     }
 
     private static boolean hasWallpaperIdChanged(Context context) {

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/IPreferenceProvider.kt
@@ -83,6 +83,7 @@ interface IPreferenceProvider {
     val transparentHotseat: Boolean
     val enableDynamicUi: Boolean
     val enableBlur: Boolean
+    fun enableBlur(enable: Boolean)
     val enableVibrancy: Boolean
     val useWhiteGoogleIcon: Boolean
     val useRoundSearchBar: Boolean

--- a/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
+++ b/app/src/main/java/ch/deletescape/lawnchair/preferences/PreferenceImpl.kt
@@ -233,6 +233,11 @@ open class PreferenceImpl(context: Context) : IPreferenceProvider {
     override val transparentHotseat by BooleanPref(FeatureFlags.KEY_PREF_TRANSPARENT_HOTSEAT, false)
     override val enableDynamicUi by BooleanPref(FeatureFlags.KEY_PREF_ENABLE_DYNAMIC_UI, false)
     override val enableBlur by BooleanPref(FeatureFlags.KEY_PREF_ENABLE_BLUR, false)
+    override fun enableBlur(enable: Boolean) {
+        sharedPrefs.edit()
+                .putBoolean(FeatureFlags.KEY_PREF_ENABLE_BLUR, enable)
+                .apply()
+    }
     override val useWhiteGoogleIcon by BooleanPref(FeatureFlags.KEY_PREF_WHITE_GOOGLE_ICON, false)
     override val ayyMatey by BooleanPref(PreferenceFlags.KEY_AYY_MATEY, false)
     override fun migrateThemePref(context: Context) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -498,4 +498,6 @@
 
     <string name="lawnfeed_outdated_title">Lawnfeed update required</string>
     <string name="lawnfeed_outdated">A newer version of Lawnfeed is required in order to work with this version of Lawnchair.\n\nBefore installing the update you will probably need to uninstall the current version of Lawnfeed.\n\nDo you want to download it now?</string>
+    <string name="title_storage_permission_required">Storage Permission Required</string>
+    <string name="content_storage_permission_required">On Android 8.1 and above the storage permission is required for apps to access the wallpaper. Without said permission Lawnchair might crash or show unexpected behaviours.</string>
 </resources>


### PR DESCRIPTION
Prompt the user for the Storage permission with an explaination and disable blur without it to prevent crashes.