### PR TITLE
Fix: Some widgets causing launcher to crash

### DIFF
--- a/quickstep/src/com/android/launcher3/uioverrides/QuickstepInteractionHandler.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/QuickstepInteractionHandler.java
@@ -79,9 +79,13 @@ class QuickstepInteractionHandler implements RemoteViews.InteractionHandler {
                             activityOptions.options.getRemoteAnimationAdapter(),
                             launchCookie);
                 } catch (NoSuchMethodError e) {
-                    atm.registerRemoteAnimationForNextActivityStart(
+                    try {
+                        atm.registerRemoteAnimationForNextActivityStart(
                             pendingIntent.getCreatorPackage(),
                             activityOptions.options.getRemoteAnimationAdapter());
+                    } catch (NoSuchMethodError err) {
+                        // Do nothing.
+                    }
                 }
             } catch (RemoteException e) {
                 // Do nothing.


### PR DESCRIPTION
## Description

Skip widget activity animation if `ActivityTaskManager.getService().registerRemoteAnimationForNextActivityStart()` is not available.

Fixes #2707

## Type of change

- [ ] General change (non-breaking change that fixes typos/grammar, or adds additional content that isn't a bug or a feature)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)