### PR TITLE
Add "Show Component Name" feature

### DIFF
--- a/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
+++ b/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt
@@ -140,7 +140,10 @@ fun CustomizeAppDialog(
         defaultTitle = defaultTitle,
         launchSelectIcon = if (prefs.enableIconSelection.get()) openIconPicker else null,
     ) {
-        PreferenceGroup {
+        PreferenceGroup(
+            description = componentKey.componentName.flattenToString(),
+            showDescription = prefs.showComponentName.get()
+        ) {
             val stringKey = componentKey.toString()
             var hiddenApps by prefs.hiddenAppSet.getAdapter()
             val adapter = customPreferenceAdapter(

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
@@ -123,6 +123,7 @@ class PreferenceManager private constructor(private val context: Context) : Base
     val searchResultSettings = BoolPref("pref_searchResultSettings", false)
 
     val enableIconSelection = BoolPref("pref_enableIconSelection", false)
+    val showComponentName = BoolPref("pref_showComponentName", false)
     val themedIcons = BoolPref("themed_icons", false)
     val hotseatQsbCornerRadius = FloatPref("pref_hotseatQsbCornerRadius", 1F, recreate)
     val themedHotseatQsb = BoolPref("pref_themedHotseatQsb", false)

--- a/lawnchair/src/app/lawnchair/ui/preferences/DebugMenuPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/DebugMenuPreferences.kt
@@ -59,6 +59,7 @@ fun DebugMenuPreferences() {
 private fun PreferenceManager.getDebugFlags(): List<PrefEntry<Boolean>> {
     return listOf(
         enableIconSelection,
+        showComponentName,
         themedIcons,
         deviceSearch,
         searchResultShortcuts,


### PR DESCRIPTION
This new preference would allow developers and designers who want to contribute to https://github.com/LawnchairLauncher/lawnicons or any other icon pack to easily obtain the component name (package name and activity name) of the target app if needed.

By default, the flag is set to false, but it can be enabled in the Debug menu. Once enabled, the component name of any app can be seen under the Customize dialog (accessible from both the app drawer and the home screen) thanks to the `description` and `showDescription` parameters of the `PreferenceGroup` component. Here's how it looks like:

![feature/show-component-name](https://user-images.githubusercontent.com/9381261/152830851-226cf804-7ed5-4719-ac61-404d2213e614.png)
