### PR TITLE
Typo: Unescaped '

### DIFF
--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -372,7 +372,7 @@
   <string name="pref_applyBlur">Aplica el difuminat a</string>
   <string name="search_bar">Barra de cerca</string>
   <string name="folder">Carpeta</string>
-  <string name="dock_allapps"><![CDATA[Barra d'aplicacions i calaix]]></string>
+  <string name="dock_allapps"><![CDATA[Barra d\'aplicacions i calaix]]></string>
   <string name="app_shortcuts">Draceres d\'aplicació</string>
   <string name="blur_effect">Efecte difuminat</string>
   <string name="pref_weather_provider">Proveïdor del temps</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -372,7 +372,7 @@
   <string name="pref_applyBlur">Appliquez le flou sur</string>
   <string name="search_bar">Barre de recherche</string>
   <string name="folder">Dossier</string>
-  <string name="dock_allapps"><![CDATA[Dock & tiroir d'applications]]></string>
+  <string name="dock_allapps"><![CDATA[Dock & tiroir d\'applications]]></string>
   <string name="app_shortcuts">Raccourcis d\'application</string>
   <string name="blur_effect">Effet de flou</string>
   <string name="pref_weather_provider">Fournisseur météo</string>


### PR DESCRIPTION
Two translations, ca and fr had an apostrophe not preceded with \ which caused a build error.