### PR TITLE
CustomBottomSheet: App label improvements

### DIFF
--- a/res/layout/app_edit_bottom_sheet.xml
+++ b/res/layout/app_edit_bottom_sheet.xml
@@ -44,7 +44,7 @@
         android:textSize="24sp"
         android:layout_marginBottom="32dp"/>
 
-    <EditText
+    <com.android.launcher3.ExtendedEditText
         style="@style/TextTitle"
         android:id="@+id/edit_title"
         android:background="@android:color/transparent"
@@ -56,7 +56,9 @@
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="24sp"
         android:layout_marginBottom="32dp"
-        app:customFontType="title"/>
+        app:customFontType="title"
+        android:maxLength="30"
+        android:inputType="textFilter"/>
 
     <fragment
         android:id="@+id/sheet_prefs"

--- a/src/com/android/launcher3/ExtendedEditText.java
+++ b/src/com/android/launcher3/ExtendedEditText.java
@@ -34,6 +34,7 @@ public class ExtendedEditText extends EditText {
 
     private boolean mShowImeAfterFirstLayout;
     private boolean mForceDisableSuggestions = false;
+    private boolean mForceDisableAutoFill = false;
 
     /**
      * Implemented by listeners of the back key.
@@ -140,5 +141,19 @@ public class ExtendedEditText extends EditText {
             }
         }
         hideKeyboard();
+    }
+
+    /**
+     * This method allows to force AutoFill availability.
+     *
+     * @param forceDisableAutoFill whether to disable AutoFill or not.
+     */
+    public void setAutoFill(boolean forceDisableAutoFill) {
+        mForceDisableAutoFill = forceDisableAutoFill;
+    }
+
+    @Override
+    public int getAutofillType() {
+        return mForceDisableAutoFill ? AUTOFILL_TYPE_NONE : super.getAutofillType();
     }
 }

--- a/src/com/google/android/apps/nexuslauncher/CustomBottomSheet.java
+++ b/src/com/google/android/apps/nexuslauncher/CustomBottomSheet.java
@@ -31,7 +31,6 @@ import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -43,6 +42,7 @@ import ch.deletescape.lawnchair.gestures.ui.LauncherGesturePreference;
 import ch.deletescape.lawnchair.override.CustomInfoProvider;
 import ch.deletescape.lawnchair.preferences.MultiSelectTabPreference;
 import com.android.launcher3.AppInfo;
+import com.android.launcher3.ExtendedEditText;
 import com.android.launcher3.FolderInfo;
 import com.android.launcher3.ItemInfo;
 import com.android.launcher3.ItemInfoWithIcon;
@@ -56,7 +56,7 @@ import com.android.launcher3.widget.WidgetsBottomSheet;
 
 public class CustomBottomSheet extends WidgetsBottomSheet {
     private FragmentManager mFragmentManager;
-    private EditText mEditTitle;
+    private ExtendedEditText mEditTitle;
     private String mPreviousTitle;
     private ItemInfo mItemInfo;
     private CustomInfoProvider<ItemInfo> mInfoProvider;
@@ -104,6 +104,8 @@ public class CustomBottomSheet extends WidgetsBottomSheet {
             if (mPreviousTitle == null)
                 mPreviousTitle = "";
             mEditTitle = findViewById(R.id.edit_title);
+            // Disable AutoFill
+            mEditTitle.setAutoFill(true);
             mEditTitle.setHint(mInfoProvider.getDefaultTitle(mItemInfo));
             mEditTitle.setText(mPreviousTitle);
             mEditTitle.setVisibility(VISIBLE);


### PR DESCRIPTION
* Move from EditText to ExtendedEditText from L3 with a small
  method added to force disabling the AutoFill avaiability.
  Also set the maximum app label size to 30 as it sounds reasonable
  to do so, and disable suggestions for label inputs.