### PR TITLE
Add enabled/disabled icons to Switch in SwitchPreference

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/SwitchPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/SwitchPreference.kt
@@ -19,7 +19,12 @@ package app.lawnchair.ui.preferences.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -80,6 +85,8 @@ fun SwitchPreference(
                         .background(dividerColor())
                 )
             }
+
+            val thumbIcon = if (checked) Icons.Rounded.Check else Icons.Rounded.Close
             Switch(
                 modifier = Modifier
                     .addIf(onClick != null) {
@@ -90,6 +97,13 @@ fun SwitchPreference(
                 checked = checked,
                 onCheckedChange = null,
                 enabled = enabled,
+                thumbContent = {
+                    Icon(
+                        imageVector = thumbIcon,
+                        contentDescription = null,
+                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                    )
+                },
             )
         },
         enabled = enabled,


### PR DESCRIPTION
## Description

This change aims at providing better accessibility to Lawnchair by adding icons over the Switch in SwitchPreference.

Here's how it looks like:
![pref-switch-icons](https://user-images.githubusercontent.com/9381261/179495814-b9482e4c-1a84-4fb5-836e-19fcd06e99a1.png)

Note: While this change may be considered by many as a "general change," it may also be considered as a new feature for some, which is why I checked the following option below.

## Type of change

- [x] General change (non-breaking change that fixes typos/grammar, or adds additional content that isn't a bug or a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)