### PR TITLE
Add copy & paste buttons to Hex Color Picker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -362,6 +362,7 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
     implementation "androidx.compose.ui:ui-text-google-fonts:$compose_version"
     implementation "androidx.compose.foundation:foundation:$compose_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.material3:material3:1.0.0-alpha14"
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"

--- a/lawnchair/res/drawable/ic_content_paste.xml
+++ b/lawnchair/res/drawable/ic_content_paste.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?android:textColorSecondary" android:pathData="M5.075,21.225q-0.95,0 -1.612,-0.675 -0.663,-0.675 -0.663,-1.6L2.8,5.1q0,-0.95 0.663,-1.613 0.662,-0.662 1.612,-0.662h3.95q0.3,-0.9 1.138,-1.475Q11,0.775 12,0.775q1.025,0 1.863,0.575 0.837,0.575 1.137,1.475h3.925q0.95,0 1.613,0.662 0.662,0.663 0.662,1.613v13.85q0,0.925 -0.662,1.6 -0.663,0.675 -1.613,0.675ZM5.075,18.95h13.85L18.925,5.1h-1.95v3.075h-9.95L7.025,5.1h-1.95v13.85ZM12,5q0.425,0 0.713,-0.288Q13,4.425 13,4t-0.287,-0.713Q12.425,3 12,3t-0.712,0.287Q11,3.575 11,4t0.288,0.712Q11.575,5 12,5Z"/>
+</vector>

--- a/lawnchair/res/drawable/ic_content_paste.xml
+++ b/lawnchair/res/drawable/ic_content_paste.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="?android:textColorSecondary" android:pathData="M5.075,21.225q-0.95,0 -1.612,-0.675 -0.663,-0.675 -0.663,-1.6L2.8,5.1q0,-0.95 0.663,-1.613 0.662,-0.662 1.612,-0.662h3.95q0.3,-0.9 1.138,-1.475Q11,0.775 12,0.775q1.025,0 1.863,0.575 0.837,0.575 1.137,1.475h3.925q0.95,0 1.613,0.662 0.662,0.663 0.662,1.613v13.85q0,0.925 -0.662,1.6 -0.663,0.675 -1.613,0.675ZM5.075,18.95h13.85L18.925,5.1h-1.95v3.075h-9.95L7.025,5.1h-1.95v13.85ZM12,5q0.425,0 0.713,-0.288Q13,4.425 13,4t-0.287,-0.713Q12.425,3 12,3t-0.712,0.287Q11,3.575 11,4t0.288,0.712Q11.575,5 12,5Z"/>
-</vector>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -200,6 +200,7 @@
 
     <string name="action_copy_link">Copy Link</string>
     <string name="action_copy">Copy</string>
+    <string name="action_paste">Paste</string>
     <string name="copied_toast">Copied to clipboard.</string>
     <string name="action_share">Share</string>
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/pickers/CustomColorPicker.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/pickers/CustomColorPicker.kt
@@ -1,6 +1,10 @@
 package app.lawnchair.ui.preferences.components.colorpreference.pickers
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.graphics.Color.argb
+import android.widget.Toast
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
@@ -183,44 +187,93 @@ fun CustomColorPicker(
 
 @Composable
 private fun HexColorPicker(
+    modifier: Modifier = Modifier,
     textFieldValue: TextFieldValue,
     onTextFieldValueChange: (TextFieldValue) -> Unit,
 ) {
 
+    val context = LocalContext.current
     val focusManager = LocalFocusManager.current
+    val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 
     val invalidString = colorStringToIntColor(textFieldValue.text) == null
 
-    OutlinedTextField(
-        textStyle = LocalTextStyle.current.copy(
-            fontSize = 18.sp,
-            textAlign = TextAlign.Start,
-        ),
-        isError = invalidString,
-        value = textFieldValue,
-        onValueChange = onTextFieldValueChange,
-        singleLine = true,
-        keyboardOptions = KeyboardOptions(
-            capitalization = KeyboardCapitalization.Characters,
-            autoCorrect = false,
-            imeAction = ImeAction.Done,
-        ),
-        keyboardActions = KeyboardActions(
-            onDone = {
-                focusManager.clearFocus()
-            },
-        ),
-        trailingIcon = {
-            Crossfade(targetState = invalidString) {
-                if (it) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_warning),
-                        contentDescription = stringResource(id = R.string.invalid_color),
-                    )
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+
+        OutlinedTextField(
+            modifier = Modifier.weight(1f),
+            textStyle = LocalTextStyle.current.copy(
+                fontSize = 18.sp,
+                textAlign = TextAlign.Start,
+            ),
+            isError = invalidString,
+            value = textFieldValue,
+            onValueChange = onTextFieldValueChange,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Characters,
+                autoCorrect = false,
+                imeAction = ImeAction.Done,
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    focusManager.clearFocus()
+                },
+            ),
+            trailingIcon = {
+                Crossfade(targetState = invalidString) {
+                    if (it) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_warning),
+                            contentDescription = stringResource(id = R.string.invalid_color),
+                        )
+                    }
                 }
