### PR TITLE
Allow icon pack dashboards to change icon pack externally

### DIFF
--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -48,6 +48,14 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+        <activity android:exported="true"
+            android:name="app.lawnchair.ui.preferences.ApplyIconPackActivity"
+            android:theme="@style/ApplyIconPackDialog">
+            <intent-filter>
+                <action android:name="app.lawnchair.APPLY_ICONS"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
         <receiver
             android:name="app.lawnchair.gestures.handlers.SleepMethodDeviceAdmin$SleepDeviceAdmin"
             android:label="@string/derived_app_name"

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -200,5 +200,4 @@
     <string name="dark_status_bar_label">Dark Status Bar</string>
     <string name="lawnicons_not_installed_description">Lawnicons not installed.</string>
     <string name="apply_icon_pack_description">Do you want to apply %s? You can change this later from %s</string>
-    <string name="invalid_icon_pack_description">%s is not a valid icon pack</string>
 </resources>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -199,4 +199,6 @@
     <string name="all_apps_device_search_hint">Search</string>
     <string name="dark_status_bar_label">Dark Status Bar</string>
     <string name="lawnicons_not_installed_description">Lawnicons not installed.</string>
+    <string name="apply_icon_pack_description">Do you want to apply %s? You can change this later from %s</string>
+    <string name="invalid_icon_pack_description">%s is not a valid icon pack</string>
 </resources>

--- a/lawnchair/res/values/styles.xml
+++ b/lawnchair/res/values/styles.xml
@@ -177,4 +177,15 @@
         <item name="keyShadowOffsetX">@dimen/smartspaceKeyShadowOffset</item>
         <item name="keyShadowOffsetY">@dimen/smartspaceKeyShadowOffset</item>
     </style>
+
+    <style name="ApplyIconPackDialog" parent="Theme.Lawnchair">
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:backgroundDimEnabled">true</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowIsFloating">false</item>
+    </style>
+
 </resources>

