### PR TITLE
Fix adaptive icon shapes for legacy shortcuts

### DIFF
--- a/src/com/android/launcher3/graphics/LauncherIcons.java
+++ b/src/com/android/launcher3/graphics/LauncherIcons.java
@@ -146,9 +146,13 @@ public class LauncherIcons implements AutoCloseable {
             Resources resources = mPm.getResourcesForApplication(iconRes.packageName);
             if (resources != null) {
                 final int id = resources.getIdentifier(iconRes.resourceName, null, null);
+                Drawable drawable = resources.getDrawableForDensity(id, mFillResIconDpi);
+                if (drawable != null) {
+                    drawable = AdaptiveIconCompat.wrap(drawable);
+                }
                 // do not stamp old legacy shortcuts as the app may have already forgotten about it
                 return createBadgedIconBitmap(
-                        resources.getDrawableForDensity(id, mFillResIconDpi),
+                        drawable,
                         Process.myUserHandle() /* only available on primary user */,
                         0 /* do not apply legacy treatment */);
             }


### PR DESCRIPTION
Fixed by updating `createIconBitmap` to wrap icon drawables using `AdaptiveIconCompat`.

Below are screenshots of a Pixel 2 emulator, configured for square icons. The "Sleep" shortcut is a legacy shortcut using an adaptive icon, and the two shortcuts to the right of it are legacy shortcuts which don't use adaptive icons.

Before | After
:-------------------------:|:-------------------------:
![bad](https://user-images.githubusercontent.com/11037113/68569418-e592ef80-04c2-11ea-9bcc-1fd5f09007a8.png) | ![good](https://user-images.githubusercontent.com/11037113/68569423-e9267680-04c2-11ea-9685-c80b69328b0e.png)

I _think_ this is the right place for this change but I could be wrong. Please let me know what you think.

Thanks!