### PR TITLE
Time on Glance

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -67,6 +67,9 @@
     <bool name="config_default_enable_feed">true</bool>
     <bool name="config_default_enable_icon_selection">false</bool>
     <bool name="config_default_show_component_names">false</bool>
+    <bool name="config_default_smartspace_show_date">true</bool>
+    <bool name="config_default_smartspace_show_time">false</bool>
+    <bool name="config_default_smartspace_24_hour_format">false</bool>
 
     <item name="config_default_home_icon_size_factor" type="dimen" format="float">1.0</item>
     <item name="config_default_folder_preview_background_opacity" type="dimen" format="float">1.0</item>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -235,7 +235,10 @@
 
     <!-- Smartspace -->
     <string name="generic_smartspace_concatenated_desc">%1$s, %2$s</string>
-    <string name="smartspace_icu_date_pattern_gregorian" translatable="false">EEEMMMd</string>
+    <string name="smartspace_icu_date_pattern_gregorian_wday_month_day_no_year" translatable="false">EEEMMMd</string>
+    <string name="smartspace_icu_date_pattern_gregorian_time" translatable="false">HH:mm</string>
+    <string name="smartspace_icu_date_pattern_gregorian_time_12h" translatable="false">hh:mm aa</string>
+    <string name="smartspace_icu_date_pattern_gregorian_date" translatable="false"> dd MMMM</string>
     <string name="smartspace_icu_date_pattern_persian" translatable="false">l، j F</string>
     <string name="smartspace_battery_charging">Charging</string>
     <string name="smartspace_battery_full">Charged</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -249,6 +249,10 @@
 
     <string name="preview_label">Preview</string>
     <string name="smartspace_calendar">Calendar</string>
+    <string name="smartspace_date_and_time">Date &amp; Time</string>
+    <string name="smartspace_date">Date</string>
+    <string name="smartspace_time">Time</string>
+    <string name="smartspace_time_24_hour_format">24-Hour Format</string>
     <string name="smartspace_weather">Weather</string>
     <string name="smartspace_battery_status">Battery Status</string>
     <string name="smartspace_now_playing">Now Playing</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -282,6 +282,21 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         defaultValue = true
     )
 
+    val smartspaceShowDate = preference(
+        key = booleanPreferencesKey("smartspace_show_date"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_smartspace_show_date),
+    )
+
+    val smartspaceShowTime = preference(
+        key = booleanPreferencesKey("smartspace_show_time"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_smartspace_show_time),
+    )
+
+    val smartspace24HourFormat = preference(
+        key = booleanPreferencesKey("smartspace_24_hour_format"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_smartspace_24_hour_format),
+    )
+
     val smartspaceCalendar = preference(
         key = stringPreferencesKey(name = "smartspace_calendar"),
         defaultValue = SmartspaceCalendar.fromString(context.getString(R.string.config_default_smart_space_calendar)),

--- a/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
-import androidx.compose.animation.Crossfade
+import androidx.compose.animation.*
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -62,11 +62,6 @@ fun SmartspacePreferences(fromWidget: Boolean) {
                         heading = stringResource(id = R.string.what_to_show),
                         modifier = Modifier.padding(top = 8.dp),
                     ) {
-                        val calendarSelectionEnabled =
-                            preferenceManager2.enableSmartspaceCalendarSelection.getAdapter()
-                        if (calendarSelectionEnabled.state.value) {
-                            SmartspaceCalendarPreference()
-                        }
                         smartspaceProvider.dataSources
                             .filter { it.isAvailable }
                             .forEach {
@@ -78,6 +73,7 @@ fun SmartspacePreferences(fromWidget: Boolean) {
                                 }
                             }
                     }
+                    SmartspaceDateAndTimePreferences()
                 }
             }
         }
@@ -110,6 +106,62 @@ fun SmartspacePreview() {
         }
         LaunchedEffect(key1 = null) {
             SmartspaceProvider.INSTANCE.get(context).startSetup(context as Activity)
+        }
+    }
+}
+
+@Composable
+fun SmartspaceDateAndTimePreferences() {
+    PreferenceGroup(
+        heading = stringResource(id = R.string.smartspace_date_and_time),
+        modifier = Modifier.padding(top = 8.dp),
+    ) {
+        val preferenceManager2 = preferenceManager2()
+
+        val calendarAdapter = preferenceManager2.smartspaceCalendar.getAdapter()
+        val showDateAdapter = preferenceManager2.smartspaceShowDate.getAdapter()
+        val showTimeAdapter = preferenceManager2.smartspaceShowTime.getAdapter()
+        val use24HourFormatAdapter = preferenceManager2.smartspace24HourFormat.getAdapter()
+
+        val calendarHasMinimumContent = !showDateAdapter.state.value or !showTimeAdapter.state.value
+        val isGregorian = calendarAdapter.state.value != SmartspaceCalendar.Persian
+
+        AnimatedVisibility(
+            visible = isGregorian,
+            enter = expandVertically() + fadeIn(),
+            exit = shrinkVertically() + fadeOut()
+        ) {
+            SwitchPreference(
+                adapter = showDateAdapter,
+                label = stringResource(id = R.string.smartspace_date),
+                enabled = if (showDateAdapter.state.value) !calendarHasMinimumContent else true,
+            )
+        }
+        AnimatedVisibility(
+            visible = isGregorian,
+            enter = expandVertically() + fadeIn(),
+            exit = shrinkVertically() + fadeOut()
+        ) {
+            SwitchPreference(
+                adapter = showTimeAdapter,
+                label = stringResource(id = R.string.smartspace_time),
+                enabled = if (showTimeAdapter.state.value) !calendarHasMinimumContent else true,
+            )
+        }
+        AnimatedVisibility(
+            visible = isGregorian && showTimeAdapter.state.value,
+            enter = expandVertically() + fadeIn(),
+            exit = shrinkVertically() + fadeOut()
+        ) {
+            SwitchPreference(
+                adapter = use24HourFormatAdapter,
+                label = stringResource(id = R.string.smartspace_time_24_hour_format),
+            )
+        }
+        val calendarSelectionEnabled =
+            preferenceManager2.enableSmartspaceCalendarSelection.getAdapter()
+        if (calendarSelectionEnabled.state.value) {
+            SmartspaceCalendarPreference()
         }
     }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
@@ -4,7 +4,12 @@ import android.app.Activity
 import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
-import androidx.compose.animation.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -123,7 +128,7 @@ fun SmartspaceDateAndTimePreferences() {
         val showTimeAdapter = preferenceManager2.smartspaceShowTime.getAdapter()
         val use24HourFormatAdapter = preferenceManager2.smartspace24HourFormat.getAdapter()
 
-        val calendarHasMinimumContent = !showDateAdapter.state.value or !showTimeAdapter.state.value
+        val calendarHasMinimumContent = !showDateAdapter.state.value || !showTimeAdapter.state.value
         val isGregorian = calendarAdapter.state.value != SmartspaceCalendar.Persian
 
         AnimatedVisibility(


### PR DESCRIPTION
Adds Date, Time (with 24-hour format toggle) options to Glance preferences. The new options will be available only for Gregorian Calendar at least for now.

The format creation is similar to how it's done on [9-dev's IcuDateTextView](https://github.com/LawnchairLauncher/lawnchair/blob/9-dev/src/com/google/android/apps/nexuslauncher/graphics/IcuDateTextView.java).

I use `subscribeBlocking` to listen to preference changes as @paphonb suggested previously on #2637 but as there are now multiple variables to observe, maybe it would be better to use the broadcast receiver method.