### PR TITLE
Feature: Allow user to hide shortcut badges

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -480,6 +480,7 @@
     <string name="about_summary_title">Summary</string>
 
     <string name="hide_app">Hide Shortcut</string>
+    <string name="hide_badge">Hide Badge</string>
     <string name="icon_shape_rounded_square">Rounded Square</string>
 
     <string name="hide_app_selected">“&#160;” hidden.</string>

--- a/lawnchair/src/ch/deletescape/lawnchair/override/CustomInfoProvider.kt
+++ b/lawnchair/src/ch/deletescape/lawnchair/override/CustomInfoProvider.kt
@@ -50,6 +50,16 @@ abstract class CustomInfoProvider<in T : ItemInfo>(val context: Context) {
         TODO("not implemented")
     }
 
+    open fun supportsBadgeVisible(info: T) = false
+
+    open fun setBadgeVisible(info: T, visible: Boolean) {
+        TODO("not implemented")
+    }
+
+    open fun getBadgeVisible(info: T): Boolean {
+        TODO("not implemented")
+    }
+
     companion object {
 
         @Suppress("UNCHECKED_CAST")

--- a/lawnchair/src/ch/deletescape/lawnchair/override/ShortcutInfoProvider.kt
+++ b/lawnchair/src/ch/deletescape/lawnchair/override/ShortcutInfoProvider.kt
@@ -25,6 +25,8 @@ import ch.deletescape.lawnchair.iconpack.IconPackManager
 import ch.deletescape.lawnchair.useApplicationContext
 import ch.deletescape.lawnchair.util.SingletonHolder
 import com.android.launcher3.LauncherAppState
+import com.android.launcher3.LauncherSettings.BaseLauncherColumns.ITEM_TYPE_SHORTCUT
+import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_DEEP_SHORTCUT
 import com.android.launcher3.ShortcutInfo
 import com.android.launcher3.compat.LauncherAppsCompat
 import com.android.launcher3.graphics.LauncherIcons
@@ -74,6 +76,20 @@ class ShortcutInfoProvider private constructor(context: Context) : CustomInfoPro
 
     override fun getSwipeUpAction(info: ShortcutInfo): String? {
         return info.swipeUpAction
+    }
+
+    override fun supportsBadgeVisible(info: ShortcutInfo) = when (info.itemType) {
+        ITEM_TYPE_SHORTCUT, ITEM_TYPE_DEEP_SHORTCUT -> true
+        // TODO if work badge is present
+        else -> false
+    }
+
+    override fun setBadgeVisible(info: ShortcutInfo, visible: Boolean) {
+        info.setBadgeVisible(context, visible)
+    }
+
+    override fun getBadgeVisible(info: ShortcutInfo): Boolean {
+        return info.isBadgeVisible
     }
 
     private fun getLauncherActivityInfo(info: ShortcutInfo): LauncherActivityInfo? {

--- a/res/xml/app_edit_prefs.xml
+++ b/res/xml/app_edit_prefs.xml
@@ -22,6 +22,12 @@
         android:defaultValue="false"
         android:persistent="false"/>
 
+    <ch.deletescape.lawnchair.preferences.StyledSwitchPreference
+        android:key="pref_badge_hide"
+        android:title="@string/hide_badge"
+        android:defaultValue="false"
+        android:persistent="false"/>
+
     <ch.deletescape.lawnchair.preferences.MultiSelectTabPreference
         android:key="pref_show_in_tabs"
         android:title="@string/show_in_tabs"/>

--- a/src/com/android/launcher3/FolderInfo.java
+++ b/src/com/android/launcher3/FolderInfo.java
@@ -189,7 +189,7 @@ public class FolderInfo extends ItemInfo {
 
     public void setSwipeUpAction(@NonNull Context context, @Nullable String action) {
         swipeUpAction = action;
-        ModelWriter.modifyItemInDatabase(context, this, null, swipeUpAction, null, null, false, true);
+        ModelWriter.modifyItemInDatabase(context, this, null, swipeUpAction, false, null, null, false, true);
     }
 
     public ComponentKey toComponentKey() {

--- a/src/com/android/launcher3/InstallShortcutReceiver.java
+++ b/src/com/android/launcher3/InstallShortcutReceiver.java
@@ -499,7 +499,7 @@ public class InstallShortcutReceiver extends BroadcastReceiver {
             } else if (shortcutInfo != null) {
                 ShortcutInfo si = new ShortcutInfo(shortcutInfo, mContext);
                 LauncherIcons li = LauncherIcons.obtain(mContext);
-                li.createShortcutIcon(shortcutInfo).applyTo(si);
+                li.createShortcutIcon(shortcutInfo, si.isBadgeVisible()).applyTo(si);
                 li.recycle();
                 return Pair.create((ItemInfo) si, (Object) shortcutInfo);
             } else if (providerInfo != null) {

--- a/src/com/android/launcher3/ItemInfoWithIcon.java
+++ b/src/com/android/launcher3/ItemInfoWithIcon.java
@@ -121,4 +121,8 @@ public abstract class ItemInfoWithIcon extends ItemInfo {
     public boolean isDisabled() {
         return (runtimeStatusFlags & FLAG_DISABLED_MASK) != 0;
     }
+
+    public boolean isBadgeVisible() {
+        return (runtimeStatusFlags & FLAG_ICON_BADGED) != 0;
+    }
 }

--- a/src/com/android/launcher3/LauncherModel.java
+++ b/src/com/android/launcher3/LauncherModel.java
@@ -660,7 +660,7 @@ public class LauncherModel extends BroadcastReceiver
             public ShortcutInfo get() {
                 si.updateFromDeepShortcutInfo(info, mApp.getContext());
                 LauncherIcons li = LauncherIcons.obtain(mApp.getContext());
-                li.createShortcutIcon(info).applyTo(si);
+                li.createShortcutIcon(info, si.isBadgeVisible()).applyTo(si);
                 li.recycle();
                 return si;
             }

--- a/src/com/android/launcher3/LauncherProvider.java
+++ b/src/com/android/launcher3/LauncherProvider.java
@@ -80,7 +80,7 @@ public class LauncherProvider extends ContentProvider {
     /**
      * Represents the schema of the database. Changes in scheme need not be backwards compatible.
      */
-    public static final int SCHEMA_VERSION = 31;
+    public static final int SCHEMA_VERSION = 32;
 
     public static final String AUTHORITY = FeatureFlags.AUTHORITY;
 
@@ -800,6 +800,8 @@ public class LauncherProvider extends ContentProvider {
                     db.execSQL("ALTER TABLE " + Favorites.TABLE_NAME + " ADD COLUMN " + Favorites.CUSTOM_ICON_ENTRY + " TEXT;");
                 case 30:
                     db.execSQL("ALTER TABLE " + Favorites.TABLE_NAME + " ADD COLUMN " + Favorites.SWIPE_UP_ACTION + " TEXT;");
+                case 31:
+                    db.execSQL("ALTER TABLE " + Favorites.TABLE_NAME + " ADD COLUMN " + Favorites.BADGE_VISIBLE + " INTEGER NOT NULL DEFAULT 0;");
                     return;
             }
 

--- a/src/com/android/launcher3/LauncherSettings.java
+++ b/src/com/android/launcher3/LauncherSettings.java
@@ -265,6 +265,8 @@ public class LauncherSettings {
 
         public static final String SWIPE_UP_ACTION = "swipeUpAction";
 
+        public static final String BADGE_VISIBLE = "badgeVisible";
+
         public static void addTableToDb(SQLiteDatabase db, long myProfileId, boolean optional) {
             String ifNotExists = optional ? " IF NOT EXISTS " : "";
             db.execSQL("CREATE TABLE " + ifNotExists + TABLE_NAME + " (" +
@@ -287,6 +289,7 @@ public class LauncherSettings {
                     "titleAlias TEXT," +
                     "swipeUpAction TEXT," +
                     "appWidgetProvider TEXT," +
+                    "badgeVisible INTEGER NOT NULL DEFAULT 0," +
                     "modified INTEGER NOT NULL DEFAULT 0," +
                     "restored INTEGER NOT NULL DEFAULT 0," +
                     "profileId INTEGER DEFAULT " + myProfileId + "," +

--- a/src/com/android/launcher3/ShortcutInfo.java
+++ b/src/com/android/launcher3/ShortcutInfo.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import android.util.DisplayMetrics;
+import android.util.Log;
 import ch.deletescape.lawnchair.iconpack.IconPackManager;
 import ch.deletescape.lawnchair.sesame.SesameShortcutInfo;
 import com.android.launcher3.LauncherSettings.Favorites;
@@ -105,6 +106,8 @@ public class ShortcutInfo extends ItemInfoWithIcon {
     public IconPackManager.CustomIconEntry customIconEntry;
 
     public String swipeUpAction;
+
+    private boolean badgeVisible = true;
 
     public ShortcutInfoCompat shortcutInfo;
 
@@ -234,21 +237,27 @@ public class ShortcutInfo extends ItemInfoWithIcon {
         return cn;
     }
 
+    @Override
+    public boolean isBadgeVisible() {
+        return badgeVisible;
+    }
+
     private void updateDatabase(Context context, boolean updateIcon, boolean reload) {
         if (updateIcon)
             ModelWriter.modifyItemInDatabase(context, this, (String) customTitle, swipeUpAction
-                    , customIconEntry, customIcon, true, reload);
+                    , badgeVisible, customIconEntry, customIcon, true, reload);
         else
             ModelWriter.modifyItemInDatabase(context, this, (String) customTitle, swipeUpAction
-                    , null, null, false, reload);
+                    , badgeVisible, null, null, false, reload);
     }
 
-    public void onLoadCustomizations(String titleAlias, String swipeUpAction,
+    public void onLoadCustomizations(String titleAlias, String swipeUpAction, boolean badgeVisible,
             IconPackManager.CustomIconEntry customIcon, Bitmap icon) {
         customTitle = titleAlias;
         customIconEntry = customIcon;
         this.customIcon = icon;
         this.swipeUpAction = swipeUpAction;
+        this.badgeVisible = badgeVisible;
     }
 
     public void setTitle(@NotNull Context context, @Nullable String title) {
@@ -268,6 +277,11 @@ public class ShortcutInfo extends ItemInfoWithIcon {
 
     public void setSwipeUpAction(@NonNull Context context, @Nullable String action) {
         swipeUpAction = action;
+        updateDatabase(context, false, true);
+    }
+
+    public void setBadgeVisible(@NonNull Context context, @NonNull Boolean visible) {
+        badgeVisible = visible;
         updateDatabase(context, false, true);
     }
 }

--- a/src/com/android/launcher3/compat/LauncherAppsCompatVO.java
+++ b/src/com/android/launcher3/compat/LauncherAppsCompatVO.java
@@ -30,6 +30,7 @@ import android.os.Process;
 import android.os.UserHandle;
 import android.support.annotation.Nullable;
 
+import android.util.Log;
 import com.android.launcher3.LauncherAppState;
 import com.android.launcher3.LauncherModel;
 import com.android.launcher3.ShortcutInfo;
@@ -138,7 +139,7 @@ public class LauncherAppsCompatVO extends LauncherAppsCompatVL {
             ShortcutInfo info = new ShortcutInfo(compat, context);
             // Apply the unbadged icon and fetch the actual icon asynchronously.
             LauncherIcons li = LauncherIcons.obtain(context);
-            li.createShortcutIcon(compat, false /* badged */).applyTo(info);
+            li.createShortcutIconPlain(compat).applyTo(info);
             li.recycle();
             LauncherAppState.getInstance(context).getModel()
                     .updateAndBindShortcutInfo(info, compat);

--- a/src/com/android/launcher3/dragndrop/DragView.java
+++ b/src/com/android/launcher3/dragndrop/DragView.java
@@ -393,8 +393,8 @@ public class DragView extends View {
         int iconSize = appState.getInvariantDeviceProfile().iconBitmapSize;
         if (info.itemType == LauncherSettings.Favorites.ITEM_TYPE_DEEP_SHORTCUT) {
             boolean iconBadged = (info instanceof ItemInfoWithIcon)
-                    && (((ItemInfoWithIcon) info).runtimeStatusFlags & FLAG_ICON_BADGED) > 0;
-            if ((info.id == ItemInfo.NO_ID && !iconBadged)
+                    && ((ItemInfoWithIcon) info).isBadgeVisible();
+            if (info.id == ItemInfo.NO_ID || !iconBadged
                     || !(obj instanceof ShortcutInfoCompat)) {
                 // The item is not yet added on home screen.
                 return new FixedSizeEmptyDrawable(iconSize);

--- a/src/com/android/launcher3/graphics/ShadowGenerator.java
+++ b/src/com/android/launcher3/graphics/ShadowGenerator.java
@@ -77,6 +77,10 @@ public class ShadowGenerator {
         mDrawPaint.setAlpha(keyAlpha);
         out.drawBitmap(shadow, offset[0], offset[1] + KEY_SHADOW_DISTANCE * mIconSize, mDrawPaint);
 
+        copyIcon(icon, out);
+    }
+
+    public synchronized void copyIcon(Bitmap icon, Canvas out) {
         // Draw the icon
         mDrawPaint.setAlpha(255);
         out.drawBitmap(icon, 0, 0, mDrawPaint);

--- a/src/com/android/launcher3/model/LoaderTask.java
+++ b/src/com/android/launcher3/model/LoaderTask.java
@@ -303,6 +303,8 @@ public class LoaderTask implements Runnable {
                         LauncherSettings.Favorites.CUSTOM_ICON_ENTRY);
                 final int swipeUpActionEntryIndex = c.getColumnIndexOrThrow(
                         LauncherSettings.Favorites.SWIPE_UP_ACTION);
+                final int badgeVisibleIndex = c.getColumnIndexOrThrow(
+                        LauncherSettings.Favorites.BADGE_VISIBLE);
 
                 final LongSparseArray<UserHandle> allUsers = c.allUsers;
                 final LongSparseArray<Boolean> quietMode = new LongSparseArray<>();
@@ -340,6 +342,7 @@ public class LoaderTask implements Runnable {
                 String titleAlias;
                 String customIconEntry;
                 String swipeUpAction;
+                boolean badgeVisible;
 
                 FolderIconPreviewVerifier verifier =
                         new FolderIconPreviewVerifier(mApp.getInvariantDeviceProfile());
@@ -369,6 +372,7 @@ public class LoaderTask implements Runnable {
                             titleAlias = c.getString(titleAliasIndex);
                             customIconEntry = c.getString(customIconEntryIndex);
                             swipeUpAction = c.getString(swipeUpActionEntryIndex);
+                            badgeVisible = c.getInt(badgeVisibleIndex) != 0;
 
                             if (!Process.myUserHandle().equals(c.user)) {
                                 if (c.itemType == LauncherSettings.Favorites.ITEM_TYPE_SHORTCUT) {
@@ -508,7 +512,7 @@ public class LoaderTask implements Runnable {
                                     };
                                     LauncherIcons li = LauncherIcons.obtain(context);
                                     li.createShortcutIcon(pinnedShortcut,
-                                            true /* badged */, fallbackIconProvider).applyTo(info);
+                                            badgeVisible, fallbackIconProvider).applyTo(info);
                                     li.recycle();
                                     if (pmHelper.isAppSuspended(
                                             pinnedShortcut.getPackage(), info.user)) {
@@ -549,7 +553,7 @@ public class LoaderTask implements Runnable {
                             if (info != null) {
                                 c.applyCommonProperties(info);
 
-                                info.onLoadCustomizations(titleAlias, swipeUpAction,
+                                info.onLoadCustomizations(titleAlias, swipeUpAction, badgeVisible,
                                         IconPackManager.CustomIconEntry.Companion.fromNullableString(customIconEntry),
                                         c.loadCustomIcon(info));
                                 info.intent = intent;

--- a/src/com/android/launcher3/model/ModelWriter.java
+++ b/src/com/android/launcher3/model/ModelWriter.java
@@ -219,12 +219,13 @@ public class ModelWriter {
     }
 
     public static void modifyItemInDatabase(Context context, final ItemInfo item, String alias,
-                                            String swipeUpAction,
+                                            String swipeUpAction, boolean badgeVisible,
                                             IconPackManager.CustomIconEntry iconEntry, Bitmap icon,
                                             boolean updateIcon, boolean reload) {
         final ContentWriter writer = new ContentWriter(context);
         writer.put(Favorites.TITLE_ALIAS, alias);
         writer.put(Favorites.SWIPE_UP_ACTION, swipeUpAction);
+        writer.put(Favorites.BADGE_VISIBLE, badgeVisible ? 1 : 0);
         if (updateIcon) {
             writer.put(Favorites.CUSTOM_ICON, icon != null ? Utilities.flattenBitmap(icon) : null);
             writer.put(Favorites.CUSTOM_ICON_ENTRY, iconEntry != null ? iconEntry.toString() : null);

--- a/src/com/android/launcher3/popup/PopupPopulator.java
+++ b/src/com/android/launcher3/popup/PopupPopulator.java
@@ -158,7 +158,7 @@ public class PopupPopulator {
                 final ShortcutInfo si = new ShortcutInfo(shortcut, launcher);
                 // Use unbadged icon for the menu.
                 LauncherIcons li = LauncherIcons.obtain(launcher);
-                li.createShortcutIcon(shortcut, false /* badged */).applyTo(si);
+                li.createShortcutIcon(shortcut, si.isBadgeVisible()).applyTo(si);
                 li.recycle();
                 si.rank = i;
 

--- a/src/com/google/android/apps/nexuslauncher/CustomBottomSheet.java
+++ b/src/com/google/android/apps/nexuslauncher/CustomBottomSheet.java
@@ -30,6 +30,7 @@ import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -174,6 +175,7 @@ public class CustomBottomSheet extends WidgetsBottomSheet {
 
     public static class PrefsFragment extends PreferenceFragment implements Preference.OnPreferenceChangeListener, Preference.OnPreferenceClickListener {
         private final static String PREF_HIDE = "pref_app_hide";
+        private final static String PREF_HIDE_BADGE = "pref_badge_hide";
         private final static String PREF_HIDE_FROM_PREDICTIONS = "pref_app_prediction_hide";
         private final static boolean HIDE_PREDICTION_OPTION = true;
         public final static int requestCode = "swipeUp".hashCode() & 65535;
@@ -182,6 +184,7 @@ public class CustomBottomSheet extends WidgetsBottomSheet {
         private LauncherGesturePreference mSwipeUpPref;
         private MultiSelectTabPreference mTabsPref;
         private SwitchPreference mPrefCoverMode;
+        private SwitchPreference mPrefHideBadge;
         private LawnchairPreferences prefs;
 
         private ComponentKey mKey;
@@ -220,6 +223,7 @@ public class CustomBottomSheet extends WidgetsBottomSheet {
                 mKey = new ComponentKey(itemInfo.getTargetComponent(), itemInfo.user);
             }
             SwitchPreference mPrefHide = (SwitchPreference) findPreference(PREF_HIDE);
+            mPrefHideBadge = (SwitchPreference) findPreference(PREF_HIDE_BADGE);
             mPrefCoverMode = (SwitchPreference) findPreference("pref_cover_mode");
 
             if (isApp) {
@@ -245,6 +249,13 @@ public class CustomBottomSheet extends WidgetsBottomSheet {
                 });
             } else {
                 getPreferenceScreen().removePreference(mSwipeUpPref);
+            }
+
+            if (mProvider != null && mProvider.supportsBadgeVisible(itemInfo)) {
+                boolean badgeVisible = mProvider.getBadgeVisible(itemInfo);
+                mPrefHideBadge.setChecked(!badgeVisible);
+            } else {
+                screen.removePreference(mPrefHideBadge);
             }
 
             if (mPrefHidePredictions != null) {
@@ -337,6 +348,12 @@ public class CustomBottomSheet extends WidgetsBottomSheet {
                 provider.setSwipeUpAction(itemInfo, stringValue);
             }
 
+            if (mProvider != null && mProvider.supportsBadgeVisible(itemInfo)) {
+                CustomInfoProvider provider = CustomInfoProvider.Companion.forItem(getActivity(), itemInfo);
+                boolean badgeHidden = mPrefHideBadge.isChecked();
+                provider.setBadgeVisible(itemInfo, !badgeHidden);
+            }
+
             if (mTabsPref.getEdited()) {
                 prefs.getDrawerTabs().saveToJson();
             }
@@ -362,6 +379,7 @@ public class CustomBottomSheet extends WidgetsBottomSheet {
                     break;
                 case PREF_HIDE_FROM_PREDICTIONS:
                     CustomAppPredictor.setComponentNameState(launcher, mKey, enabled);
+                    break;
             }
             return true;
         }


### PR DESCRIPTION
Closes #1797

First time contributing here, so I would love advice for how to improve this.

As mentioned in the feature request issue, it would be great to be able to hide the badges in the lower right corner for some shortcuts (like those representing web apps). This PR adds a new toggle to "Hide badge" and changes the drawn icon if enabled.

For now I only made this work with shortcuts. Long-term it could also be used to hide work profile badges, so I tried to not make the code specific to shortcuts.

<img width="200" alt="Icon badge vs icon with badge hidden" src="https://user-images.githubusercontent.com/1782266/71304640-7db3ac80-237e-11ea-9d28-99d5f38c6b3e.png">
