### PR TITLE
Always assume that an app could be on the sd card, fixes  #507

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/util/PackageManagerHelper.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/util/PackageManagerHelper.java
@@ -38,9 +38,10 @@ public class PackageManagerHelper {
     /**
      * Returns true if the app can possibly be on the SDCard. This is just a workaround and doesn't
      * guarantee that the app is on SD card.
+     * Currently, this always returns true as a previous approach did not work properly.
      */
     public static boolean isAppOnSdcard(PackageManager pm, String packageName) {
-        return isAppEnabled(pm, packageName, PackageManager.GET_UNINSTALLED_PACKAGES);
+        return true;
     }
 
     public static boolean isAppEnabled(PackageManager pm, String packageName, int flags) {


### PR DESCRIPTION
@fonix232 According to the commit history, you are the one who submitted the original code. Do you know if there could be any drawbacks if this method just always returns true? According to the method comment, false-positives can already happen (it "doesn't guarantee that the app is on the SD card")