### PR TITLE
Move all preference defaults to resources 

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -37,4 +37,34 @@
     <!-- Which QSB search provider to use by default -->
     <string name="config_default_qsb_search_provider_id" translatable="false">google</string>
 
+
+    <!-- Which icon shape to use by default -->
+    <string name="config_default_icon_shape" translatable="false">circle</string>
+
+    <bool name="config_default_dark_status_bar">false</bool>
+    <bool name="config_default_dock_search_bar">true</bool>
+    <bool name="config_default_themed_hotseat_qsb">false</bool>
+    <bool name="config_default_dock_search_bar_force_website">false</bool>
+    <bool name="config_default_rounded_widgets">true</bool>
+    <bool name="config_default_show_status_bar">true</bool>
+    <bool name="config_default_show_top_shadow">true</bool>
+    <bool name="config_default_hide_app_drawer_search_bar">false</bool>
+    <bool name="config_default_enable_font_selection">true</bool>
+    <bool name="config_default_dts2">true</bool>
+    <bool name="config_default_auto_show_keyboard_in_drawer">false</bool>
+    <bool name="config_default_show_icon_labels_on_home_screen">true</bool>
+    <bool name="config_default_show_icon_labels_in_drawer">true</bool>
+    <bool name="config_default_enable_fuzzy_search">false</bool>
+    <bool name="config_default_enable_smartspace">true</bool>
+    <bool name="config_default_enable_feed">true</bool>
+    <bool name="config_default_enable_icon_selection">false</bool>
+    <bool name="config_default_show_component_names">false</bool>
+
+    <item name="config_default_home_icon_size_factor" type="dimen" format="float">1.0</item>
+    <item name="config_default_folder_preview_background_opacity" type="dimen" format="float">1.0</item>
+    <item name="config_default_drawer_icon_size_factor" type="dimen" format="float">1.0</item>
+    <item name="config_default_home_icon_label_size_factor" type="dimen" format="float">1.0</item>
+    <item name="config_default_drawer_icon_label_size_factor" type="dimen" format="float">1.0</item>
+    <item name="config_default_drawer_cell_height_factor" type="dimen" format="float">1.0</item>
+
 </resources>

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -33,4 +33,8 @@
         <!-- Lawnchair -->
         <item>@string/launcher_component</item>
     </string-array>
+
+    <!-- Which QSB search provider to use by default -->
+    <string name="config_default_qsb_search_provider_id" translatable="false">google</string>
+
 </resources>

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -37,7 +37,6 @@
     <!-- Which QSB search provider to use by default -->
     <string name="config_default_qsb_search_provider_id" translatable="false">google</string>
 
-
     <!-- Which icon shape to use by default -->
     <string name="config_default_icon_shape" translatable="false">circle</string>
 

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -33,7 +33,9 @@ import app.lawnchair.icons.shape.IconShapeManager
 import app.lawnchair.qsb.providers.QsbSearchProvider
 import app.lawnchair.theme.color.ColorOption
 import com.android.launcher3.InvariantDeviceProfile
+import com.android.launcher3.R
 import com.android.launcher3.Utilities
+import com.android.launcher3.util.DynamicResource
 import com.android.launcher3.util.MainThreadInitializedObject
 import com.patrykmichalik.preferencemanager.PreferenceManager
 import kotlinx.coroutines.CoroutineScope
