### PR TITLE
Allow smartspace time to follow the system format

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -53,6 +53,9 @@
     <!-- which notification dot color to use by default -->
     <string name="config_default_notification_dot_color" translatable="false">app_icon</string>
 
+    <!-- which time format to use by default on smartspace -->
+    <string name="config_default_smartspace_time_format" translatable="false">system</string>
+
     <bool name="config_default_dark_status_bar">false</bool>
     <bool name="config_default_dock_search_bar">true</bool>
     <bool name="config_default_show_notification_count">false</bool>
@@ -78,7 +81,6 @@
     <bool name="config_default_show_component_names">false</bool>
     <bool name="config_default_smartspace_show_date">true</bool>
     <bool name="config_default_smartspace_show_time">false</bool>
-    <bool name="config_default_smartspace_24_hour_format">false</bool>
 
     <item name="config_default_home_icon_size_factor" type="dimen" format="float">1.0</item>
     <item name="config_default_folder_preview_background_opacity" type="dimen" format="float">1.0</item>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -282,6 +282,9 @@
     <string name="smartspace_date_and_time">Date &amp; Time</string>
     <string name="smartspace_date">Date</string>
     <string name="smartspace_time">Time</string>
+    <string name="smartspace_time_format">Time Format</string>
+    <string name="smartspace_time_follow_system">Follow System</string>
+    <string name="smartspace_time_12_hour_format">12-Hour Format</string>
     <string name="smartspace_time_24_hour_format">24-Hour Format</string>
     <string name="smartspace_weather">Weather</string>
     <string name="smartspace_battery_status">Battery Status</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -29,6 +29,7 @@ import app.lawnchair.icons.shape.IconShape
 import app.lawnchair.icons.shape.IconShapeManager
 import app.lawnchair.qsb.providers.QsbSearchProvider
 import app.lawnchair.smartspace.model.SmartspaceCalendar
+import app.lawnchair.smartspace.model.SmartspaceTimeFormat
 import app.lawnchair.theme.color.ColorOption
 import com.android.launcher3.InvariantDeviceProfile
 import com.android.launcher3.LauncherAppState
@@ -313,9 +314,11 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         defaultValue = context.resources.getBoolean(R.bool.config_default_smartspace_show_time),
     )
 
-    val smartspace24HourFormat = preference(
-        key = booleanPreferencesKey("smartspace_24_hour_format"),
-        defaultValue = context.resources.getBoolean(R.bool.config_default_smartspace_24_hour_format),
+    val smartspaceTimeFormat = preference(
+        key = stringPreferencesKey("smartspace_time_format"),
+        defaultValue = SmartspaceTimeFormat.fromString(context.getString(R.string.config_default_smartspace_time_format)),
+        parse = { SmartspaceTimeFormat.fromString(it) },
+        save = { it.toString() },
     )
 
     val smartspaceCalendar = preference(

--- a/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceTimeFormat.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceTimeFormat.kt
@@ -1,0 +1,40 @@
+package app.lawnchair.smartspace.model
+
+import androidx.annotation.StringRes
+import com.android.launcher3.R
+
+open class SmartspaceTimeFormat(@StringRes val nameResourceId: Int) {
+
+    companion object {
+
+        fun fromString(value: String): SmartspaceTimeFormat = when (value) {
+            "12_hour_format" -> TwelveHourFormat
+            "24_hour_format" -> TwentyFourHourFormat
+            else -> FollowSystem
+        }
+
+        /**
+         * @return The list of all time format options.
+         */
+        fun values() = listOf(FollowSystem, TwelveHourFormat, TwentyFourHourFormat)
+    }
+
+    object FollowSystem : SmartspaceTimeFormat(
+        nameResourceId = R.string.smartspace_time_follow_system,
+    ) {
+        override fun toString() = "system"
+    }
+
+    object TwelveHourFormat : SmartspaceTimeFormat(
+        nameResourceId = R.string.smartspace_time_12_hour_format,
+    ) {
+        override fun toString() = "12_hour_format"
+    }
+
+    object TwentyFourHourFormat : SmartspaceTimeFormat(
+        nameResourceId = R.string.smartspace_time_24_hour_format,
+    ) {
+        override fun toString() = "24_hour_format"
+    }
+
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
@@ -22,6 +22,7 @@ import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.smartspace.SmartspaceViewContainer
 import app.lawnchair.smartspace.model.SmartspaceCalendar
+import app.lawnchair.smartspace.model.SmartspaceTimeFormat
 import app.lawnchair.smartspace.provider.SmartspaceProvider
 import app.lawnchair.ui.preferences.components.DividerColumn
 import app.lawnchair.ui.preferences.components.ExpandAndShrink
@@ -123,7 +124,7 @@ fun SmartspaceDateAndTimePreferences() {
         val calendarAdapter = preferenceManager2.smartspaceCalendar.getAdapter()
         val showDateAdapter = preferenceManager2.smartspaceShowDate.getAdapter()
         val showTimeAdapter = preferenceManager2.smartspaceShowTime.getAdapter()
-        val use24HourFormatAdapter = preferenceManager2.smartspace24HourFormat.getAdapter()
+        val use24HourFormatAdapter = preferenceManager2.smartspaceTimeFormat.getAdapter()
 
         val calendarHasMinimumContent = !showDateAdapter.state.value || !showTimeAdapter.state.value
 
@@ -146,10 +147,7 @@ fun SmartspaceDateAndTimePreferences() {
                     enabled = if (showTimeAdapter.state.value) !calendarHasMinimumContent else true,
                 )
                 ExpandAndShrink(visible = showTimeAdapter.state.value) {
-                    SwitchPreference(
-                        adapter = use24HourFormatAdapter,
-                        label = stringResource(id = R.string.smartspace_time_24_hour_format),
-                    )
+                    SmartspaceTimeFormatPreference()
                 }
             }
         }
@@ -159,6 +157,24 @@ fun SmartspaceDateAndTimePreferences() {
             SmartspaceCalendarPreference()
         }
     }
+}
+
+@Composable
+fun SmartspaceTimeFormatPreference() {
+
+    val entries = remember {
+        SmartspaceTimeFormat.values().map { format ->
+            ListPreferenceEntry(format) { stringResource(id = format.nameResourceId) }
+        }
+    }
+
+    val adapter = preferenceManager2().smartspaceTimeFormat.getAdapter()
+
+    ListPreference(
+        adapter = adapter,
+        entries = entries,
+        label = stringResource(id = R.string.smartspace_time_format),
+    )
 }
 
 @Composable


### PR DESCRIPTION
## Description

Changes how time format on Glance is handled; A new "Follow System" option is now added. This allows the time format to follow the system settings which was not possible previously (even before the rewrite). This new option is also the new default.

Test APK: [Lawnchair 12.1.0 Dev (095f99b).zip](https://github.com/LawnchairLauncher/lawnchair/files/9240345/Lawnchair.12.1.0.Dev.095f99b.zip)

![Peek 2022-08-02 12-39](https://user-images.githubusercontent.com/41836211/182326798-300115b3-2e10-43f5-92ec-dc088ad304d7.gif)

## Type of change

- [ ] General change (non-breaking change that fixes typos/grammar, or adds additional content that isn't a bug or a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)