### PR TITLE
Notification count support for Notification Dots

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -44,6 +44,7 @@
 
     <bool name="config_default_dark_status_bar">false</bool>
     <bool name="config_default_dock_search_bar">true</bool>
+    <bool name="config_default_show_notification_count">false</bool>
     <bool name="config_default_themed_hotseat_qsb">false</bool>
     <bool name="config_default_dock_search_bar_force_website">false</bool>
     <bool name="config_default_rounded_widgets">true</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -225,6 +225,7 @@
     <string name="always_open_website_description">Open search provider’s website even if their app is installed.</string>
     <string name="search_provider">Search Provider</string>
     <string name="status_bar_label">Status Bar</string>
+    <string name="show_notification_count">Show Notification Count</string>
     <string name="icon_picker_load_failed">Couldn’t load more icons.</string>
     <string name="reset_custom_icons">Reset Custom Icons</string>
     <string name="reset_custom_icons_confirmation">All custom icons will be reset. Do you want to continue?</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -78,6 +78,12 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         save = { it.toString() },
     )
 
+    val showNotificationCount = preference(
+        key = booleanPreferencesKey(name = "show_notification_count"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_show_notification_count),
+        onSet = { reloadHelper.restart() },
+    )
+
     val themedHotseatQsb = preference(
         key = booleanPreferencesKey(name = "themed_hotseat_qsb"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_themed_hotseat_qsb),

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -81,7 +81,7 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
     val showNotificationCount = preference(
         key = booleanPreferencesKey(name = "show_notification_count"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_show_notification_count),
-        onSet = { reloadHelper.restart() },
+        onSet = { reloadHelper.reloadGrid() },
     )
 
     val themedHotseatQsb = preference(

--- a/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
@@ -73,14 +73,10 @@ fun GeneralPreferences() {
             val enabled by remember { notificationDotsEnabled(context) }.collectAsState(initial = false)
             val serviceEnabled = notificationServiceEnabled()
             NotificationDotsPreference(enabled = enabled, serviceEnabled = serviceEnabled)
-            AnimatedVisibility(
-                visible = enabled && serviceEnabled,
-                enter = expandVertically() + fadeIn(),
-                exit = shrinkVertically() + fadeOut()
-            ) {
+            if (enabled && serviceEnabled) {
                 SwitchPreference(
                     adapter = prefs2.showNotificationCount.getAdapter(),
-                    label = stringResource(id = R.string.show_notification_count)
+                    label = stringResource(id = R.string.show_notification_count),
                 )
             }
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
@@ -21,6 +21,8 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavGraphBuilder
 import app.lawnchair.preferences.getAdapter
@@ -52,7 +54,6 @@ fun GeneralPreferences() {
                 label = stringResource(id = R.string.home_screen_rotation_label),
                 description = stringResource(id = R.string.home_screen_rotaton_description),
             )
-            NotificationDotsPreference()
             NavigationActionPreference(
                 label = stringResource(id = R.string.icon_pack),
                 destination = subRoute(name = GeneralRoutes.ICON_PACK),
@@ -64,6 +65,22 @@ fun GeneralPreferences() {
                 FontPreference(
                     fontPref = prefs.fontWorkspace,
                     label = stringResource(id = R.string.font_label),
+                )
+            }
+        }
+        PreferenceGroup(heading = stringResource(id = R.string.notification_dots)) {
+            val context = LocalContext.current
+            val enabled by remember { notificationDotsEnabled(context) }.collectAsState(initial = false)
+            val serviceEnabled = notificationServiceEnabled()
+            NotificationDotsPreference(enabled = enabled, serviceEnabled = serviceEnabled)
+            AnimatedVisibility(
+                visible = enabled && serviceEnabled,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                SwitchPreference(
+                    adapter = prefs2.showNotificationCount.getAdapter(),
+                    label = stringResource(id = R.string.show_notification_count)
                 )
             }
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/NotificationDotsPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/NotificationDotsPreference.kt
@@ -48,11 +48,9 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 
 @Composable
-fun NotificationDotsPreference() {
+fun NotificationDotsPreference(enabled: Boolean, serviceEnabled: Boolean) {
     val bottomSheetHandler = bottomSheetHandler
     val context = LocalContext.current
-    val enabled by remember { notificationDotsEnabled(context) }.collectAsState(initial = false)
-    val serviceEnabled = notificationServiceEnabled()
     val showWarning = enabled && !serviceEnabled
     val summary = when {
         showWarning -> R.string.missing_notification_access_description

--- a/src/com/android/launcher3/BubbleTextView.java
+++ b/src/com/android/launcher3/BubbleTextView.java
@@ -568,7 +568,7 @@ public class BubbleTextView extends TextView implements ItemInfoUpdateReceiver,
             final int scrollX = getScrollX();
             final int scrollY = getScrollY();
             canvas.translate(scrollX, scrollY);
-            mDotRenderer.draw(canvas, mDotParams);
+            mDotRenderer.draw(canvas, mDotParams, mDotInfo == null ? -1 : mDotInfo.getNotificationCount());
             canvas.translate(-scrollX, -scrollY);
         }
     }

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -31,8 +31,10 @@ import android.graphics.Path;
 import android.graphics.Point;
 import android.graphics.PointF;
 import android.graphics.Rect;
+import android.graphics.Typeface;
 import android.util.DisplayMetrics;
 import android.view.Surface;
+import androidx.core.content.res.ResourcesCompat;
 
 import com.android.launcher3.CellLayout.ContainerType;
 import com.android.launcher3.DevicePaddings.DevicePadding;
@@ -487,11 +489,20 @@ public class DeviceProfile {
         flingToDeleteThresholdVelocity = res.getDimensionPixelSize(
                 R.dimen.drag_flingToDeleteMinVelocity);
 
+        // Check if notification dots should show the notification count
+        boolean showNotificationCount = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getShowNotificationCount());
+
+        // Load the default font to use on notification dots
+        Typeface typeface = null;
+        if (showNotificationCount) {
+            typeface = ResourcesCompat.getFont(context, R.font.inter_regular);
+        }
+
         // This is done last, after iconSizePx is calculated above.
         Path dotPath = GraphicsUtils.getShapePath(DEFAULT_DOT_SIZE);
-        mDotRendererWorkSpace = new DotRenderer(iconSizePx, dotPath, DEFAULT_DOT_SIZE);
+        mDotRendererWorkSpace = new DotRenderer(iconSizePx, dotPath, DEFAULT_DOT_SIZE, showNotificationCount, typeface);
         mDotRendererAllApps = iconSizePx == allAppsIconSizePx ? mDotRendererWorkSpace :
-                new DotRenderer(allAppsIconSizePx, dotPath, DEFAULT_DOT_SIZE);
+                new DotRenderer(allAppsIconSizePx, dotPath, DEFAULT_DOT_SIZE, showNotificationCount, typeface);
     }
 
     private int getHorizontalMarginPx(InvariantDeviceProfile idp, Resources res) {

--- a/src/com/android/launcher3/folder/FolderIcon.java
+++ b/src/com/android/launcher3/folder/FolderIcon.java
@@ -640,7 +640,7 @@ public class FolderIcon extends FrameLayout implements FolderListener, IconLabel
             // If we are animating to the accepting state, animate the dot out.
             mDotParams.scale = Math.max(0, mDotScale - mBackground.getScaleProgress());
             mDotParams.color = mBackground.getDotColor();
-            mDotRenderer.draw(canvas, mDotParams);
+            mDotRenderer.draw(canvas, mDotParams, mDotInfo == null ? -1 : mDotInfo.getNotificationCount());
         }
     }
 


### PR DESCRIPTION
Adds notification counter support to Notification Dots & the option to toggle it on the preferences GUI.
The commit that platform_frameworks_libs_systemui is pointing to does not exist on the remote and you need to check out [the other part of the PR on systemui_libs](https://github.com/LawnchairLauncher/platform_frameworks_libs_systemui/pull/1).

The actual drawing of the counter texts happens on `systemui_libs`' `DotRenderer` and the changes on this merge request only add the functionality of passing the required data to it.

Currently, it always passes the default typeface to `DotRenderer` as font selection is still experimental, and in my tests, it did not always work as expected. For now, I just manually get the default typeface (which looks to be *inter_regular*) and pass it to `DotRenderer` but I am going to start working on custom font support once this PR pair is merged.