### PR TITLE
Replace mentions of Lawnchair 12 to Lawnchair 12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Lawnchair 12
+# Lawnchair 12.1
 
 [![Build debug APK](https://github.com/LawnchairLauncher/lawnchair/actions/workflows/build_debug_apk.yml/badge.svg)](https://github.com/LawnchairLauncher/lawnchair/actions/workflows/build_debug_apk.yml)
 [![Build release APK](https://github.com/LawnchairLauncher/lawnchair/actions/workflows/build_release_apk.yml/badge.svg)](https://github.com/LawnchairLauncher/lawnchair/actions/workflows/build_release_apk.yml)
 [![Crowdin](https://badges.crowdin.net/e/188ba69d884418987f0b7f1dd55e3a4e/localized.svg)](https://lawnchair.crowdin.com/lawnchair)
 
-Lawnchair is a free, open-source home app for Android. Taking Launcher3—Android’s default home app—as a starting point, it ports Pixel Launcher features and introduces rich options for customization. This branch houses the codebase of Lawnchair 12, currently in alpha and based on Launcher3 from Android 12. For Lawnchair 9, 10, and 11, see the branches with the `9-`, `10-`, and `11-` prefixes, respectively.
+Lawnchair is a free, open-source home app for Android. Taking Launcher3—Android’s default home app—as a starting point, it ports Pixel Launcher features and introduces rich options for customization. This branch houses the codebase of Lawnchair 12.1, currently in alpha and based on Launcher3 from Android 12.1. For Lawnchair 9, 10, 11 and 12, see the branches with the `9-`, `10-`, `11-` and `12-` prefixes, respectively.
 
 ## Contribute code
 
-Whether you’ve fixed a bug or introduced a new feature, we welcome pull requests! (If you’d like to make a larger change and check with us first, you can do so via [Lawnchair’s Telegram group chat](https://t.me/lawnchairci).) To help translate Lawnchair 12 instead, please see “[Translate](#translate).”
+Whether you’ve fixed a bug or introduced a new feature, we welcome pull requests! (If you’d like to make a larger change and check with us first, you can do so via [Lawnchair’s Telegram group chat](https://t.me/lawnchairci).) To help translate Lawnchair 12.1 instead, please see “[Translate](#translate).”
 
 You can use Git to clone this repository:
 
@@ -20,17 +20,17 @@ To build the app, select the `lawnWithQuickstepDebug` build type. Should you fac
 
 Here are a few contribution tips:
 
-- [The `lawnchair` package](https://github.com/LawnchairLauncher/lawnchair/tree/12-dev/lawnchair) houses Lawnchair’s own code, whereas [the `src` package](https://github.com/LawnchairLauncher/lawnchair/tree/12-dev/src) includes a clone of the Launcher3 codebase with modifications. Generally, place new files in the former, keeping changes to the latter to a minimum.
+- [The `lawnchair` package](https://github.com/LawnchairLauncher/lawnchair/tree/12.1-dev/lawnchair) houses Lawnchair’s own code, whereas [the `src` package](https://github.com/LawnchairLauncher/lawnchair/tree/12.1-dev/src) includes a clone of the Launcher3 codebase with modifications. Generally, place new files in the former, keeping changes to the latter to a minimum.
 
 - You can use either Java or, preferably, Kotlin.
 
 - Make sure your code is logical and well formatted. If using Kotlin, see [“Coding conventions” in the Kotlin documentation](https://kotlinlang.org/docs/coding-conventions.html).
 
-- Set `12-dev` as the base branch for pull requests.
+- Set `12.1-dev` as the base branch for pull requests.
 
 ## Translate
 
-You can help translate Lawnchair 12 [on Crowdin](https://lawnchair.crowdin.com/lawnchair). Here are a few tips:
+You can help translate Lawnchair 12.1 [on Crowdin](https://lawnchair.crowdin.com/lawnchair). Here are a few tips:
 
 - When using quotation marks, insert the symbols specific to the target language, as listed in [this table](https://en.wikipedia.org/wiki/Quotation_mark#Summary_table).
 


### PR DESCRIPTION
The branch name is now `12.1` (alongside the codebase), so updating the text to be consistent.