### PR TITLE
Add missing icon shapes to the preferences GUI

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -151,8 +151,13 @@
     <string name="icon_shape_label">Icon Shape</string>
     <string name="icon_shape_system">System</string>
     <string name="icon_shape_circle">Circle</string>
+    <string name="icon_shape_square">Square</string>
     <string name="icon_shape_rounded_square">Rounded Square</string>
     <string name="icon_shape_squircle">Squircle</string>
+    <string name="icon_shape_sammy">One UI</string>
+    <string name="icon_shape_teardrop">Teardrop</string>
+    <string name="icon_shape_cylinder">Cylinder</string>
+    <string name="icon_shape_cupertino">Cupertino</string>
 
     <string name="customize_button_text">Customize</string>
     <string name="app_title_label">Title</string>

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/IconShapePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/IconShapePreference.kt
@@ -39,9 +39,14 @@ fun PreferenceCollectorScope.IconShapePreference(
         listOf<ListPreferenceEntry2<IconShape>>(
             ListPreferenceEntry2(systemShape) { stringResource(id = R.string.icon_shape_system) },
             ListPreferenceEntry2(IconShape.Circle) { stringResource(id = R.string.icon_shape_circle) },
-            ListPreferenceEntry2(IconShape.Cupertino) { stringResource(id = R.string.icon_shape_rounded_square) },
+            ListPreferenceEntry2(IconShape.Square) { stringResource(id = R.string.icon_shape_square) },
+            ListPreferenceEntry2(IconShape.RoundedSquare) { stringResource(id = R.string.icon_shape_rounded_square) },
             ListPreferenceEntry2(IconShape.Squircle) { stringResource(id = R.string.icon_shape_squircle) },
-        )
+            ListPreferenceEntry2(IconShape.Sammy) { stringResource(id = R.string.icon_shape_sammy) },
+            ListPreferenceEntry2(IconShape.Teardrop) { stringResource(id = R.string.icon_shape_teardrop) },
+            ListPreferenceEntry2(IconShape.Cylinder) { stringResource(id = R.string.icon_shape_cylinder) },
+            ListPreferenceEntry2(IconShape.Cupertino) { stringResource(id = R.string.icon_shape_cupertino) },
+            )
     }
 
     ListPreference2(


### PR DESCRIPTION
There are only 3 icon shape options (excluding *System*) in the GUI but internally Lawnchair 12 supports 8 icon shapes. Based on my testing they all work and are unique. This PR adds them all to the preferences GUI.

Old/Current icon shapes list:
![photo_2022-04-21_12-30-14](https://user-images.githubusercontent.com/41836211/164410564-aab00de4-4bfe-40b8-9d96-a81e89cc8e96.jpg)

New icon shapes list:
![photo_2022-04-21_12-54-55](https://user-images.githubusercontent.com/41836211/164412893-3a0b6926-709b-4316-8f28-c29e9552b457.jpg)

On the previous GUI, `Cupertino` is named *Rounded Square*. Since I wanted to add all of the options and `RoundedSquare` is another shape, `Cupertino` is now named *Cupertino* in the GUI. All the options in the GUI match the shape names in the code now except `Sammy` which is shown as *One UI* in the preferences GUI since based on #2541 it looks like that should be the name the users see.