### PR TITLE
Fix memory leak due to unregistered receiver

### DIFF
--- a/lawnchair/src/app/lawnchair/nexuslauncher/OverlayCallbackImpl.java
+++ b/lawnchair/src/app/lawnchair/nexuslauncher/OverlayCallbackImpl.java
@@ -121,6 +121,7 @@ public class OverlayCallbackImpl
 
     @Override
     public void onActivityDestroyed(Activity activity) {
+        mClient.onDestroy();
         mClient.mDestroyed = true;
     }
 

--- a/lawnchair/src/com/google/android/libraries/launcherclient/LauncherClient.java
+++ b/lawnchair/src/com/google/android/libraries/launcherclient/LauncherClient.java
@@ -215,6 +215,10 @@ public class LauncherClient {
         }
     }
 
+    public void onDestroy() {
+        mActivity.unregisterReceiver(googleInstallListener);
+    }
+
     private void reconnect() {
         if (!mDestroyed && (!mLauncherService.connect() || !mBaseService.connect())) {
             mActivity.runOnUiThread(() -> setServiceState(0));


### PR DESCRIPTION
Unregister GoogleInstallListener receiver on activity destroy