-            }
-        },
-    )
+            },
+        )
+
+        Spacer(modifier = Modifier.requiredWidth(16.dp))
+
+        IconButton(
+            onClick = {
+                val clip =
+                    ClipData.newPlainText(context.getString(R.string.hex), textFieldValue.text)
+                clipboardManager.setPrimaryClip(clip)
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.copied_toast),
+                    Toast.LENGTH_SHORT
+                ).show()
+            },
+            content = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_copy),
+                    contentDescription = stringResource(id = R.string.action_copy),
+                )
+            },
+        )
+
+        IconButton(
+            onClick = {
+                clipboardManager.primaryClip?.getItemAt(0)?.text?.let {
+                    onTextFieldValueChange(textFieldValue.copy(text = it.toString()))
+                    focusManager.clearFocus()
+                }
+            },
+            content = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_content_paste),
+                    contentDescription = stringResource(id = R.string.action_paste),
+                )
+            },
+        )
+
+    }
+
 }
 
 @Composable

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/pickers/CustomColorPicker.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/pickers/CustomColorPicker.kt
@@ -12,6 +12,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ContentCopy
+import androidx.compose.material.icons.rounded.ContentPaste
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -33,6 +36,7 @@ import androidx.core.graphics.green
 import androidx.core.graphics.red
 import app.lawnchair.theme.color.ColorOption
 import app.lawnchair.ui.preferences.components.Chip
+import app.lawnchair.ui.preferences.components.ClickableIcon
 import app.lawnchair.ui.preferences.components.DividerColumn
 import app.lawnchair.ui.preferences.components.PreferenceGroup
 import app.lawnchair.ui.preferences.components.colorpreference.*
@@ -238,7 +242,8 @@ private fun HexColorPicker(
 
         Spacer(modifier = Modifier.requiredWidth(16.dp))
 
-        IconButton(
+        ClickableIcon(
+            imageVector = Icons.Rounded.ContentCopy,
             onClick = {
                 val clip =
                     ClipData.newPlainText(context.getString(R.string.hex), textFieldValue.text)
@@ -249,26 +254,15 @@ private fun HexColorPicker(
                     Toast.LENGTH_SHORT
                 ).show()
             },
-            content = {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_copy),
-                    contentDescription = stringResource(id = R.string.action_copy),
-                )
-            },
         )
 
-        IconButton(
+        ClickableIcon(
+            imageVector = Icons.Rounded.ContentPaste,
             onClick = {
                 clipboardManager.primaryClip?.getItemAt(0)?.text?.let {
                     onTextFieldValueChange(textFieldValue.copy(text = it.toString()))
                     focusManager.clearFocus()
                 }
-            },
-            content = {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_content_paste),
-                    contentDescription = stringResource(id = R.string.action_paste),
-                )
             },
         )
 


### PR DESCRIPTION
Adds copy & paste buttons to Hex Color Picker to allow users to handle Hex codes easier.

The reason that `androidx.compose.ui.platform.ClipboardManager` is not used is that we initially tried it but it sometimes would paste blank strings; as a result, we ended up using `android.content.ClipboardManager`.

Test APK: [Lawnchair 12.1.0 Dev (6d63c73).zip](https://github.com/LawnchairLauncher/lawnchair/files/9175404/Lawnchair.12.1.0.Dev.6d63c73.zip)

Preview:
![Peek 2022-07-24 12-59](https://user-images.githubusercontent.com/41836211/180638945-98d36fd7-b28a-4059-8fe3-d311211b43dd.gif)