### PR TITLE
Disable Force Dark on the launcher

### DIFF
--- a/lawnchair/res/values/styles.xml
+++ b/lawnchair/res/values/styles.xml
@@ -8,6 +8,7 @@
         <item name="android:colorBackgroundFloating">@color/background_floating_device_default_light</item>
         <item name="android:dialogCornerRadius" tools:ignore="NewApi">@dimen/lawnchair_dialog_corner_radius</item>
         <item name="android:textAppearance">@style/TextAppearance.Lawnchair</item>
+        <item name="android:forceDarkAllowed">false</item>
 
         <item name="colorAccentPrimary">@color/accent_primary_device_default</item>
         <item name="textColorOnAccent">@color/text_color_on_accent_device_default</item>

--- a/lawnchair/res/values/styles.xml
+++ b/lawnchair/res/values/styles.xml
@@ -8,7 +8,6 @@
         <item name="android:colorBackgroundFloating">@color/background_floating_device_default_light</item>
         <item name="android:dialogCornerRadius" tools:ignore="NewApi">@dimen/lawnchair_dialog_corner_radius</item>
         <item name="android:textAppearance">@style/TextAppearance.Lawnchair</item>
-        <item name="android:forceDarkAllowed">false</item>
 
         <item name="colorAccentPrimary">@color/accent_primary_device_default</item>
         <item name="textColorOnAccent">@color/text_color_on_accent_device_default</item>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -41,6 +41,7 @@
         <item name="popupShadeSecond">@color/popup_shade_second_light</item>
         <item name="popupShadeThird">@color/popup_shade_third_light</item>
         <item name="popupNotificationDotColor">@color/popup_notification_dot_light</item>
+        <item name="android:forceDarkAllowed">false</item>
         <item name="isMainColorDark">false</item>
         <item name="isWorkspaceDarkText">false</item>
         <item name="workspaceTextColor">@color/workspace_text_color_light</item>


### PR DESCRIPTION
In order to avoid potentially miscolored icons when users have this option active on their devices