### PR TITLE
Fixed Issue #1266

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/pixelify/DateWidgetView.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/pixelify/DateWidgetView.java
@@ -18,6 +18,7 @@ import android.text.format.DateFormat;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
+import android.widget.Toast;
 
 import java.util.List;
 import java.util.Locale;
@@ -145,17 +146,7 @@ public class DateWidgetView extends LinearLayout implements TextWatcher, View.On
             intent.setSourceBounds(launcher.getViewBounds(dateText1));
             context.startActivity(intent, launcher.getActivityLaunchOptions(dateText1));
         } else{
-            AlertDialog.Builder alertBuilder = new AlertDialog.Builder(context);
-            alertBuilder.setTitle(R.string.no_calendar_app_title)
-                    .setMessage(R.string.no_calendar_app_content)
-                    .setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-
-                        }
-                    });
-            AlertDialog alert = alertBuilder.create();
-            alert.show();
+            Toast.makeText(context, R.string.no_calendar_app_content,Toast.LENGTH_LONG).show();
         }
     }
 }

--- a/app/src/main/java/ch/deletescape/lawnchair/pixelify/DateWidgetView.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/pixelify/DateWidgetView.java
@@ -1,8 +1,12 @@
 package ch.deletescape.lawnchair.pixelify;
 
+import android.app.AlertDialog;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.net.Uri;
@@ -15,6 +19,7 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
 
+import java.util.List;
 import java.util.Locale;
 
 import ch.deletescape.lawnchair.DeviceProfile;
@@ -123,6 +128,7 @@ public class DateWidgetView extends LinearLayout implements TextWatcher, View.On
     @Override
     public void onClick(View v) {
         Context context = v.getContext();
+        PackageManager pm = context.getPackageManager();
         long currentTime = System.currentTimeMillis();
         Uri.Builder builder = CalendarContract.CONTENT_URI.buildUpon();
         builder.appendPath("time");
@@ -130,7 +136,26 @@ public class DateWidgetView extends LinearLayout implements TextWatcher, View.On
 
         Launcher launcher = Launcher.getLauncher(getContext());
         Intent intent = new Intent(Intent.ACTION_VIEW).setData(builder.build());
-        intent.setSourceBounds(launcher.getViewBounds(dateText1));
-        context.startActivity(intent, launcher.getActivityLaunchOptions(dateText1));
+
+        //Returns all activities/apps that are suitable for the intent 'intent' as a list
+        List<ResolveInfo> calendarActivities = pm.queryIntentActivities(intent, 0);
+
+        //if the size of that list is not 0, then the user has some kind of calendar app installed
+        if(calendarActivities.size() != 0){
+            intent.setSourceBounds(launcher.getViewBounds(dateText1));
+            context.startActivity(intent, launcher.getActivityLaunchOptions(dateText1));
+        } else{
+            AlertDialog.Builder alertBuilder = new AlertDialog.Builder(context);
+            alertBuilder.setTitle(R.string.no_calendar_app_title)
+                    .setMessage(R.string.no_calendar_app_content)
+                    .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+
+                        }
+                    });
+            AlertDialog alert = alertBuilder.create();
+            alert.show();
+        }
     }
 }

--- a/app/src/main/java/ch/deletescape/lawnchair/pixelify/DateWidgetView.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/pixelify/DateWidgetView.java
@@ -1,9 +1,7 @@
 package ch.deletescape.lawnchair.pixelify;
 
-import android.app.AlertDialog;
 import android.content.ContentUris;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
@@ -142,11 +140,11 @@ public class DateWidgetView extends LinearLayout implements TextWatcher, View.On
         List<ResolveInfo> calendarActivities = pm.queryIntentActivities(intent, 0);
 
         //if the size of that list is not 0, then the user has some kind of calendar app installed
-        if(calendarActivities.size() != 0){
+        if (calendarActivities.size() != 0) {
             intent.setSourceBounds(launcher.getViewBounds(dateText1));
             context.startActivity(intent, launcher.getActivityLaunchOptions(dateText1));
-        } else{
-            Toast.makeText(context, R.string.no_calendar_app_content,Toast.LENGTH_LONG).show();
+        } else {
+            Toast.makeText(context, R.string.no_calendar_app_content, Toast.LENGTH_LONG).show();
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -529,8 +529,7 @@
     <string name="local_backups">Local backups</string>
     <string name="backup_location_device_storage">Device storage</string>
     <string name="backup_location_documents_storage">Documents storage</string>
-    <string name="no_calendar_app_title">No calendar app installed</string>
-    <string name="no_calendar_app_content">You don\'t have a calendar-app installed. Please either activate the built-in calendar or download one from the Play Store</string>
+    <string name="no_calendar_app_content">You don\'t have a calendar-app installed. Please either enable the built-in calendar or download one from the Play Store</string>
 
     <!-- Preference Category Pixel Searchbar Title -->
     <string name="pref_category_pixel_searchbar">Pixel Searchbar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -529,6 +529,8 @@
     <string name="local_backups">Local backups</string>
     <string name="backup_location_device_storage">Device storage</string>
     <string name="backup_location_documents_storage">Documents storage</string>
+    <string name="no_calendar_app_title">No calendar app installed</string>
+    <string name="no_calendar_app_content">You don\'t have a calendar-app installed. Please either activate the built-in calendar or download one from the Play Store</string>
 
     <!-- Preference Category Pixel Searchbar Title -->
     <string name="pref_category_pixel_searchbar">Pixel Searchbar</string>


### PR DESCRIPTION
Fixed issue #1266 where the launcher would crash if there was no available calendar app. Now, a dialog pops up, which informs the user about the fact and prevents the launcher from crashing.