### PR TITLE
Persian Calendar on Glance

### DIFF
--- a/AndroidManifest-common.xml
+++ b/AndroidManifest-common.xml
@@ -78,7 +78,8 @@
         android:label="@string/derived_app_name"
         android:largeHeap="@bool/config_largeHeap"
         android:restoreAnyVersion="true"
-        android:supportsRtl="true" >
+        android:supportsRtl="true"
+        tools:replace="android:label">
 
         <!-- Intent received when a session is committed -->
         <receiver

--- a/build.gradle
+++ b/build.gradle
@@ -389,6 +389,9 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-javalite:3.8.0'
     implementation 'com.github.LawnchairLauncher:oss-notices:1.0.2'
 
+    // Persian Date
+    implementation 'com.github.samanzamani:PersianDate:1.5.0'
+
     api 'com.airbnb.android:lottie:5.0.3'
 }
 

--- a/lawnchair/res/values-fa-rIR/config.xml
+++ b/lawnchair/res/values-fa-rIR/config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021, Lawnchair
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+
+    <!-- Which calendar to use on smartspace by default -->
+    <string name="config_default_smart_space_calendar" translatable="false">persian</string>
+
+</resources>

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -44,6 +44,9 @@
     <!-- Which icon shape to use by default -->
     <string name="config_default_icon_shape" translatable="false">circle</string>
 
+    <!-- Which calendar to use on smartspace by default -->
+    <string name="config_default_smart_space_calendar" translatable="false">gregorian</string>
+
     <bool name="config_default_dark_status_bar">false</bool>
     <bool name="config_default_dock_search_bar">true</bool>
     <bool name="config_default_show_notification_count">false</bool>

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -57,6 +57,7 @@
     <bool name="config_default_show_top_shadow">true</bool>
     <bool name="config_default_hide_app_drawer_search_bar">false</bool>
     <bool name="config_default_enable_font_selection">true</bool>
+    <bool name="config_default_enable_smartspace_calendar_selection">true</bool>
     <bool name="config_default_dts2">true</bool>
     <bool name="config_default_auto_show_keyboard_in_drawer">false</bool>
     <bool name="config_default_show_icon_labels_on_home_screen">true</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -216,6 +216,8 @@
     <string name="icon_picker_description">May cause Lawnchair to freeze.</string>
     <string name="font_picker_label">Font Customization</string>
     <string name="font_picker_description">Some text remains unchanged.</string>
+    <string name="smartspace_calendar_label">At a Glance Calendar Customization</string>
+    <string name="smartspace_calendar_description">Allow showing date in non-Gregorian calendar systems.</string>
     <string name="search_provider_app_search">App Search</string>
     <string name="search_provider_google" translatable="false">Google</string>
     <string name="search_provider_google_go" translatable="false">Google Go</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -233,7 +233,8 @@
 
     <!-- Smartspace -->
     <string name="generic_smartspace_concatenated_desc">%1$s, %2$s</string>
-    <string name="smartspace_icu_date_pattern" translatable="false">EEEMMMd</string>
+    <string name="smartspace_icu_date_pattern_gregorian" translatable="false">EEEMMMd</string>
+    <string name="smartspace_icu_date_pattern_persian" translatable="false">l، j F</string>
     <string name="smartspace_battery_charging">Charging</string>
     <string name="smartspace_battery_full">Charged</string>
     <string name="smartspace_battery_low">Battery Low</string>
@@ -245,12 +246,16 @@
     <string name="quickstep_incompatible_description">Your device is configured to have system gestures (known as Quickstep) provided by %1$s, but this version of %1$s is not compatible with your Android version. To continue using your device, please uninstall %1$s updates or disable %1$s as a system-gesture provider.</string>
 
     <string name="preview_label">Preview</string>
