### PR TITLE
Center icons on workspace when hiding app names #1576

### DIFF
--- a/src/com/android/launcher3/BubbleTextView.java
+++ b/src/com/android/launcher3/BubbleTextView.java
@@ -487,7 +487,7 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver, 
     protected void drawBadgeIfNecessary(Canvas canvas) {
         if (!mForceHideBadge && (hasBadge() || mBadgeScale > 0)) {
             getIconBounds(mTempIconBounds);
-            mTempSpaceForBadgeOffset.set((getWidth() - mIconSize) / 2, getPaddingTop());
+            mTempSpaceForBadgeOffset.set((getWidth() - mIconSize) / 2, mHideText ? (getHeight() - mIconSize) / 2 : getPaddingTop());
             final int scrollX = getScrollX();
             final int scrollY = getScrollY();
             canvas.translate(scrollX, scrollY);
@@ -516,7 +516,7 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver, 
     }
 
     public void getIconBounds(Rect outBounds) {
-        int top = getPaddingTop();
+        int top = mHideText ? (getHeight() - mIconSize) / 2 : getPaddingTop();
         int left = (getWidth() - mIconSize) / 2;
         int right = left + mIconSize;
         int bottom = top + mIconSize;
@@ -525,10 +525,10 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver, 
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        if (mCenterVertically) {
+        if (mCenterVertically || mHideText) {
             Paint.FontMetrics fm = getPaint().getFontMetrics();
-            int cellHeightPx = mIconSize + getCompoundDrawablePadding() +
-                    (int) Math.ceil(fm.bottom - fm.top);
+            int cellHeightPx = mIconSize +
+                    (mHideText ? 0 : getCompoundDrawablePadding() + (int) Math.ceil(fm.bottom - fm.top));
             int height = MeasureSpec.getSize(heightMeasureSpec);
             setPadding(getPaddingLeft(), (height - cellHeightPx) / 2, getPaddingRight(),
                     getPaddingBottom());

--- a/src/com/android/launcher3/folder/FolderIcon.java
+++ b/src/com/android/launcher3/folder/FolderIcon.java
@@ -133,6 +133,8 @@ public class FolderIcon extends FrameLayout implements FolderListener, OnResumeC
 
     public boolean isCustomIcon = false;
     private boolean mIsTextVisible = true;
+    private int mVerticalOffset = 0;
+    private boolean mHideText = false;
 
     private static final Property<FolderIcon, Float> BADGE_SCALE_PROPERTY
             = new Property<FolderIcon, Float>(Float.TYPE, "badgeScale") {
@@ -193,6 +195,10 @@ public class FolderIcon extends FrameLayout implements FolderListener, OnResumeC
             lp.topMargin = grid.iconSizePx + grid.iconDrawablePaddingPx;
         }
 
+        if(Utilities.getLawnchairPrefs(launcher).getHideAppLabels()){
+            icon.mHideText = true;
+            icon.mVerticalOffset = (grid.cellHeightPx - grid.iconSizePx) / 2;
+        }
         icon.setTag(folderInfo);
         icon.setOnClickListener(ItemClickHandler.INSTANCE);
         icon.mInfo = folderInfo;
@@ -549,6 +555,9 @@ public class FolderIcon extends FrameLayout implements FolderListener, OnResumeC
     @Override
     protected void dispatchDraw(Canvas canvas) {
         super.dispatchDraw(canvas);
+        if(mHideText) {
+            canvas.translate(0, mVerticalOffset);
+        }
 
         if (mBackgroundIsVisible) {
             mPreviewItemManager.recomputePreviewDrawingParams();
@@ -564,6 +573,7 @@ public class FolderIcon extends FrameLayout implements FolderListener, OnResumeC
 
         if (mFolder == null) return;
         if (mFolder.getItemCount() == 0 && !mAnimating) return;
+
 
         final int saveCount = canvas.save();
         canvas.clipPath(mBackground.getClipPath());


### PR DESCRIPTION
The implementation of centering folder icons vertically is not very clean because I wasn't able to find another easy way. I'm open to suggestions/edits.