### PR TITLE
Fix time always showing in 24-Hour format on Persian Calendar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -398,7 +398,7 @@ dependencies {
     implementation 'com.github.LawnchairLauncher:oss-notices:1.0.2'
 
     // Persian Date
-    implementation 'com.github.samanzamani:PersianDate:1.5.0'
+    implementation 'com.github.samanzamani:PersianDate:1.5.4'
 
     api 'com.airbnb.android:lottie:5.0.3'
 }

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -264,7 +264,7 @@
     <string name="smartspace_icu_date_pattern_gregorian_date" translatable="false"> dd MMMM</string>
     <string name="smartspace_icu_date_pattern_persian_wday_month_day_no_year" translatable="false">l، j F</string>
     <string name="smartspace_icu_date_pattern_persian_time" translatable="false">H:i</string>
-    <string name="smartspace_icu_date_pattern_persian_time_12h" translatable="false">H:i a</string>
+    <string name="smartspace_icu_date_pattern_persian_time_12h" translatable="false">g:i a</string>
     <string name="smartspace_icu_date_pattern_persian_date" translatable="false">"j F، "</string>
     <string name="smartspace_battery_charging">Charging</string>
     <string name="smartspace_battery_full">Charged</string>


### PR DESCRIPTION
Fixes an issue related to #2637. The fix required a newer version of the PersianDate library, that's why it's also updated.