### PR TITLE
Fixes #1266: Launcher Crashes on Date Click

### DIFF
--- a/app/src/main/java/ch/deletescape/lawnchair/pixelify/DateWidgetView.java
+++ b/app/src/main/java/ch/deletescape/lawnchair/pixelify/DateWidgetView.java
@@ -3,6 +3,8 @@ package ch.deletescape.lawnchair.pixelify;
 import android.content.ContentUris;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.net.Uri;
@@ -14,7 +16,9 @@ import android.text.format.DateFormat;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
+import android.widget.Toast;
 
+import java.util.List;
 import java.util.Locale;
 
 import ch.deletescape.lawnchair.DeviceProfile;
@@ -123,6 +127,7 @@ public class DateWidgetView extends LinearLayout implements TextWatcher, View.On
     @Override
     public void onClick(View v) {
         Context context = v.getContext();
+        PackageManager pm = context.getPackageManager();
         long currentTime = System.currentTimeMillis();
         Uri.Builder builder = CalendarContract.CONTENT_URI.buildUpon();
         builder.appendPath("time");
@@ -130,7 +135,13 @@ public class DateWidgetView extends LinearLayout implements TextWatcher, View.On
 
         Launcher launcher = Launcher.getLauncher(getContext());
         Intent intent = new Intent(Intent.ACTION_VIEW).setData(builder.build());
-        intent.setSourceBounds(launcher.getViewBounds(dateText1));
-        context.startActivity(intent, launcher.getActivityLaunchOptions(dateText1));
+        List<ResolveInfo> calIntentAct = pm.queryIntentActivities(intent, 0);
+
+        if(calIntentAct.size() != 0) {
+            intent.setSourceBounds(launcher.getViewBounds(dateText1));
+            context.startActivity(intent, launcher.getActivityLaunchOptions(dateText1));
+        } else {
+            Toast.makeText(context, R.string.cal_app_unavail_warn, Toast.LENGTH_LONG).show();
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -495,6 +495,7 @@
     <string name="title_storage_permission_required">Storage Permission Required</string>
     <string name="content_storage_permission_required">On Android 8.1 and above the storage permission is required for apps to access the wallpaper. Without said permission Lawnchair might crash or show unexpected behaviours.</string>
     <string name="disable_popup">Don\'t show again</string>
+    <string name="cal_app_unavail_warn">You don\'t have a Calendar App installed. Please either enable the built-in Calendar App or download one from the Google Play Store.</string>
 
     <string name="backups">Backups</string>
     <string name="new_backup">Create</string>


### PR DESCRIPTION
Added a Toast to notify the user about calendar app unavailability.