@@ -59,25 +61,25 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
 
     val darkStatusBar = preference(
         key = booleanPreferencesKey(name = "dark_status_bar"),
-        defaultValue = false,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_dark_status_bar),
     )
 
     val hotseatQsb = preference(
         key = booleanPreferencesKey(name = "dock_search_bar"),
-        defaultValue = true,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_dock_search_bar),
         onSet = { reloadHelper.restart() },
     )
 
     val iconShape = preference(
         key = stringPreferencesKey(name = "icon_shape"),
-        defaultValue = IconShape.Circle,
+        defaultValue = IconShape.fromString(context.getString(R.string.config_default_icon_shape)) ?: IconShape.Circle,
         parse = { IconShape.fromString(it) ?: IconShapeManager.getSystemIconShape(context) },
         save = { it.toString() },
     )
 
     val themedHotseatQsb = preference(
         key = booleanPreferencesKey(name = "themed_hotseat_qsb"),
-        defaultValue = false,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_themed_hotseat_qsb),
     )
 
     val hotseatQsbProvider = preference(
@@ -90,7 +92,7 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
 
     val hotseatQsbForceWebsite = preference(
         key = booleanPreferencesKey(name = "dock_search_bar_force_website"),
-        defaultValue = false,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_dock_search_bar_force_website),
     )
 
     val accentColor = preference(
@@ -112,28 +114,28 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
 
     val roundedWidgets = preference(
         key = booleanPreferencesKey(name = "rounded_widgets"),
-        defaultValue = true,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_rounded_widgets),
         onSet = { reloadHelper.reloadGrid() },
     )
 
     val showStatusBar = preference(
         key = booleanPreferencesKey(name = "show_status_bar"),
-        defaultValue = true,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_show_status_bar),
     )
 
     val showTopShadow = preference(
         key = booleanPreferencesKey(name = "show_top_shadow"),
-        defaultValue = true,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_show_top_shadow),
     )
 
     val hideAppDrawerSearchBar = preference(
         key = booleanPreferencesKey(name = "hide_app_drawer_search_bar"),
-        defaultValue = false,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_hide_app_drawer_search_bar),
     )
 
     val enableFontSelection = preference(
         key = booleanPreferencesKey(name = "enable_font_selection"),
-        defaultValue = true,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_enable_font_selection),
         onSet = { newValue ->
             if (!newValue) {
                 val fontCache = FontCache.INSTANCE.get(context)
@@ -144,82 +146,82 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
 
     val dt2s = preference(
         key = booleanPreferencesKey(name = "dt2s"),
-        defaultValue = true,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_dts2),
     )
 
     val autoShowKeyboardInDrawer = preference(
         key = booleanPreferencesKey(name = "auto_show_keyboard_in_drawer"),
-        defaultValue = false,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_auto_show_keyboard_in_drawer),
     )
 
     val homeIconSizeFactor = preference(
         key = floatPreferencesKey(name = "home_icon_size_factor"),
-        defaultValue = 1F,
+        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_home_icon_size_factor),
         onSet = { reloadHelper.reloadIcons() },
     )
 
     val folderPreviewBackgroundOpacity = preference(
         key = floatPreferencesKey(name = "folder_preview_background_opacity"),
-        defaultValue = 1F,
+        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_folder_preview_background_opacity),
         onSet = { reloadHelper.reloadIcons() },
     )
 
     val showIconLabelsOnHomeScreen = preference(
         key = booleanPreferencesKey(name = "show_icon_labels_on_home_screen"),
-        defaultValue = true,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_show_icon_labels_on_home_screen),
         onSet = { reloadHelper.reloadGrid() },
     )
 
     val drawerIconSizeFactor = preference(
         key = floatPreferencesKey(name = "drawer_icon_size_factor"),
-        defaultValue = 1F,
+        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_drawer_icon_size_factor),
         onSet = { reloadHelper.reloadIcons() },
     )
 
     val showIconLabelsInDrawer = preference(
         key = booleanPreferencesKey(name = "show_icon_labels_in_drawer"),
-        defaultValue = true,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_show_icon_labels_in_drawer),
         onSet = { reloadHelper.reloadGrid() },
     )
 
     val homeIconLabelSizeFactor = preference(
         key = floatPreferencesKey(name = "home_icon_label_size_factor"),
-        defaultValue = 1F,
+        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_home_icon_label_size_factor),
         onSet = { reloadHelper.reloadGrid() },
     )
 
     val drawerIconLabelSizeFactor = preference(
         key = floatPreferencesKey(name = "drawer_icon_label_size_factor"),
-        defaultValue = 1F,
+        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_drawer_icon_label_size_factor),
         onSet = { reloadHelper.reloadGrid() },
     )
 
     val drawerCellHeightFactor = preference(
         key = floatPreferencesKey(name = "drawer_cell_height_factor"),
-        defaultValue = 1F,
+        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_drawer_cell_height_factor),
         onSet = { reloadHelper.reloadGrid() },
     )
 
     val enableFuzzySearch = preference(
         key = booleanPreferencesKey(name = "enable_fuzzy_search"),
-        defaultValue = false,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_enable_fuzzy_search),
     )
 
     val enableSmartspace = preference(
         key = booleanPreferencesKey(name = "enable_smartspace"),
-        defaultValue = true,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_enable_smartspace),
         onSet = { reloadHelper.restart() },
     )
 
     val enableFeed = preference(
         key = booleanPreferencesKey(name = "enable_feed"),
-        defaultValue = true,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_enable_feed),
         onSet = { reloadHelper.recreate() },
     )
 
     val enableIconSelection = preference(
         key = booleanPreferencesKey(name = "enable_icon_selection"),
-        defaultValue = false,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_enable_icon_selection),
         onSet = {
             if (!it) {
                 val iconOverrideRepository = IconOverrideRepository.INSTANCE.get(context)
@@ -232,7 +234,7 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
 
     val showComponentNames = preference(
         key = booleanPreferencesKey(name = "show_component_names"),
-        defaultValue = false,
+        defaultValue = context.resources.getBoolean(R.bool.config_default_show_component_names),
     )
 
     val drawerColumns = idpPreference(

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -45,6 +45,8 @@ import app.lawnchair.preferences.PreferenceManager as LawnchairPreferenceManager
 
 class PreferenceManager2(private val context: Context) : PreferenceManager {
 
+    private val resourceProvider = DynamicResource.provider(context)
+
     private fun idpPreference(
         key: Preferences.Key<Int>,
         defaultSelector: InvariantDeviceProfile.GridOption.() -> Int,
@@ -156,13 +158,13 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
 
     val homeIconSizeFactor = preference(
         key = floatPreferencesKey(name = "home_icon_size_factor"),
-        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_home_icon_size_factor),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_home_icon_size_factor),
         onSet = { reloadHelper.reloadIcons() },
     )
 
     val folderPreviewBackgroundOpacity = preference(
         key = floatPreferencesKey(name = "folder_preview_background_opacity"),
-        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_folder_preview_background_opacity),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_folder_preview_background_opacity),
         onSet = { reloadHelper.reloadIcons() },
     )
 
@@ -174,7 +176,7 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
 
     val drawerIconSizeFactor = preference(
         key = floatPreferencesKey(name = "drawer_icon_size_factor"),
-        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_drawer_icon_size_factor),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_drawer_icon_size_factor),
         onSet = { reloadHelper.reloadIcons() },
     )
 
