### PR TITLE
Add WallpaperManager check to support WSA

### DIFF
--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -1170,7 +1170,9 @@ public class Workspace extends PagedView<WorkspacePageIndicator>
             @Override
             public void run() {
                 final Point size = LauncherAppState.getIDP(getContext()).defaultWallpaperSize;
-                if (size.x != mWallpaperManager.getDesiredMinimumWidth()
+                if (!mWallpaperManager.isWallpaperSupported()) {
+                    mWallpaperManager.suggestDesiredDimensions(0, 0);
+                } else if (size.x != mWallpaperManager.getDesiredMinimumWidth()
                         || size.y != mWallpaperManager.getDesiredMinimumHeight()) {
                     mWallpaperManager.suggestDesiredDimensions(size.x, size.y);
                 }


### PR DESCRIPTION
This allows the app not to crash upon opening on Windows Subsystem for Android (WSA).

Solves #2272