### PR TITLE
Fix multiline labels in folders

### DIFF
--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -484,6 +484,7 @@ public class DeviceProfile implements LawnchairPreferences.OnPreferenceChangeLis
     }
 
     private void updateFolderCellSize(float scale, DisplayMetrics dm, Resources res) {
+        LawnchairPreferences prefs = Utilities.getLawnchairPrefs(mContext);
         int folderLabelRowCount = prefs.getHomeLabelRows();
         
         folderChildIconSizePx = (int) (Utilities.pxFromDp(inv.iconSize, dm) * scale);

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -484,8 +484,7 @@ public class DeviceProfile implements LawnchairPreferences.OnPreferenceChangeLis
     }
 
     private void updateFolderCellSize(float scale, DisplayMetrics dm, Resources res) {
-        LawnchairPreferences prefs = Utilities.getLawnchairPrefs(mContext);
-        int folderLabelRowCount = prefs.getHomeLabelRows();
+        int folderLabelRowCount = Utilities.getLawnchairPrefs(mContext).getHomeLabelRows();
         
         folderChildIconSizePx = (int) (Utilities.pxFromDp(inv.iconSize, dm) * scale);
         folderChildTextSizePx =

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -484,11 +484,13 @@ public class DeviceProfile implements LawnchairPreferences.OnPreferenceChangeLis
     }
 
     private void updateFolderCellSize(float scale, DisplayMetrics dm, Resources res) {
+        int folderLabelRowCount = prefs.getHomeLabelRows();
+        
         folderChildIconSizePx = (int) (Utilities.pxFromDp(inv.iconSize, dm) * scale);
         folderChildTextSizePx =
                 (int) (res.getDimensionPixelSize(R.dimen.folder_child_text_size) * scale);
 
-        int textHeight = Utilities.calculateTextHeight(folderChildTextSizePx);
+        int textHeight = Utilities.calculateTextHeight(folderChildTextSizePx) * folderLabelRowCount;
         int cellPaddingX = (int) (res.getDimensionPixelSize(R.dimen.folder_cell_x_padding) * scale);
         int cellPaddingY = (int) (res.getDimensionPixelSize(R.dimen.folder_cell_y_padding) * scale);
 


### PR DESCRIPTION
Attempt to fix multiline labels in folders being cut off. Use HomeLabelRows since that's what folders use.

Please take a look and see if it works as I'm not pro enough. :/