+    <string name="smartspace_calendar">Calendar</string>
     <string name="smartspace_weather">Weather</string>
     <string name="smartspace_battery_status">Battery Status</string>
     <string name="smartspace_now_playing">Now Playing</string>
     <string name="smartspace_requires_setup">Tap to Set Up</string>
     <string name="event_provider_missing_notification_dots">To use <xliff:g example="My Provider" id="providerName">%1$s</xliff:g>, enable Notification Dots.</string>
     <string name="smartspace_media_info_separator">" — "</string>
+
+    <string name="smartspace_calendar_gregorian">Gregorian</string>
+    <string name="smartspace_calendar_persian">Persian</string>
 
     <string name="pref_fonts_add_fonts">Add Fonts</string>
     <string name="pref_fonts_add_fonts_summary">OTF &amp; TTF supported.</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -155,6 +155,11 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         },
     )
 
+    val enableSmartspaceCalendarSelection = preference(
+        key = booleanPreferencesKey(name = "enable_smartspace_calendar_selection"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_enable_smartspace_calendar_selection),
+    )
+
     val dt2s = preference(
         key = booleanPreferencesKey(name = "dt2s"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_dts2),

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -26,6 +26,7 @@ import app.lawnchair.icons.CustomAdaptiveIconDrawable
 import app.lawnchair.icons.shape.IconShape
 import app.lawnchair.icons.shape.IconShapeManager
 import app.lawnchair.qsb.providers.QsbSearchProvider
+import app.lawnchair.smartspace.model.SmartspaceCalendar
 import app.lawnchair.theme.color.ColorOption
 import com.android.launcher3.InvariantDeviceProfile
 import com.android.launcher3.LauncherAppState
@@ -274,6 +275,13 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
     val smartspaceNowPlaying = preference(
         key = booleanPreferencesKey("enable_smartspace_now_playing"),
         defaultValue = true
+    )
+
+    val smartspaceCalendar = preference(
+        key = stringPreferencesKey(name = "smartspace_calendar"),
+        defaultValue = SmartspaceCalendar.fromString(context.getString(R.string.config_default_smart_space_calendar)),
+        parse = { SmartspaceCalendar.fromString(it) },
+        save = { it.toString() },
     )
 
     init {

--- a/lawnchair/src/app/lawnchair/smartspace/IcuDateTextView.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/IcuDateTextView.kt
@@ -8,11 +8,14 @@ import android.icu.text.DateFormat
 import android.icu.text.DisplayContext
 import android.os.SystemClock
 import android.util.AttributeSet
+import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.preferences2.subscribeBlocking
 import app.lawnchair.smartspace.model.SmartspaceCalendar
 import app.lawnchair.util.viewAttachedScope
 import com.android.launcher3.R
+import com.patrykmichalik.preferencemanager.first
+import com.patrykmichalik.preferencemanager.firstBlocking
 import saman.zamani.persiandate.PersianDate
 import saman.zamani.persiandate.PersianDateFormat
 import java.util.*
@@ -87,8 +90,14 @@ class IcuDateTextView @JvmOverloads constructor(
     override fun onFinishInflate() {
         super.onFinishInflate()
         preferenceManager2 = PreferenceManager2.getInstance(context)
-        preferenceManager2.smartspaceCalendar.subscribeBlocking(scope = viewAttachedScope) {
-            calendar = it
+        val calendarSelectionEnabled =
+            preferenceManager2.enableSmartspaceCalendarSelection.firstBlocking()
+        if (calendarSelectionEnabled) {
+            preferenceManager2.smartspaceCalendar.subscribeBlocking(scope = viewAttachedScope) {
+                calendar = it
+            }
+        } else {
+            calendar = preferenceManager2.smartspaceCalendar.defaultValue
         }
     }
 

--- a/lawnchair/src/app/lawnchair/smartspace/IcuDateTextView.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/IcuDateTextView.kt
@@ -8,14 +8,23 @@ import android.icu.text.DateFormat
 import android.icu.text.DisplayContext
 import android.os.SystemClock
 import android.util.AttributeSet
+import app.lawnchair.preferences2.PreferenceManager2
+import app.lawnchair.preferences2.subscribeBlocking
+import app.lawnchair.smartspace.model.SmartspaceCalendar
+import app.lawnchair.util.viewAttachedScope
 import com.android.launcher3.R
+import saman.zamani.persiandate.PersianDate
+import saman.zamani.persiandate.PersianDateFormat
 import java.util.*
 
 class IcuDateTextView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null
 ) : DoubleShadowTextView(context, attrs) {
 
-    private var formatter: DateFormat? = null
+    private lateinit var preferenceManager2: PreferenceManager2
+    private var calendar: SmartspaceCalendar? = null
+    private var formatterGregorian: DateFormat? = null
+    private var formatterPersian: PersianDateFormat? = null
     private val ticker = this::onTimeTick
     private val intentReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -39,25 +48,48 @@ class IcuDateTextView @JvmOverloads constructor(
 
     private fun onTimeChanged(updateFormatter: Boolean) {
         if (isShown) {
-            if (formatter == null || updateFormatter) {
-                val formatter: DateFormat = DateFormat.getInstanceForSkeleton(
-                    context.getString(R.string.smartspace_icu_date_pattern), Locale.getDefault()
-                )
-                this.formatter = formatter
-                formatter.setContext(DisplayContext.CAPITALIZATION_FOR_BEGINNING_OF_SENTENCE)
+            val format = when (calendar) {
+                SmartspaceCalendar.Persian -> getTimeTextPersian(updateFormatter = updateFormatter)
+                else -> getTimeTextGregorian(updateFormatter = updateFormatter)
             }
-            val format = formatter!!.format(java.lang.Long.valueOf(System.currentTimeMillis()))
             if (text != format) {
+                textAlignment =
+                    if (calendar == SmartspaceCalendar.Persian) TEXT_ALIGNMENT_TEXT_END else TEXT_ALIGNMENT_TEXT_START
                 text = format
                 contentDescription = format
             }
         }
     }
 
+    private fun getTimeTextPersian(updateFormatter: Boolean): String {
+        val formatter = formatterPersian.takeIf { updateFormatter.not() } ?: PersianDateFormat(
+            context.getString(R.string.smartspace_icu_date_pattern_persian),
+            PersianDateFormat.PersianDateNumberCharacter.FARSI,
+        ).also { formatterPersian = it }
+        return formatter.format(PersianDate(java.lang.Long.valueOf(System.currentTimeMillis())))
+    }
+
+    private fun getTimeTextGregorian(updateFormatter: Boolean): String {
+        val formatter = formatterGregorian.takeIf { updateFormatter.not() }
+            ?: DateFormat.getInstanceForSkeleton(
+                context.getString(R.string.smartspace_icu_date_pattern_gregorian),
+                Locale.getDefault()
+            ).also { formatterGregorian = it }
+        return formatter.format(java.lang.Long.valueOf(System.currentTimeMillis()))
+    }
+
     private fun onTimeTick() {
         onTimeChanged(false)
         val uptimeMillis: Long = SystemClock.uptimeMillis()
         handler?.postAtTime(ticker, uptimeMillis + (1000 - uptimeMillis % 1000))
+    }
+
+    override fun onFinishInflate() {
+        super.onFinishInflate()
+        preferenceManager2 = PreferenceManager2.getInstance(context)
+        preferenceManager2.smartspaceCalendar.subscribeBlocking(scope = viewAttachedScope) {
+            calendar = it
+        }
     }
 
     override fun onVisibilityAggregated(isVisible: Boolean) {

--- a/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceCalendar.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceCalendar.kt
@@ -1,0 +1,31 @@
+package app.lawnchair.smartspace.model
+
+import androidx.annotation.StringRes
+import com.android.launcher3.R
+
+/**
+ * Contains the data of a single calendar system for smartspace.
+ */
+open class SmartspaceCalendar(@StringRes val nameResourceId: Int) {
+
+    companion object {
+
+        fun fromString(value: String): SmartspaceCalendar = when (value) {
+            "persian" -> Persian
+            else -> Gregorian
+        }
+
+        /**
+         * @return The list of all calendars.
+         */
+        fun values() = listOf(Gregorian, Persian)
+    }
+
+    object Gregorian : SmartspaceCalendar(nameResourceId = R.string.smartspace_calendar_gregorian) {
+        override fun toString() = "gregorian"
+    }
+    object Persian : SmartspaceCalendar(nameResourceId = R.string.smartspace_calendar_persian) {
+        override fun toString() = "persian"
+    }
+
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/ExperimentalFeaturesPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/ExperimentalFeaturesPreferences.kt
@@ -24,6 +24,11 @@ fun ExperimentalFeaturesPreferences() {
                 label = stringResource(id = R.string.font_picker_label),
                 description = stringResource(id = R.string.font_picker_description),
             )
+            SwitchPreference(
+                adapter = prefs.enableSmartspaceCalendarSelection.getAdapter(),
+                label = stringResource(id = R.string.smartspace_calendar_label),
+                description = stringResource(id = R.string.smartspace_calendar_description),
+            )
         }
     }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
@@ -21,7 +21,10 @@ import androidx.navigation.NavGraphBuilder
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.smartspace.SmartspaceViewContainer
+import app.lawnchair.smartspace.model.SmartspaceCalendar
 import app.lawnchair.smartspace.provider.SmartspaceProvider
+import app.lawnchair.ui.preferences.components.ListPreference
+import app.lawnchair.ui.preferences.components.ListPreferenceEntry
 import app.lawnchair.ui.preferences.components.PreferenceGroup
 import app.lawnchair.ui.preferences.components.PreferenceLayout
 import app.lawnchair.ui.preferences.components.SwitchPreference
@@ -59,6 +62,7 @@ fun SmartspacePreferences(fromWidget: Boolean) {
                         heading = stringResource(id = R.string.what_to_show),
                         modifier = Modifier.padding(top = 8.dp),
                     ) {
+                        SmartspaceCalendarPreference()
                         smartspaceProvider.dataSources
                             .filter { it.isAvailable }
                             .forEach {
@@ -105,3 +109,22 @@ fun SmartspacePreview() {
         }
     }
 }
+
+@Composable
+fun SmartspaceCalendarPreference() {
+
+    val entries = remember {
+        SmartspaceCalendar.values().map { calendar ->
+            ListPreferenceEntry(calendar) { stringResource(id = calendar.nameResourceId) }
+        }
+    }
+
+    val adapter = preferenceManager2().smartspaceCalendar.getAdapter()
+
+    ListPreference(
+        adapter = adapter,
+        entries = entries,
+        label = stringResource(id = R.string.smartspace_calendar),
+    )
+}
+

--- a/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
@@ -62,7 +62,11 @@ fun SmartspacePreferences(fromWidget: Boolean) {
                         heading = stringResource(id = R.string.what_to_show),
                         modifier = Modifier.padding(top = 8.dp),
                     ) {
-                        SmartspaceCalendarPreference()
+                        val calendarSelectionEnabled =
+                            preferenceManager2.enableSmartspaceCalendarSelection.getAdapter()
+                        if (calendarSelectionEnabled.state.value) {
+                            SmartspaceCalendarPreference()
+                        }
                         smartspaceProvider.dataSources
                             .filter { it.isAvailable }
                             .forEach {


### PR DESCRIPTION
Adds Persian Calendar support to Glance + A system to manually reload the date content on Glance as it was not previously possible.

The changes also allow other contributors to add their own local calendar system to the project easily.

The Persian Date is always shown in Farsi for now but I will create an additional PR to make the Persian Date respect the language of the device later on as the library used for the Persian Date does not support this feature (yet).