### PR TITLE
Custom Notification Dot Colors

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -50,6 +50,9 @@
     <!-- which accent color to use by default -->
     <string name="config_default_accent_color" translatable="false">default</string>
 
+    <!-- which notification dot color to use by default -->
+    <string name="config_default_notification_dot_color" translatable="false">app_icon</string>
+
     <bool name="config_default_dark_status_bar">false</bool>
     <bool name="config_default_dock_search_bar">true</bool>
     <bool name="config_default_show_notification_count">false</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -54,6 +54,8 @@
     <string name="label_size">Label Size</string>
     <string name="show_home_labels">Show Labels</string>
     <string name="notification_dots">Notification Dots</string>
+    <string name="notification_dots_color">Notification Dot Color</string>
+    <string name="app_icon_color">App Icon Color</string>
     <string name="smartspace_preferences">Preferences</string>
     <string name="about_label">About</string>
     <string name="news">News</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -86,6 +86,14 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         save = { it.toString() },
     )
 
+    val notificationDotColor = preference(
+        key = stringPreferencesKey(name = "notification_dot_color"),
+        parse = ColorOption::fromString,
+        save = ColorOption::toString,
+        onSet = { reloadHelper.reloadGrid() },
+        defaultValue = ColorOption.fromString(context.getString(R.string.config_default_notification_dot_color)),
+    )
+
     val showNotificationCount = preference(
         key = booleanPreferencesKey(name = "show_notification_count"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_show_notification_count),

--- a/lawnchair/src/app/lawnchair/theme/ThemeProvider.kt
+++ b/lawnchair/src/app/lawnchair/theme/ThemeProvider.kt
@@ -80,6 +80,7 @@ class ThemeProvider(private val context: Context) {
             getColorScheme(wallpaperPrimary ?: ColorOption.LawnchairBlue.color)
         }
         is ColorOption.CustomColor -> getColorScheme(accentColor.color)
+        else -> getColorScheme(ColorOption.LawnchairBlue.color)
     }
 
     private val systemColorScheme get() = when {

--- a/lawnchair/src/app/lawnchair/theme/color/ColorOption.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/ColorOption.kt
@@ -20,8 +20,8 @@ sealed class ColorOption {
         override val colorPreferenceEntry = ColorPreferenceEntry<ColorOption>(
             this,
             { stringResource(id = R.string.system) },
-            { LocalContext.current.getSystemAccent(false) },
-            { LocalContext.current.getSystemAccent(true) }
+            { context -> context.getSystemAccent(false) },
+            { context -> context.getSystemAccent(true) }
         )
 
         override fun toString() = "system_accent"
@@ -33,8 +33,7 @@ sealed class ColorOption {
         override val colorPreferenceEntry = ColorPreferenceEntry<ColorOption>(
             this,
             { stringResource(id = R.string.wallpaper) },
-            {
-                val context = LocalContext.current
+            { context ->
                 val wallpaperManager = WallpaperManagerCompat.INSTANCE.get(context)
                 val primaryColor = wallpaperManager.wallpaperColors?.primaryColor
                 primaryColor ?: LawnchairBlue.color
@@ -62,12 +61,25 @@ sealed class ColorOption {
         override fun toString() = "custom|#${String.format("%08x", color)}"
     }
 
+    object AppIcon : ColorOption() {
+        override val isSupported = false
+
+        override val colorPreferenceEntry = ColorPreferenceEntry<ColorOption>(
+            this,
+            { stringResource(id = R.string.app_icon_color) },
+            { 0 }
+        )
+
+        override fun toString() = "app_icon"
+    }
+
     companion object {
         val LawnchairBlue = CustomColor(0xFF007FFF)
 
         fun fromString(stringValue: String) = when (stringValue) {
             "system_accent" -> SystemAccent
             "wallpaper_primary" -> WallpaperPrimary
+            "app_icon" -> AppIcon
             else -> instantiateCustomColor(stringValue)
         }
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
@@ -106,6 +106,10 @@ fun GeneralPreferences() {
                     adapter = prefs2.showNotificationCount.getAdapter(),
                     label = stringResource(id = R.string.show_notification_count),
                 )
+                ColorPreference(
+                    preference = prefs2.notificationDotColor,
+                    label = stringResource(id = R.string.notification_dots_color),
+                )
             }
         }
         PreferenceGroup(heading = stringResource(id = R.string.colors)) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorDot.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorDot.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -17,9 +18,9 @@ fun <T> ColorDot(
     modifier: Modifier = Modifier
 ) {
     val color = if (MaterialTheme.colors.isLight) {
-        entry.lightColor()
+        entry.lightColor(LocalContext.current)
     } else {
-        entry.darkColor()
+        entry.darkColor(LocalContext.current)
     }
 
     ColorDot(

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorOptions.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorOptions.kt
@@ -21,3 +21,5 @@ val staticColors = listOf(
 val dynamicColors = listOf(ColorOption.SystemAccent, ColorOption.WallpaperPrimary)
     .filter(ColorOption::isSupported)
     .map(ColorOption::colorPreferenceEntry)
+
+val dynamicColorsForNotificationDot = dynamicColors + listOf(ColorOption.AppIcon.colorPreferenceEntry)

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorPreference.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import app.lawnchair.preferences.PreferenceAdapter
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.theme.color.ColorOption
@@ -43,7 +44,7 @@ fun ColorPreference(
     val navController = LocalNavController.current
     PreferenceTemplate(
         title = { Text(text = label) },
-        endWidget = { ColorDot(Color(adapter.state.value.colorPreferenceEntry.lightColor())) },
+        endWidget = { ColorDot(Color(adapter.state.value.colorPreferenceEntry.lightColor(LocalContext.current))) },
         description = {
             Text(text = adapter.state.value.colorPreferenceEntry.label())
         },

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorPreferenceEntry.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorPreferenceEntry.kt
@@ -1,11 +1,12 @@
 package app.lawnchair.ui.preferences.components.colorpreference
 
+import android.content.Context
 import androidx.compose.runtime.Composable
 import app.lawnchair.ui.theme.lightenColor
 
 open class ColorPreferenceEntry<T>(
     val value: T,
     val label: @Composable () -> String,
-    val lightColor: @Composable () -> Int,
-    val darkColor: @Composable () -> Int = { lightenColor(lightColor()) },
+    val lightColor: (Context) -> Int,
+    val darkColor: (Context) -> Int = { context -> lightenColor(lightColor(context)) },
 )

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorSelectionPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorSelectionPreference.kt
@@ -44,14 +44,23 @@ fun NavGraphBuilder.colorSelectionGraph(route: String) {
             val preferenceManager2 = preferenceManager2()
             val pref = when (prefKey) {
                 preferenceManager2.accentColor.key.name -> preferenceManager2.accentColor
+                preferenceManager2.notificationDotColor.key.name -> preferenceManager2.notificationDotColor
                 else -> return@composable
             }
             val label = when (prefKey) {
                 preferenceManager2.accentColor.key.name -> stringResource(id = R.string.accent_color)
+                preferenceManager2.notificationDotColor.key.name -> stringResource(id = R.string.notification_dots_color)
                 else -> return@composable
             }
-            ColorSelection(label = label, preference = pref)
-
+            val dynamicEntries = when (prefKey) {
+                preferenceManager2.notificationDotColor.key.name -> dynamicColorsForNotificationDot
+                else -> dynamicColors
+            }
+            ColorSelection(
+                label = label,
+                preference = pref,
+                dynamicEntries = dynamicEntries,
+            )
         }
     }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/pickers/CustomColorPicker.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/pickers/CustomColorPicker.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -54,7 +55,7 @@ fun CustomColorPicker(
 
     val focusManager = LocalFocusManager.current
 
-    val selectedColor = selectedColorOption.colorPreferenceEntry.lightColor()
+    val selectedColor = selectedColorOption.colorPreferenceEntry.lightColor(LocalContext.current)
     val selectedColorCompose = Color(selectedColor)
 
     val textFieldValue = remember {

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/pickers/SwatchGrid.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/pickers/SwatchGrid.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import app.lawnchair.ui.preferences.components.PreferenceGroup
 import app.lawnchair.ui.preferences.components.colorpreference.ColorPreferenceEntry
@@ -80,9 +81,9 @@ fun <T> ColorSwatch(
     selected: Boolean
 ) {
     val color = if (MaterialTheme.colors.isLight) {
-        entry.lightColor()
+        entry.lightColor(LocalContext.current)
     } else {
-        entry.darkColor()
+        entry.darkColor(LocalContext.current)
     }
 
     Box(

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -52,6 +52,7 @@ import java.io.PrintWriter;
 
 import app.lawnchair.DeviceProfileOverrides;
 import app.lawnchair.preferences2.PreferenceManager2;
+import app.lawnchair.theme.color.ColorOption;
 
 @SuppressLint("NewApi")
 public class DeviceProfile {
@@ -502,11 +503,15 @@ public class DeviceProfile {
             typeface = ResourcesCompat.getFont(context, R.font.inter_regular);
         }
 
+        // Load dot color
+        ColorOption colorOption = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getNotificationDotColor());
+        int color = colorOption.getColorPreferenceEntry().getLightColor().invoke(context);
+
         // This is done last, after iconSizePx is calculated above.
         Path dotPath = GraphicsUtils.getShapePath(DEFAULT_DOT_SIZE);
-        mDotRendererWorkSpace = new DotRenderer(iconSizePx, dotPath, DEFAULT_DOT_SIZE, showNotificationCount, typeface);
+        mDotRendererWorkSpace = new DotRenderer(iconSizePx, dotPath, DEFAULT_DOT_SIZE, showNotificationCount, typeface, color);
         mDotRendererAllApps = iconSizePx == allAppsIconSizePx ? mDotRendererWorkSpace :
-                new DotRenderer(allAppsIconSizePx, dotPath, DEFAULT_DOT_SIZE, showNotificationCount, typeface);
+                new DotRenderer(allAppsIconSizePx, dotPath, DEFAULT_DOT_SIZE, showNotificationCount, typeface, color);
     }
 
     private int getHorizontalMarginPx(InvariantDeviceProfile idp, Resources res) {


### PR DESCRIPTION
Adds custom color support to Notification Dots. This pull request depends on [platform_frameworks_libs_systemui#2](https://github.com/LawnchairLauncher/platform_frameworks_libs_systemui/pull/2).

Utilizes the standard ***Color Picker Screen*** to allow selecting a custom color for Notification Dots.

Notification Dot Colors have an extra non-standard color compared to Accent Color options: **App Icon Color**. This new color option is simply the previously available color; it selects the Dot color based on the color of the icon.

I could not find a way to use `lightColor` & `darkColor` on `DeviceProfile.java` as they are composable variables. To solve the issue, their type is now changed to `(Context) -> Int` from `@Composable () -> Int`.

Test APK: [Lawnchair 12.1.0 Dev (69bf3de).zip](https://github.com/LawnchairLauncher/lawnchair/files/9173728/Lawnchair.12.1.0.Dev.69bf3de.zip)

![Peek 2022-07-23 16-32](https://user-images.githubusercontent.com/41836211/180604004-07f3a24f-476d-4d8d-8762-7f8d15c2c3f4.gif)