### PR TITLE
Allow toggling enforced widget corner radius on Android 12+

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/HomeScreenPreferences.kt
@@ -149,13 +149,11 @@ fun HomeScreenPreferences() {
                 )
             }
         }
-        if (!Utilities.ATLEAST_S) {
-            PreferenceGroup(heading = stringResource(id = R.string.widget_button_text)) {
-                SwitchPreference(
-                    adapter = prefs2.roundedWidgets.getAdapter(),
-                    label = stringResource(id = R.string.force_rounded_widgets),
-                )
-            }
+        PreferenceGroup(heading = stringResource(id = R.string.widget_button_text)) {
+            SwitchPreference(
+                adapter = prefs2.roundedWidgets.getAdapter(),
+                label = stringResource(id = R.string.force_rounded_widgets),
+            )
         }
     }
 }

--- a/src/com/android/launcher3/widget/RoundedCornerEnforcement.java
+++ b/src/com/android/launcher3/widget/RoundedCornerEnforcement.java
@@ -75,7 +75,7 @@ public class RoundedCornerEnforcement {
 
     /** Check if the app widget is in the deny list. */
     public static boolean isRoundedCornerEnabled() {
-        return Utilities.ATLEAST_S || sRoundedCornerEnabled;
+        return sRoundedCornerEnabled;
     }
 
     /**


### PR DESCRIPTION
Simply just makes "enforced widget corner radius" option available to all android versions. I have tested it on devices below and above Android 12 and it worked on all without issues.

Closes #2668