### PR TITLE
Fix search bar bottom margin in widget mode

### DIFF
--- a/src/com/google/android/apps/nexuslauncher/qsb/HotseatQsbWidget.java
+++ b/src/com/google/android/apps/nexuslauncher/qsb/HotseatQsbWidget.java
@@ -333,12 +333,19 @@ public class HotseatQsbWidget extends AbstractQsbLayout implements o,
     }
 
     public static int getBottomMargin(Launcher launcher, boolean widgetMode) {
-        Resources resources = launcher.getResources();
-        int minBottom = launcher.getDeviceProfile().getInsets().bottom + launcher.getResources()
-                .getDimensionPixelSize(R.dimen.hotseat_qsb_bottom_margin);
-
         DeviceProfile profile = launcher.getDeviceProfile();
-        Rect rect = widgetMode ? new Rect(0,0,0,0) : profile.getInsets();
+        Resources resources = launcher.getResources();
+        int resBottomMargin = resources.getDimensionPixelSize(R.dimen.hotseat_qsb_bottom_margin);
+
+        if (widgetMode) {
+            int cellHeight = profile.getCellSize().y;
+            int widgetHeight = resources.getDimensionPixelSize(R.dimen.qsb_widget_height);
+            int bottomMargin = Math.round((cellHeight - widgetHeight) / 2.0f);
+            return Math.max(bottomMargin, resBottomMargin);
+        }
+
+        Rect rect = profile.getInsets();
+        int minBottom = rect.bottom + resBottomMargin;
         Rect hotseatLayoutPadding = profile.getHotseatLayoutPadding();
 
         int hotseatTop = profile.hotseatBarSizePx + rect.bottom;


### PR DESCRIPTION
The minimum bottom margin for the search bar is using device profile
insets intended for the hotseat search bar which are incorrect for
widgets. As a result, the widget is too high on the home screen and may
be cropped on some devices, especially if using more (and therefore
smaller) home screen rows than the default.

Fix by referencing the launcher's cell size relative to the widget
height rather than the device insets, making the search widget properly
centered in its row.

The calculation for non-widget mode is unchanged, but clean up some
duplicate calls to launcher.getDeviceProfile and getResources.

Fixes: https://github.com/LawnchairLauncher/Lawnchair/issues/1860
Signed-off-by: Allen Wild <allenwild93@gmail.com>