### PR TITLE
return if launcher is null in notifyRecentsOfOrientation

### DIFF
--- a/quickstep/src/com/android/quickstep/LauncherActivityInterface.java
+++ b/quickstep/src/com/android/quickstep/LauncherActivityInterface.java
@@ -245,7 +245,11 @@ public final class LauncherActivityInterface extends
 
     private void notifyRecentsOfOrientation(RotationTouchHelper rotationTouchHelper) {
         // reset layout on swipe to home
-        RecentsView recentsView = getCreatedActivity().getOverviewPanel();
+        Launcher launcher = getCreatedActivity();
+        if (launcher == null) {
+            return;
+        }
+        RecentsView recentsView = launcher.getOverviewPanel();
         recentsView.setLayoutRotation(rotationTouchHelper.getCurrentActiveRotation(),
                 rotationTouchHelper.getDisplayRotation());
     }


### PR DESCRIPTION
fixes
01-28 16:04:37.309836 E/AndroidRuntime(17717): FATAL EXCEPTION: main
01-28 16:04:37.309836 E/AndroidRuntime(17717): Process: app.lawnchair, PID: 17717
01-28 16:04:37.309836 E/AndroidRuntime(17717): java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.View com.android.launcher3.BaseQuickstepLauncher.getOverviewPanel()' on a null object reference
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.LauncherActivityInterface.notifyRecentsOfOrientation(LauncherActivityInterface.java:248)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.LauncherActivityInterface.prepareRecentsUI(LauncherActivityInterface.java:120)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.AbsSwipeUpHandler.lambda$onLauncherStart$5$com-android-quickstep-AbsSwipeUpHandler(AbsSwipeUpHandler.java:431)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.AbsSwipeUpHandler$$ExternalSyntheticLambda7.run(Unknown Source:2)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.MultiStateCallback.setState(MultiStateCallback.java:83)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.MultiStateCallback.setStateOnUiThread(MultiStateCallback.java:58)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.AbsSwipeUpHandler.onGestureStarted(AbsSwipeUpHandler.java:803)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.inputconsumers.OtherActivityInputConsumer.notifyGestureStarted(OtherActivityInputConsumer.java:383)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.inputconsumers.OtherActivityInputConsumer.onMotionEvent(OtherActivityInputConsumer.java:338)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.TouchInteractionService.onInputEvent(TouchInteractionService.java:618)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.TouchInteractionService.$r8$lambda$QnySfMPM3HQvC_OREg1W70p37mY(Unknown Source:0)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.quickstep.TouchInteractionService$$ExternalSyntheticLambda6.onInputEvent(Unknown Source:2)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.systemui.shared.system.InputChannelCompat$InputEventReceiver$1.onInputEvent(InputChannelCompat.java:76)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at android.view.InputEventReceiver.dispatchInputEvent(InputEventReceiver.java:259)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at android.view.InputEventReceiver.nativeConsumeBatchedInputEvents(Native Method)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at android.view.InputEventReceiver.consumeBatchedInputEvents(InputEventReceiver.java:239)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at android.view.BatchedInputEventReceiver.onBatchedInputEventPending(BatchedInputEventReceiver.java:44)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at android.os.MessageQueue.nativePollOnce(Native Method)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at android.os.MessageQueue.next(MessageQueue.java:335)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at android.os.Looper.loopOnce(Looper.java:161)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at android.os.Looper.loop(Looper.java:288)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at android.app.ActivityThread.main(ActivityThread.java:7840)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at java.lang.reflect.Method.invoke(Native Method)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:550)
01-28 16:04:37.309836 E/AndroidRuntime(17717): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)

Signed-off-by: Pranav <npv12@iitbbs.ac.in>