### PR TITLE
Fix alignment of app drawer folders when multiline app names enabled

### DIFF
--- a/lawnchair/res/layout/all_apps_folder_icon.xml
+++ b/lawnchair/res/layout/all_apps_folder_icon.xml
@@ -21,7 +21,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/folder_icon"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:layout_gravity="center"
     android:orientation="vertical"
     android:paddingLeft="@dimen/dynamic_grid_cell_padding_x"

--- a/src/com/android/launcher3/folder/FolderIcon.java
+++ b/src/com/android/launcher3/folder/FolderIcon.java
@@ -655,11 +655,9 @@ public class FolderIcon extends FrameLayout implements FolderListener, OnResumeC
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        if (!mInfo.useIconMode(mLauncher)) {
+        if (!mInfo.useIconMode(mLauncher) && isInAppDrawer()) {
             DeviceProfile grid = mLauncher.getDeviceProfile();
-            int drawablePadding = isInAppDrawer() ?
-                    grid.allAppsIconDrawablePaddingPx :
-                    grid.iconDrawablePaddingPx;
+            int drawablePadding = grid.allAppsIconDrawablePaddingPx;
 
             Paint.FontMetrics fm = mFolderName.getPaint().getFontMetrics();
             int cellHeightPx = mFolderName.getIconSize() + drawablePadding +

--- a/src/com/android/launcher3/folder/FolderIcon.java
+++ b/src/com/android/launcher3/folder/FolderIcon.java
@@ -23,14 +23,13 @@ import android.animation.Animator;
 import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.graphics.Canvas;
-import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.util.Property;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -38,7 +37,6 @@ import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
-
 import ch.deletescape.lawnchair.LawnchairLauncher;
 import ch.deletescape.lawnchair.LawnchairUtilsKt;
 import ch.deletescape.lawnchair.gestures.BlankGestureHandler;
@@ -56,7 +54,6 @@ import com.android.launcher3.DeviceProfile;
 import com.android.launcher3.DropTarget.DragObject;
 import com.android.launcher3.FolderInfo;
 import com.android.launcher3.FolderInfo.FolderListener;
-import com.android.launcher3.IconCache.ItemInfoUpdateReceiver;
 import com.android.launcher3.ItemInfo;
 import com.android.launcher3.ItemInfoWithIcon;
 import com.android.launcher3.Launcher;
@@ -81,7 +78,6 @@ import com.android.launcher3.touch.ItemClickHandler;
 import com.android.launcher3.util.PackageUserKey;
 import com.android.launcher3.util.Thunk;
 import com.android.launcher3.widget.PendingAddShortcutInfo;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -655,6 +651,24 @@ public class FolderIcon extends FrameLayout implements FolderListener, OnResumeC
     @Override
     protected boolean verifyDrawable(@NonNull Drawable who) {
         return mPreviewItemManager.verifyDrawable(who) || super.verifyDrawable(who);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        if (!mInfo.useIconMode(mLauncher)) {
+            DeviceProfile grid = mLauncher.getDeviceProfile();
+            int drawablePadding = isInAppDrawer() ?
+                    grid.allAppsIconDrawablePaddingPx :
+                    grid.iconDrawablePaddingPx;
+
+            Paint.FontMetrics fm = mFolderName.getPaint().getFontMetrics();
+            int cellHeightPx = mFolderName.getIconSize() + drawablePadding +
+                    (int) Math.ceil(fm.bottom - fm.top);
+            int height = MeasureSpec.getSize(heightMeasureSpec);
+            setPadding(getPaddingLeft(), (height - cellHeightPx) / 2, getPaddingRight(),
+                    getPaddingBottom());
+        }
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 
     @Override


### PR DESCRIPTION
The FolderIcon container's height is already set to allAppsCellHeightPx in AllAppsGridAdapter, so use match_parent to set the correct height on the FolderIcon. Then vertically align by matching BubbleTextView's onMeasure implementation.

BubbleTextView's onMeasure implementation looks like this:
https://github.com/LawnchairLauncher/Lawnchair/blob/3b24173397f6d77a5bdd9ef2e40cf8ff7c67efc9/src/com/android/launcher3/BubbleTextView.java#L526-L537

Resolves https://github.com/LawnchairLauncher/Lawnchair/issues/1832.

Before | After
|-|-|
![before-multi](https://user-images.githubusercontent.com/11037113/69770786-2bec8c00-11ef-11ea-89fe-f391d1901fd9.png) | ![after](https://user-images.githubusercontent.com/11037113/69770788-3018a980-11ef-11ea-9483-50e36d0f403a.png)

Inspector Before | Inspector After
|-|-|
![inspector-before](https://user-images.githubusercontent.com/11037113/69770792-3575f400-11ef-11ea-9632-d2dbe6f95d83.png) | ![inspector-after](https://user-images.githubusercontent.com/11037113/69770796-39097b00-11ef-11ea-90b8-bfc09bf3de98.png)
