### PR TITLE
fix icon space in dock part -2

### DIFF
--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -232,7 +232,7 @@ public class DeviceProfile {
                 R.dimen.dynamic_grid_hotseat_land_right_nav_bar_left_padding);
         hotseatBarSizePx = getHotseatSize(inv, res, dm);
 
-        mBottomMarginHw = 0; // res.getDimensionPixelSize(R.dimen.qsb_hotseat_bottom_margin_hw); (For now)
+        mBottomMarginHw = res.getDimensionPixelSize(R.dimen.qsb_hotseat_bottom_margin_hw); //(For now)
         if (!isVerticalBarLayout()) {
             hotseatBarSizePx += mBottomMarginHw;
             hotseatBarBottomPaddingPx += mBottomMarginHw;


### PR DESCRIPTION
this will fix icon space in dock completely cos here we use 2 dp margin instead of 12 dp.