--- a/lawnchair/src/app/lawnchair/ui/preferences/ApplyIconPackActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/ApplyIconPackActivity.kt
@@ -62,36 +62,35 @@ class ApplyIconPackActivity : AppCompatActivity() {
                     CompositionLocalProvider(LocalPreferenceInteractor provides viewModel<PreferenceViewModel>()) {
                         val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsState()
                         val isIconPackValid = iconPacks.any { it.packageName == packPackageName }
-                        Box(modifier = Modifier.fillMaxSize()) {
-                            Surface(
-                                shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
-                                color = MaterialTheme.colorScheme.surface,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .align(Alignment.BottomCenter)
-                            ) {
-                                Box(
-                                    Modifier
+                        if (iconPacks.isNotEmpty()) {
+                            Box(modifier = Modifier.fillMaxSize()) {
+                                Surface(
+                                    shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
+                                    color = MaterialTheme.colorScheme.surface,
+                                    modifier = Modifier
                                         .fillMaxWidth()
-                                        .navigationBarsOrDisplayCutoutPadding()
+                                        .align(Alignment.BottomCenter)
                                 ) {
-                                    Column(
-                                        modifier = Modifier
+                                    Box(
+                                        Modifier
                                             .fillMaxWidth()
-                                            .padding(25.dp)
-                                            .verticalScroll(rememberScrollState())
+                                            .navigationBarsOrDisplayCutoutPadding()
                                     ) {
-                                        if (isIconPackValid && packPackageName != null) {
-                                            ApplyIconPackShowcase(
-                                                iconPackPackageName = packPackageName,
-                                                iconPackName = packName,
-                                                iconPackIcon = packIcon
-                                            )
-                                        } else {
-                                            InvalidIconPackPlaceholder(
-                                                iconPackName = packName,
-                                                iconPackIcon = packIcon
-                                            )
+                                        Column(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(25.dp)
+                                                .verticalScroll(rememberScrollState())
+                                        ) {
+                                            if (isIconPackValid && packPackageName != null) {
+                                                ApplyIconPackShowcase(
+                                                    iconPackPackageName = packPackageName,
+                                                    iconPackName = packName,
+                                                    iconPackIcon = packIcon
+                                                )
+                                            } else {
+                                                finish()
+                                            }
                                         }
                                     }
                                 }
@@ -122,30 +121,6 @@ class ApplyIconPackActivity : AppCompatActivity() {
                 )
             }
             HorizontalSpacer(height = 8.dp)
-        }
-    }
-
-    @Composable
-    private fun ColumnScope.InvalidIconPackPlaceholder(
-        iconPackName: String?,
-        iconPackIcon: Bitmap?
-    ) {
-        ShowcaseIcon(bitmap = iconPackIcon)
-        Text(
-            text = stringResource(R.string.invalid_icon_pack_description).format(
-                Locale.getDefault(),
-                iconPackName
-            ),
-            modifier = Modifier.fillMaxWidth(),
-            textAlign = TextAlign.Center,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        HorizontalSpacer()
-        FullWidthButton(
-            muted = true,
-            text = stringResource(id = android.R.string.cancel)
-        ) {
-            finish()
         }
     }
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/ApplyIconPackActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/ApplyIconPackActivity.kt
@@ -8,20 +8,16 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Surface
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
@@ -34,12 +30,10 @@ import androidx.compose.ui.unit.sp
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
-import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.ui.theme.LawnchairTheme
 import app.lawnchair.util.navigationBarsOrDisplayCutoutPadding
 import coil.annotation.ExperimentalCoilApi
-import coil.compose.rememberImagePainter
 import com.android.launcher3.R
 import com.google.accompanist.insets.ProvideWindowInsets
 import java.util.*
@@ -70,7 +64,7 @@ class ApplyIconPackActivity : AppCompatActivity() {
                         val isIconPackValid = iconPacks.any { it.packageName == packPackageName }
                         Box(modifier = Modifier.fillMaxSize()) {
                             Surface(
-                                shape = RoundedCornerShape(topStart = 25.dp, topEnd = 25.dp),
+                                shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
                                 color = MaterialTheme.colorScheme.surface,
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -111,10 +105,10 @@ class ApplyIconPackActivity : AppCompatActivity() {
 
     @OptIn(ExperimentalCoilApi::class)
     @Composable
-    private fun ColumnScope.CircularIcon(bitmap: Bitmap?) {
-        if (bitmap != null)
+    private fun ColumnScope.ShowcaseIcon(bitmap: Bitmap?) {
+        if (bitmap != null) {
+            HorizontalSpacer(height = 8.dp)
             Surface(
-                shape = CircleShape,
                 modifier = Modifier
                     .height(80.dp)
                     .aspectRatio(1f)
@@ -122,11 +116,13 @@ class ApplyIconPackActivity : AppCompatActivity() {
                 color = MaterialTheme.colorScheme.surface
             ) {
                 Image(
-                    painter = rememberImagePainter(bitmap),
+                    bitmap = bitmap.asImageBitmap(),
                     contentDescription = null,
                     modifier = Modifier.fillMaxSize(),
                 )
             }
+            HorizontalSpacer(height = 8.dp)
+        }
     }
 
     @Composable
@@ -134,8 +130,7 @@ class ApplyIconPackActivity : AppCompatActivity() {
         iconPackName: String?,
         iconPackIcon: Bitmap?
     ) {
-        CircularIcon(bitmap = iconPackIcon)
-        HorizontalSpacer()
+        ShowcaseIcon(bitmap = iconPackIcon)
         Text(
             text = stringResource(R.string.invalid_icon_pack_description).format(
                 Locale.getDefault(),
@@ -161,9 +156,8 @@ class ApplyIconPackActivity : AppCompatActivity() {
         iconPackIcon: Bitmap?
     ) {
         val hapticFeedback = LocalHapticFeedback.current
-        var iconPacksPreference by preferenceManager().iconPackPackage.getAdapter()
-        CircularIcon(bitmap = iconPackIcon)
-        HorizontalSpacer(height = 8.dp)
+        var iconPacksPreference by preferenceManager().iconPackPackage
+        ShowcaseIcon(bitmap = iconPackIcon)
         Text(
             text = iconPackName,
             modifier = Modifier.fillMaxWidth(),
@@ -174,14 +168,13 @@ class ApplyIconPackActivity : AppCompatActivity() {
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurface
         )
-        HorizontalSpacer(height = 8.dp)
+        HorizontalSpacer()
         Text(
             text = formattedIconPackApplyMessage(iconPackName = iconPackName),
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurface
         )
-
         HorizontalSpacer()
         FullWidthButton(text = stringResource(id = R.string.apply_grid)) {
             if (iconPacksPreference == iconPackPackageName) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/ApplyIconPackActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/ApplyIconPackActivity.kt
@@ -1,0 +1,247 @@
+package app.lawnchair.ui.preferences
+
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Surface
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.graphics.drawable.toBitmap
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.viewmodel.compose.viewModel
+import app.lawnchair.preferences.getAdapter
+import app.lawnchair.preferences.preferenceManager
+import app.lawnchair.ui.theme.LawnchairTheme
+import app.lawnchair.util.navigationBarsOrDisplayCutoutPadding
+import coil.annotation.ExperimentalCoilApi
+import coil.compose.rememberImagePainter
+import com.android.launcher3.R
+import com.google.accompanist.insets.ProvideWindowInsets
+import java.util.*
+
+class ApplyIconPackActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        val packPackageName = intent.getStringExtra("packageName")
+        val (packName, packIcon) =
+            try {
+                packageManager.getApplicationInfo(packPackageName ?: "INVALID_PKG", 0)
+                    .let {
+                        packageManager.getApplicationLabel(it)
+                            .toString() to packageManager.getApplicationIcon(it)
+                            .toBitmap()
+                    }
+            } catch (nameNotFoundException: PackageManager.NameNotFoundException) {
+                "\"%s\"".format(Locale.getDefault(), packPackageName) to null
+            }
+
+        setContent {
+            LawnchairTheme {
+                ProvideWindowInsets {
+                    CompositionLocalProvider(LocalPreferenceInteractor provides viewModel<PreferenceViewModel>()) {
+                        val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsState()
+                        val isIconPackValid = iconPacks.any { it.packageName == packPackageName }
+                        Box(modifier = Modifier.fillMaxSize()) {
+                            Surface(
+                                shape = RoundedCornerShape(topStart = 25.dp, topEnd = 25.dp),
+                                color = MaterialTheme.colorScheme.surface,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .align(Alignment.BottomCenter)
+                            ) {
+                                Box(
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .navigationBarsOrDisplayCutoutPadding()
+                                ) {
+                                    Column(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(25.dp)
+                                            .verticalScroll(rememberScrollState())
+                                    ) {
+                                        if (isIconPackValid && packPackageName != null) {
+                                            ApplyIconPackShowcase(
+                                                iconPackPackageName = packPackageName,
+                                                iconPackName = packName,
+                                                iconPackIcon = packIcon
+                                            )
+                                        } else {
+                                            InvalidIconPackPlaceholder(
+                                                iconPackName = packName,
+                                                iconPackIcon = packIcon
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @OptIn(ExperimentalCoilApi::class)
+    @Composable
+    private fun ColumnScope.CircularIcon(bitmap: Bitmap?) {
+        if (bitmap != null)
+            Surface(
+                shape = CircleShape,
+                modifier = Modifier
+                    .height(80.dp)
+                    .aspectRatio(1f)
+                    .align(Alignment.CenterHorizontally),
+                color = MaterialTheme.colorScheme.surface
+            ) {
+                Image(
+                    painter = rememberImagePainter(bitmap),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+    }
+
+    @Composable
+    private fun ColumnScope.InvalidIconPackPlaceholder(
+        iconPackName: String?,
+        iconPackIcon: Bitmap?
+    ) {
+        CircularIcon(bitmap = iconPackIcon)
+        HorizontalSpacer()
+        Text(
+            text = stringResource(R.string.invalid_icon_pack_description).format(
+                Locale.getDefault(),
+                iconPackName
+            ),
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        HorizontalSpacer()
+        FullWidthButton(
+            muted = true,
+            text = stringResource(id = android.R.string.cancel)
+        ) {
+            finish()
+        }
+    }
+
+    @Composable
+    private fun ColumnScope.ApplyIconPackShowcase(
+        iconPackPackageName: String,
+        iconPackName: String,
+        iconPackIcon: Bitmap?
+    ) {
+        val hapticFeedback = LocalHapticFeedback.current
+        var iconPacksPreference by preferenceManager().iconPackPackage.getAdapter()
+        CircularIcon(bitmap = iconPackIcon)
+        HorizontalSpacer(height = 8.dp)
+        Text(
+            text = iconPackName,
+            modifier = Modifier.fillMaxWidth(),
+            fontWeight = FontWeight.Medium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            fontSize = 20.sp,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        HorizontalSpacer(height = 8.dp)
+        Text(
+            text = formattedIconPackApplyMessage(iconPackName = iconPackName),
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        HorizontalSpacer()
+        FullWidthButton(text = stringResource(id = R.string.apply_grid)) {
+            if (iconPacksPreference == iconPackPackageName) {
+                iconPacksPreference = ""
+            }
+            iconPacksPreference = iconPackPackageName
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+            finish()
+        }
+        HorizontalSpacer()
+        FullWidthButton(
+            muted = true,
+            text = stringResource(id = android.R.string.cancel)
+        ) {
+            finish()
+        }
+    }
+
+    @Composable
+    private fun FullWidthButton(
+        text: String,
+        muted: Boolean = false,
+        onClick: () -> Unit
+    ) {
+        Button(
+            colors = ButtonDefaults.buttonColors(containerColor = if (muted) MaterialTheme.colorScheme.surfaceVariant else MaterialTheme.colorScheme.primary),
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onClick
+        ) {
+            Text(
+                text = text,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(16.dp),
+                color = if (muted) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onPrimary
+            )
+        }
+    }
+
+
+    @Composable
+    private fun formattedIconPackApplyMessage(iconPackName: String): String {
+        return stringResource(R.string.apply_icon_pack_description).format(
+            iconPackName, kotlin.run {
+                "%s > %s > %s".format(
+                    Locale.getDefault(),
+                    stringResource(id = R.string.smartspace_preferences),
+                    stringResource(id = R.string.general_label),
+                    stringResource(id = R.string.icon_pack)
+                )
+            }
+        )
+    }
+
+    @Composable
+    private fun HorizontalSpacer(height: Dp = 16.dp) {
+        Spacer(
+            modifier = Modifier
+                .requiredHeight(height)
+                .fillMaxWidth()
+        )
+    }
+}


### PR DESCRIPTION
Hello!

This is a port from legacy Lawnchair, but with a new intent name to match the new package name of the app '`app.lawnchair`'

Check out the video below to see how it looks, or download the test icon pack (attached) to test it yourself 


How to call:
```
        val lawnchair = Intent("app.lawnchair.APPLY_ICONS", null)
        lawnchair.putExtra("packageName", packageName)
        startActivity(lawnchair)
```
[(test icon pack) app-release.zip](https://github.com/LawnchairLauncher/lawnchair/files/7780210/app-release.zip)

Tested on Android 12, but I assume it works fine on older versions because the UI is made in Compose

https://user-images.githubusercontent.com/11511782/147472892-193dd5ff-4490-4301-8c0e-bf62573741dc.mp4


