### PR TITLE
Replace task lists with emojis

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,11 +3,12 @@
 <!-- Please include a summary of the change. Please also include relevant motivation and context. -->
 
 
-Fixes # (issue) <!-- optional -->
+Fixes #(issue) <!-- optional -->
 
 ## Type of change
+<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->
 
-- [ ] General change (non-breaking change that fixes typos/grammar, or adds additional content that isn't a bug or a feature)
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
+:x: Bug fix (non-breaking change which fixes an issue)
+:x: New feature (non-breaking change which adds functionality)
+:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
This PR replaces the task lists with emojis (❌ and ✅) to prevent the "Task 1 of 4" behavior, as stated in https://github.com/LawnchairLauncher/lawnchair/issues/2749#issuecomment-1204068661 by @yasandev. Alongside that, I've also copyedited the "General change" description to be more cleaner and consistent with the other lists.

Note: Ignore the unformatted list on the MD file, it's due to different behaviors when writing markdown on PRs vs on plain text files.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)