### PR TITLE
Home Screen Lock

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -55,6 +55,7 @@
     <bool name="config_default_rounded_widgets">true</bool>
     <bool name="config_default_show_status_bar">true</bool>
     <bool name="config_default_show_top_shadow">true</bool>
+    <bool name="config_default_lock_home_screen">false</bool>
     <bool name="config_default_hide_app_drawer_search_bar">false</bool>
     <bool name="config_default_enable_font_selection">true</bool>
     <bool name="config_default_enable_smartspace_calendar_selection">true</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="max_folder_columns">Max. Folder Columns</string>
     <string name="max_folder_rows">Max. Folder Rows</string>
     <string name="home_screen_grid">Home Screen Grid</string>
+    <string name="home_screen_lock">Lock Home Screen</string>
     <string name="columns">Columns</string>
     <string name="grid">Grid</string>
     <string name="rows">Rows</string>
@@ -116,6 +117,7 @@
     <string name="wallpaper_scrolling_label">Scroll Wallpaper</string>
     <string name="show_sys_ui_scrim">Top Shadow</string>
     <string name="show_status_bar">Show Status Bar</string>
+    <string name="layout">Layout</string>
     <string name="what_to_show">What to Show</string>
     <string name="missing_notification_access_label">Notification Access Needed</string>
     <string name="missing_notification_access_description">Notification access needed.</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -142,6 +142,11 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         defaultValue = context.resources.getBoolean(R.bool.config_default_show_top_shadow),
     )
 
