### PR TITLE
Fix npe, gesture stuck issue

### DIFF
--- a/quickstep/src/com/android/quickstep/AbsSwipeUpHandler.java
+++ b/quickstep/src/com/android/quickstep/AbsSwipeUpHandler.java
@@ -427,12 +427,10 @@ public abstract class AbsSwipeUpHandler<T extends StatefulActivity<S>,
                 HashMap<Integer, ThumbnailData> snapshots =
                         mGestureState.consumeRecentsAnimationCanceledSnapshot();
                 if (snapshots != null) {
-                    mRecentsView.switchToScreenshot(snapshots, () -> {
-                        if (mRecentsAnimationController != null) {
-                            mRecentsAnimationController.cleanupScreenshot();
-                        }
-                    });
                     mRecentsView.onRecentsAnimationComplete();
+                    if (mRecentsAnimationController != null) {
+                        mRecentsAnimationController.cleanupScreenshot();
+                    }
                 }
             });
 

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -605,7 +605,10 @@ public class Workspace extends PagedView<WorkspacePageIndicator>
 
         // Recycle the QSB widget
         if (mQsb != null) {
-            ((ViewGroup) mQsb.getParent()).removeView(mQsb);
+            ViewGroup viewGroup = (ViewGroup) mQsb.getParent();
+            if (viewGroup != null) {
+                viewGroup.removeView(mQsb);
+            }
         }
 
         // Remove the pages and clear the screen models


### PR DESCRIPTION
1. First commit fixes an issue where the gesture would randomly get stuck while trying to access the recents. It occured randomly on lawnchair and all l3 launcher after 12.1. 
2. Fixes app to drawer close animation (see icon artifacts)
3. Fixes a NPE