### PR TITLE
Add Date & Time support to Persian Calendar on Glance

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -242,7 +242,10 @@
     <string name="smartspace_icu_date_pattern_gregorian_time" translatable="false">HH:mm</string>
     <string name="smartspace_icu_date_pattern_gregorian_time_12h" translatable="false">hh:mm aa</string>
     <string name="smartspace_icu_date_pattern_gregorian_date" translatable="false"> dd MMMM</string>
-    <string name="smartspace_icu_date_pattern_persian" translatable="false">l، j F</string>
+    <string name="smartspace_icu_date_pattern_persian_wday_month_day_no_year" translatable="false">l، j F</string>
+    <string name="smartspace_icu_date_pattern_persian_time" translatable="false">H:i</string>
+    <string name="smartspace_icu_date_pattern_persian_time_12h" translatable="false">H:i a</string>
+    <string name="smartspace_icu_date_pattern_persian_date" translatable="false">"j F، "</string>
     <string name="smartspace_battery_charging">Charging</string>
     <string name="smartspace_battery_full">Charged</string>
     <string name="smartspace_battery_low">Battery Low</string>

--- a/lawnchair/src/app/lawnchair/smartspace/IcuDateTextView.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/IcuDateTextView.kt
@@ -61,14 +61,18 @@ class IcuDateTextView @JvmOverloads constructor(
         if (isShown) {
             val timeText = getTimeText(updateFormatter)
             if (text != timeText) {
-                textAlignment =
-                    if (calendar == SmartspaceCalendar.Persian) TEXT_ALIGNMENT_TEXT_END else TEXT_ALIGNMENT_TEXT_START
+                textAlignment = if (shouldAlignToTextEnd()) TEXT_ALIGNMENT_TEXT_END else TEXT_ALIGNMENT_TEXT_START
                 text = timeText
                 contentDescription = timeText
             }
         } else if (updateFormatter) {
             formatterFunction = null
         }
+    }
+
+    private fun shouldAlignToTextEnd(): Boolean {
+        val shouldNotAlignToEnd = dateTimeOptions.showTime && dateTimeOptions.time24HourFormat && !dateTimeOptions.showDate
+        return calendar == SmartspaceCalendar.Persian && !shouldNotAlignToEnd
     }
 
     private fun getTimeText(updateFormatter: Boolean): String {
@@ -89,10 +93,17 @@ class IcuDateTextView @JvmOverloads constructor(
     }
 
     private fun createPersianFormatter(): FormatterFunction {
-        val formatter = PersianDateFormat(
-            context.getString(R.string.smartspace_icu_date_pattern_persian),
-            PersianDateFormat.PersianDateNumberCharacter.FARSI,
-        )
+        var format: String
+        if (dateTimeOptions.showTime) {
+            format = context.getString(
+                if (dateTimeOptions.time24HourFormat) R.string.smartspace_icu_date_pattern_persian_time
+                else R.string.smartspace_icu_date_pattern_persian_time_12h
+            )
+            if (dateTimeOptions.showDate) format = context.getString(R.string.smartspace_icu_date_pattern_persian_date) + format
+        } else {
+            format = context.getString(R.string.smartspace_icu_date_pattern_persian_wday_month_day_no_year)
+        }
+        val formatter = PersianDateFormat(format, PersianDateFormat.PersianDateNumberCharacter.FARSI)
         return { formatter.format(PersianDate(it)) }
     }
 

--- a/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceCalendar.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceCalendar.kt
@@ -26,7 +26,7 @@ open class SmartspaceCalendar(@StringRes val nameResourceId: Int, val formatCust
     object Gregorian : SmartspaceCalendar(nameResourceId = R.string.smartspace_calendar_gregorian) {
         override fun toString() = "gregorian"
     }
-    object Persian : SmartspaceCalendar(nameResourceId = R.string.smartspace_calendar_persian, formatCustomizationSupport = false) {
+    object Persian : SmartspaceCalendar(nameResourceId = R.string.smartspace_calendar_persian) {
         override fun toString() = "persian"
     }
 


### PR DESCRIPTION
Adds Date & Time support for Persian Calendar on Glance. This was not originally added due to the time formats not being properly documented on the library used for Persian Date. 

I did not remove `formatCustomizationSupport` from `SmartSpaceCalendar` just in case it would be useful later on but I can fully remove it if you want.