+    val lockHomeScreen = preference(
+        key = booleanPreferencesKey(name = "lock_home_screen"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_lock_home_screen),
+    )
+
     val hideAppDrawerSearchBar = preference(
         key = booleanPreferencesKey(name = "hide_app_drawer_search_bar"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_hide_app_drawer_search_bar),

--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.dp
 import app.lawnchair.LawnchairLauncher
 import app.lawnchair.override.CustomizeAppDialog
+import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.views.ComposeBottomSheet
 import com.android.launcher3.AbstractFloatingView
 import com.android.launcher3.LauncherSettings.Favorites.ITEM_TYPE_APPLICATION
@@ -16,12 +17,15 @@ import com.android.launcher3.model.data.AppInfo as ModelAppInfo
 import com.android.launcher3.model.data.ItemInfo
 import com.android.launcher3.popup.SystemShortcut
 import com.android.launcher3.util.ComponentKey
+import com.patrykmichalik.preferencemanager.firstBlocking
 
 class LawnchairShortcut {
 
     companion object {
-        val CUSTOMIZE = SystemShortcut.Factory<LawnchairLauncher> { activity, itemInfo ->
-            getAppInfo(activity, itemInfo)?.let { Customize(activity, it, itemInfo) }
+
+        val CUSTOMIZE: SystemShortcut.Factory<LawnchairLauncher> = SystemShortcut.Factory<LawnchairLauncher> { activity, itemInfo ->
+            if (PreferenceManager2.getInstance(activity).lockHomeScreen.firstBlocking()) null
+            else getAppInfo(activity, itemInfo)?.let { Customize(activity, it, itemInfo) }
         }
 
         private fun getAppInfo(launcher: LawnchairLauncher, itemInfo: ItemInfo): ModelAppInfo? {

--- a/lawnchair/src/app/lawnchair/ui/preferences/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/HomeScreenPreferences.kt
@@ -50,10 +50,14 @@ fun HomeScreenPreferences() {
     val prefs2 = preferenceManager2()
     val scope = rememberCoroutineScope()
     PreferenceLayout(label = stringResource(id = R.string.home_screen_label)) {
+        val lockHomeScreenAdapter = prefs2.lockHomeScreen.getAdapter()
         PreferenceGroup(heading = stringResource(id = R.string.general_label)) {
+            val addIconToHomeAdapter = prefs.addIconToHome.getAdapter()
             SwitchPreference(
-                prefs.addIconToHome.getAdapter(),
+                checked = !lockHomeScreenAdapter.state.value && addIconToHomeAdapter.state.value,
+                onCheckedChange = addIconToHomeAdapter::onChange,
                 label = stringResource(id = R.string.auto_add_shortcuts_label),
+                enabled = lockHomeScreenAdapter.state.value.not(),
             )
             SwitchPreference(
                 prefs.wallpaperScrolling.getAdapter(),
@@ -90,7 +94,7 @@ fun HomeScreenPreferences() {
                 subtitle = stringResource(id = R.string.x_by_y, columns, rows),
             )
             SwitchPreference(
-                adapter = prefs2.lockHomeScreen.getAdapter(),
+                adapter = lockHomeScreenAdapter,
                 label = stringResource(id = R.string.home_screen_lock),
             )
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/HomeScreenPreferences.kt
@@ -80,12 +80,18 @@ fun HomeScreenPreferences() {
                 adapter = prefs2.showTopShadow.getAdapter(),
                 label = stringResource(id = R.string.show_sys_ui_scrim),
             )
+        }
+        PreferenceGroup(heading = stringResource(id = R.string.layout)) {
             val columns by prefs.workspaceColumns.getAdapter()
             val rows by prefs.workspaceRows.getAdapter()
             NavigationActionPreference(
                 label = stringResource(id = R.string.home_screen_grid),
                 destination = subRoute(name = HomeScreenRoutes.GRID),
                 subtitle = stringResource(id = R.string.x_by_y, columns, rows),
+            )
+            SwitchPreference(
+                adapter = prefs2.lockHomeScreen.getAdapter(),
+                label = stringResource(id = R.string.home_screen_lock),
             )
         }
         PreferenceGroup(heading = stringResource(id = R.string.status_bar_label)) {

--- a/src/com/android/launcher3/SessionCommitReceiver.java
+++ b/src/com/android/launcher3/SessionCommitReceiver.java
@@ -31,6 +31,9 @@ import com.android.launcher3.logging.FileLog;
 import com.android.launcher3.model.ItemInstallQueue;
 import com.android.launcher3.pm.InstallSessionHelper;
 import com.android.launcher3.util.Executors;
+import com.patrykmichalik.preferencemanager.PreferenceExtensionsKt;
+
+import app.lawnchair.preferences2.PreferenceManager2;
 
 /**
  * BroadcastReceiver to handle session commit intent.
@@ -81,6 +84,7 @@ public class SessionCommitReceiver extends BroadcastReceiver {
     }
 
     public static boolean isEnabled(Context context) {
+        if (PreferenceExtensionsKt.firstBlocking(PreferenceManager2.getInstance(context).getLockHomeScreen())) return false;
         return Utilities.getPrefs(context).getBoolean(ADD_ICON_PREFERENCE_KEY, true);
     }
 }

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -55,6 +55,7 @@ import android.os.UserHandle;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.SparseArray;
+import android.view.HapticFeedbackConstants;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -121,6 +122,7 @@ import com.android.launcher3.widget.WidgetManagerHelper;
 import com.android.launcher3.widget.dragndrop.AppWidgetHostViewDragListener;
 import com.android.launcher3.widget.util.WidgetSizes;
 import com.android.systemui.plugins.shared.LauncherOverlayManager.LauncherOverlay;
+import com.patrykmichalik.preferencemanager.PreferenceExtensionsKt;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -130,6 +132,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.smartspace.SmartspaceAppWidgetProvider;
 
 /**
@@ -270,6 +273,8 @@ public class Workspace extends PagedView<WorkspacePageIndicator>
 
     private final StatsLogManager mStatsLogManager;
 
+    PreferenceManager2 mPreferenceManager2;
+
     /**
      * Used to inflate the Workspace from XML.
      *
@@ -293,6 +298,7 @@ public class Workspace extends PagedView<WorkspacePageIndicator>
         mLauncher = Launcher.getLauncher(context);
         mStateTransitionAnimation = new WorkspaceStateTransitionAnimation(mLauncher, this);
         mWallpaperManager = WallpaperManager.getInstance(context);
+        mPreferenceManager2 = PreferenceManager2.getInstance(context);
 
         mWallpaperOffset = new WallpaperOffsetInterpolator(this);
 
@@ -1721,6 +1727,15 @@ public class Workspace extends PagedView<WorkspacePageIndicator>
             }
         }
 
+        boolean lockHomeScreen = PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getLockHomeScreen());
+        if (lockHomeScreen) {
+            child.setVisibility(View.VISIBLE);
+
+            if (dragOptions.preDragCondition != null) {
+                mLauncher.getDragLayer().performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+            }
+            return null;
+        }
         final DragView dv;
         if (contentView instanceof View) {
             if (contentView instanceof LauncherAppWidgetHostView) {

--- a/src/com/android/launcher3/folder/FolderNameEditText.java
+++ b/src/com/android/launcher3/folder/FolderNameEditText.java
@@ -18,6 +18,7 @@ package com.android.launcher3.folder;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.inputmethod.CompletionInfo;
 import android.view.inputmethod.EditorInfo;
@@ -26,8 +27,11 @@ import android.view.inputmethod.InputConnectionWrapper;
 import android.view.inputmethod.InputMethodManager;
 
 import com.android.launcher3.ExtendedEditText;
+import com.patrykmichalik.preferencemanager.PreferenceExtensionsKt;
 
 import java.util.List;
+
+import app.lawnchair.preferences2.PreferenceManager2;
 
 /**
  * Handles additional edit text functionality to better support folder name suggestion.
@@ -38,6 +42,8 @@ import java.util.List;
 public class FolderNameEditText extends ExtendedEditText {
     private static final String TAG = "FolderNameEditText";
     private static final boolean DEBUG = false;
+
+    private final PreferenceManager2 mPreferenceManager2 = PreferenceManager2.getInstance(getContext());
 
     private boolean mEnteredCompose = false;
 
@@ -129,5 +135,11 @@ public class FolderNameEditText extends ExtendedEditText {
             }
         }
         hideKeyboard();
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getLockHomeScreen())) return true;
+        return super.onTouchEvent(event);
     }
 }

--- a/src/com/android/launcher3/popup/PopupContainerWithArrow.java
+++ b/src/com/android/launcher3/popup/PopupContainerWithArrow.java
@@ -68,6 +68,7 @@ import com.android.launcher3.util.PackageUserKey;
 import com.android.launcher3.util.ShortcutUtil;
 import com.android.launcher3.views.ActivityContext;
 import com.android.launcher3.views.BaseDragLayer;
+import com.patrykmichalik.preferencemanager.PreferenceExtensionsKt;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,6 +78,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.theme.color.ColorTokens;
 import app.lawnchair.theme.drawable.DrawableTokens;
 
@@ -87,6 +89,9 @@ import app.lawnchair.theme.drawable.DrawableTokens;
  */
 public class PopupContainerWithArrow<T extends Context & ActivityContext>
         extends ArrowPopup<T> implements DragSource, DragController.DragListener {
+
+    private final PreferenceManager2 preferenceManager2 = PreferenceManager2.getInstance(getContext());
+    private final boolean lockHomeScreen = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getLockHomeScreen());
 
     private final List<DeepShortcutView> mShortcuts = new ArrayList<>();
     private final PointF mInterceptTouchDown = new PointF();
@@ -650,6 +655,7 @@ public class PopupContainerWithArrow<T extends Context & ActivityContext>
 
         @Override
         public boolean onLongClick(View v) {
+            if (mContainer.lockHomeScreen) return false;
             if (!ItemLongClickListener.canStartDrag(mLauncher)) return false;
             // Return early if not the correct view
             if (!(v.getParent() instanceof DeepShortcutView)) return false;

--- a/src/com/android/launcher3/popup/SystemShortcut.java
+++ b/src/com/android/launcher3/popup/SystemShortcut.java
@@ -27,8 +27,11 @@ import com.android.launcher3.util.PackageManagerHelper;
 import com.android.launcher3.util.PackageUserKey;
 import com.android.launcher3.views.ActivityContext;
 import com.android.launcher3.widget.WidgetsBottomSheet;
+import com.patrykmichalik.preferencemanager.PreferenceExtensionsKt;
 
 import java.util.List;
+
+import app.lawnchair.preferences2.PreferenceManager2;
 
 /**
  * Represents a system shortcut for a given app. The shortcut should have a label and icon, and an
@@ -108,6 +111,7 @@ public abstract class SystemShortcut<T extends Context & ActivityContext> extend
     }
 
     public static final Factory<Launcher> WIDGETS = (launcher, itemInfo) -> {
+        if (PreferenceExtensionsKt.firstBlocking(PreferenceManager2.getInstance(launcher).getLockHomeScreen())) return null;
         if (itemInfo.getTargetComponent() == null) return null;
         final List<WidgetItem> widgets =
                 launcher.getPopupDataProvider().getWidgetsForPackageUser(new PackageUserKey(

--- a/src/com/android/launcher3/shortcuts/DeepShortcutTextView.java
+++ b/src/com/android/launcher3/shortcuts/DeepShortcutTextView.java
@@ -28,13 +28,19 @@ import android.widget.Toast;
 import com.android.launcher3.BubbleTextView;
 import com.android.launcher3.R;
 import com.android.launcher3.Utilities;
+import com.patrykmichalik.preferencemanager.PreferenceExtensionsKt;
+
+import app.lawnchair.preferences2.PreferenceManager2;
 
 /**
  * A {@link BubbleTextView} that has the shortcut icon on the left and drag handle on the right.
  */
 public class DeepShortcutTextView extends BubbleTextView {
+
+    private final PreferenceManager2 mPreferenceManager2 = PreferenceManager2.getInstance(getContext());
+
     private final Rect mDragHandleBounds = new Rect();
-    private final int mDragHandleWidth;
+    private int mDragHandleWidth;
     private boolean mShowInstructionToast = false;
 
     private Toast mInstructionToast;
@@ -59,6 +65,17 @@ public class DeepShortcutTextView extends BubbleTextView {
                 + resources.getDimensionPixelSize(R.dimen.deep_shortcut_drag_handle_size)
                 + resources.getDimensionPixelSize(R.dimen.deep_shortcut_drawable_padding) / 2;
         showLoadingState(true);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+
+        if (PreferenceExtensionsKt.firstBlocking(mPreferenceManager2.getLockHomeScreen())) {
+            setCompoundDrawables(null, null, null, null);
+            mDragHandleWidth = 0;
+            mDragHandleBounds.set(0, 0, 0, 0);
+        }
     }
 
     @Override

--- a/src/com/android/launcher3/views/OptionsPopupView.java
+++ b/src/com/android/launcher3/views/OptionsPopupView.java
@@ -52,9 +52,12 @@ import com.android.launcher3.shortcuts.DeepShortcutView;
 import com.android.launcher3.testing.TestLogging;
 import com.android.launcher3.testing.TestProtocol;
 import com.android.launcher3.widget.picker.WidgetsFullSheet;
+import com.patrykmichalik.preferencemanager.PreferenceExtensionsKt;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import app.lawnchair.preferences2.PreferenceManager2;
 
 /**
  * Popup shown on long pressing an empty space in launcher
@@ -185,7 +188,8 @@ public class OptionsPopupView extends ArrowPopup<Launcher>
                 R.drawable.ic_setting,
                 LAUNCHER_SETTINGS_BUTTON_TAP_OR_LONGPRESS,
                 OptionsPopupView::startSettings));
-        if (!WidgetsModel.GO_DISABLE_WIDGETS) {
+        boolean lockHomeScreen = PreferenceExtensionsKt.firstBlocking(PreferenceManager2.INSTANCE.get(launcher).getLockHomeScreen());
+        if (!lockHomeScreen && !WidgetsModel.GO_DISABLE_WIDGETS) {
             options.add(new OptionItem(launcher,
                     R.string.widget_button_text,
                     R.drawable.ic_widget,


### PR DESCRIPTION
Adds the option to lock home screen content, when enabled the user is unable to create any modifications to the Home screen content. The code is almost identical to how it's done on `9-dev`. (Closes #2480)

There can be a drawer lock feature as well but currently, it looks like all the Drawer interactions are meant to customize the Home content and there is no drawer customization to be locked (outside preferences).

The ***Widgets*** & **Customize** options on the apps' menu are removed when the lock is enabled and this change affects apps both on Drawer & Home since even if you *customize* an app from Drawer, it'll be reflected on the Home screen & the widgets button simply adds a widget to the Home screen.

So I wonder maybe it would be better if I rename the preference & move it to the General preferences as it's not really limited to the Home screen?

~~I also wonder if the "Add New Apps to Home Screen" should be automatically disabled when the *lock* is enabled?~~
I added a commit that disables "Add New Apps to Home Screen" & hides the preference in the GUI when the home screen is locked.