### PR TITLE
Fix Glance throwing NullPointerException

### DIFF
--- a/lawnchair/src/app/lawnchair/smartspace/BcSmartspaceCard.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/BcSmartspaceCard.kt
@@ -149,13 +149,7 @@ class BcSmartspaceCard @JvmOverloads constructor(
         }
     }
 
-    private fun isStringRTL(string: String): Boolean {
-        if (TextUtils.isEmpty(string)) {
-            return false
-        }
-        val c = string[0]
-        return c.code in 0x590..0x6ff
-    }
+    private fun isStringRTL(string: String) = string.firstOrNull()?.code in 0x590..0x6ff
 
     private fun setSubtitle(subtitle: CharSequence?, charSequence2: CharSequence?) {
         val subtitleView = subtitleTextView ?: return


### PR DESCRIPTION
Updates isStringRTL() to handle potential null exceptions which did happen on my tests after #2716 was merged.

Although looking at the code, the bug is a bit strange since the string can never be empty on line 156! Somehow it sometimes is.