### PR TITLE
Disable incompatible tasks on release build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,12 @@ allprojects {
     }.configureEach {
         notCompatibleWithConfigurationCache("https://github.com/RikkaApps/HiddenApiRefinePlugin/issues/9")
     }
+
+    tasks.matching {
+        it.name.contains("collect*Dependencies") || it.name.contains("OssLicensesTask")
+    }.configureEach {
+        notCompatibleWithConfigurationCache("https://github.com/google/play-services-plugins/issues/206")
+    }
 }
 
 apply plugin: 'com.android.application'


### PR DESCRIPTION
Follow up #2806.

```
162 problems were found storing the configuration cache, 2 of which seem unique.
- Task :collectLawnWithQuickstepReleaseDependencies of type com.android.build.gradle.internal.tasks.PerModuleReportDependenciesTask: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution
- Task :lawnWithQuickstepReleaseOssLicensesTask of type com.google.android.gms.oss.licenses.plugin.LicensesTask: invocation of 'Task.project' at execution time is unsupported.
  See https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

```