### PR TITLE
Fix Date & Time pref group being blank in some scenarios

### DIFF
--- a/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceCalendar.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceCalendar.kt
@@ -5,8 +5,10 @@ import com.android.launcher3.R
 
 /**
  * Contains the data of a single calendar system for smartspace.
+ *
+ * @param formatCustomizationSupport If the calendar system supports date & time format customization.
  */
-open class SmartspaceCalendar(@StringRes val nameResourceId: Int) {
+open class SmartspaceCalendar(@StringRes val nameResourceId: Int, val formatCustomizationSupport: Boolean = true) {
 
     companion object {
 
@@ -24,7 +26,7 @@ open class SmartspaceCalendar(@StringRes val nameResourceId: Int) {
     object Gregorian : SmartspaceCalendar(nameResourceId = R.string.smartspace_calendar_gregorian) {
         override fun toString() = "gregorian"
     }
-    object Persian : SmartspaceCalendar(nameResourceId = R.string.smartspace_calendar_persian) {
+    object Persian : SmartspaceCalendar(nameResourceId = R.string.smartspace_calendar_persian, formatCustomizationSupport = false) {
         override fun toString() = "persian"
     }
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
@@ -119,15 +119,21 @@ fun SmartspaceDateAndTimePreferences() {
     ) {
         val preferenceManager2 = preferenceManager2()
 
+        val calendarSelectionAdapter = preferenceManager2.enableSmartspaceCalendarSelection.getAdapter()
         val calendarAdapter = preferenceManager2.smartspaceCalendar.getAdapter()
         val showDateAdapter = preferenceManager2.smartspaceShowDate.getAdapter()
         val showTimeAdapter = preferenceManager2.smartspaceShowTime.getAdapter()
         val use24HourFormatAdapter = preferenceManager2.smartspace24HourFormat.getAdapter()
 
         val calendarHasMinimumContent = !showDateAdapter.state.value || !showTimeAdapter.state.value
-        val isGregorian = calendarAdapter.state.value != SmartspaceCalendar.Persian
 
-        ExpandAndShrink(visible = isGregorian) {
+        val calendar = if (calendarSelectionAdapter.state.value) {
+            calendarAdapter.state.value
+        } else {
+            preferenceManager2.smartspaceCalendar.defaultValue
+        }
+
+        ExpandAndShrink(visible = calendar.formatCustomizationSupport) {
             DividerColumn {
                 SwitchPreference(
                     adapter = showDateAdapter,


### PR DESCRIPTION
On the previously merged #2650 there is a small bug that this PR fixes.

If the selected calendar is Persian & then the experimental calendar customization is turned off, the "Date & Time" preference group will be blank because the code on `SmartspaceDateAndTimePreferences()` only checks the active calendar and does not take the experimental calendar system state into consideration. 

Instead of manually fixing the issue just for Persian, I added a new value to `SmartspaceCalendar` so this limitation could be enabled for other calendar systems later on easily.