### PR TITLE
Fix multiline labels not truncating when >2 lines

### DIFF
--- a/src/com/android/launcher3/BubbleTextView.java
+++ b/src/com/android/launcher3/BubbleTextView.java
@@ -209,6 +209,7 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver, 
         mStylusEventHelper = new StylusEventHelper(new SimpleOnStylusPressListener(this), this);
 
         setEllipsize(TruncateAt.END);
+        setHorizontallyScrolling(false);
         setAccessibilityDelegate(mActivity.getAccessibilityDelegate());
         setTextAlpha(1f);
     }


### PR DESCRIPTION
For singleline labels, if labels are too long it is truncated with an ellipsis.
For multiline labels, it is coded to be max 2 lines, but labels that are too long to fit in 2 lines instead becomes 3 lines instead of being truncated. This results in the labels getting cut off (depending on grid size I think).
This is an attempt to fix this.

@deletescape Once again I'm not sure if this will work. I based this on https://github.com/LawnchairLauncher/Lawnchair/pull/744 in V1 where 2-line labels are truncated. I hope you can test it. :)