@@ -186,19 +188,19 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
 
     val homeIconLabelSizeFactor = preference(
         key = floatPreferencesKey(name = "home_icon_label_size_factor"),
-        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_home_icon_label_size_factor),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_home_icon_label_size_factor),
         onSet = { reloadHelper.reloadGrid() },
     )
 
     val drawerIconLabelSizeFactor = preference(
         key = floatPreferencesKey(name = "drawer_icon_label_size_factor"),
-        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_drawer_icon_label_size_factor),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_drawer_icon_label_size_factor),
         onSet = { reloadHelper.reloadGrid() },
     )
 
     val drawerCellHeightFactor = preference(
         key = floatPreferencesKey(name = "drawer_cell_height_factor"),
-        defaultValue = DynamicResource.provider(context).getFloat(R.dimen.config_default_drawer_cell_height_factor),
+        defaultValue = resourceProvider.getFloat(R.dimen.config_default_drawer_cell_height_factor),
         onSet = { reloadHelper.reloadGrid() },
     )
 

--- a/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
@@ -57,10 +57,29 @@ open class QsbSearchProvider(
         fun fromId(id: String): QsbSearchProvider =
             values().firstOrNull { it.id == id } ?: AppSearch
 
-        fun resolveDefault(context: Context): QsbSearchProvider =
-            values()
+        /**
+         * Resolve the default search provider.
+         */
+        fun resolveDefault(context: Context): QsbSearchProvider {
+            val defaultProviderId = context.getString(R.string.config_default_qsb_search_provider_id)
+            val defaultProvider = fromId(defaultProviderId)
+            val isDefaultProviderIntentResolved = QsbLayout.resolveIntent(context, defaultProvider.createSearchIntent())
+
+            // Return the default value from config.xml if the value is valid
+            if (isDefaultProviderIntentResolved) {
+                if (defaultProvider != AppSearch ||
+                    (defaultProvider == AppSearch && defaultProviderId == AppSearch.id)) {
+                    return defaultProvider
+                }
+            }
+
+            // Return the best default option if the config.xml value is invalid
+            return values()
                 .filterNot { it == AppSearch }
                 .firstOrNull { QsbLayout.resolveIntent(context, it.createSearchIntent()) }
                 ?: AppSearch
+
+        }
+
     }
 }


### PR DESCRIPTION
Having default values in resources helps custom ROMs to setup desired config by creating "Runtime Resource Overlays (RROs)" on system image

On 9 version we had some prefs on res: https://github.com/LawnchairLauncher/lawnchair/blob/9-dev/lawnchair/res/values/config.xml

Sample of RRO on POSP (LawnConf): https://github.com/PotatoProject/vendor_potato/tree/baked-release/packages/overlays/Common/LawnchairConfig