### PR TITLE
Custom Folder Color Support

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -52,6 +52,7 @@
 
     <!-- which notification dot color to use by default -->
     <string name="config_default_notification_dot_color" translatable="false">app_icon</string>
+    <string name="config_default_folder_color" translatable="false">launcher_default</string>
 
     <!-- which time format to use by default on smartspace -->
     <string name="config_default_smartspace_time_format" translatable="false">system</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -154,8 +154,7 @@
     <string name="action_paste">Paste</string>
     <string name="copied_toast">Copied to clipboard.</string>
     <string name="invalid_color">Invalid Color</string>
-
-    <string name="app_icon_color">App Icon Color</string>
+    <string name="launcher_default_color">Default</string>
 
     <!-- HomeScreenPreferences -->
     <!-- <string name="general_label" /> -->
@@ -302,6 +301,7 @@
     <!-- <string name="folders_label" /> -->
     <!-- <string name="general_label" /> -->
       <string name="folder_preview_bg_opacity_label">Icon Background Opacity</string>
+      <string name="folder_preview_bg_color_label">Icon Background Color</string>
 
     <!-- <string name="grid" /> -->
     <string name="max_folder_columns">Max. Folder Columns</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -95,6 +95,14 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         defaultValue = ColorOption.fromString(context.getString(R.string.config_default_notification_dot_color)),
     )
 
+    val folderColor = preference(
+        key = stringPreferencesKey(name = "folder_color"),
+        parse = ColorOption::fromString,
+        save = ColorOption::toString,
+        onSet = { reloadHelper.reloadGrid() },
+        defaultValue = ColorOption.fromString(context.getString(R.string.config_default_folder_color)),
+    )
+
     val showNotificationCount = preference(
         key = booleanPreferencesKey(name = "show_notification_count"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_show_notification_count),

--- a/lawnchair/src/app/lawnchair/theme/color/ColorOption.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/ColorOption.kt
@@ -61,16 +61,16 @@ sealed class ColorOption {
         override fun toString() = "custom|#${String.format("%08x", color)}"
     }
 
-    object AppIcon : ColorOption() {
+    object LauncherDefault : ColorOption() {
         override val isSupported = false
 
         override val colorPreferenceEntry = ColorPreferenceEntry<ColorOption>(
             this,
-            { stringResource(id = R.string.app_icon_color) },
+            { stringResource(id = R.string.launcher_default_color) },
             { 0 }
         )
 
-        override fun toString() = "app_icon"
+        override fun toString() = "launcher_default"
     }
 
     companion object {
@@ -79,7 +79,7 @@ sealed class ColorOption {
         fun fromString(stringValue: String) = when (stringValue) {
             "system_accent" -> SystemAccent
             "wallpaper_primary" -> WallpaperPrimary
-            "app_icon" -> AppIcon
+            "launcher_default" -> LauncherDefault
             else -> instantiateCustomColor(stringValue)
         }
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/FolderPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/FolderPreferences.kt
@@ -25,6 +25,7 @@ import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.preferences.components.PreferenceGroup
 import app.lawnchair.ui.preferences.components.PreferenceLayout
 import app.lawnchair.ui.preferences.components.SliderPreference
+import app.lawnchair.ui.preferences.components.colorpreference.ColorPreference
 import com.android.launcher3.R
 
 fun NavGraphBuilder.folderGraph(route: String) {
@@ -37,6 +38,10 @@ fun FolderPreferences() {
         val prefs = preferenceManager()
         val prefs2 = preferenceManager2()
         PreferenceGroup(heading = stringResource(id = R.string.general_label)) {
+            ColorPreference(
+                preference = prefs2.folderColor,
+                label = stringResource(id = R.string.folder_preview_bg_color_label),
+            )
             SliderPreference(
                 label = stringResource(id = R.string.folder_preview_bg_opacity_label),
                 adapter = prefs2.folderPreviewBackgroundOpacity.getAdapter(),

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorOptions.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorOptions.kt
@@ -22,4 +22,4 @@ val dynamicColors = listOf(ColorOption.SystemAccent, ColorOption.WallpaperPrimar
     .filter(ColorOption::isSupported)
     .map(ColorOption::colorPreferenceEntry)
 
-val dynamicColorsForNotificationDot = dynamicColors + listOf(ColorOption.AppIcon.colorPreferenceEntry)
+val dynamicColorsWithDefault = dynamicColors + listOf(ColorOption.LauncherDefault.colorPreferenceEntry)

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorSelectionPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/colorpreference/ColorSelectionPreference.kt
@@ -45,15 +45,18 @@ fun NavGraphBuilder.colorSelectionGraph(route: String) {
             val pref = when (prefKey) {
                 preferenceManager2.accentColor.key.name -> preferenceManager2.accentColor
                 preferenceManager2.notificationDotColor.key.name -> preferenceManager2.notificationDotColor
+                preferenceManager2.folderColor.key.name -> preferenceManager2.folderColor
                 else -> return@composable
             }
             val label = when (prefKey) {
                 preferenceManager2.accentColor.key.name -> stringResource(id = R.string.accent_color)
                 preferenceManager2.notificationDotColor.key.name -> stringResource(id = R.string.notification_dots_color)
+                preferenceManager2.folderColor.key.name -> stringResource(id = R.string.folder_preview_bg_color_label)
                 else -> return@composable
             }
             val dynamicEntries = when (prefKey) {
-                preferenceManager2.notificationDotColor.key.name -> dynamicColorsForNotificationDot
+                preferenceManager2.folderColor.key.name,
+                preferenceManager2.notificationDotColor.key.name -> dynamicColorsWithDefault
                 else -> dynamicColors
             }
             ColorSelection(

--- a/src/com/android/launcher3/folder/PreviewBackground.java
+++ b/src/com/android/launcher3/folder/PreviewBackground.java
@@ -46,7 +46,10 @@ import com.android.launcher3.CellLayout;
 import com.android.launcher3.DeviceProfile;
 import com.android.launcher3.R;
 import com.android.launcher3.views.ActivityContext;
+import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
 
+import app.lawnchair.preferences2.PreferenceManager2;
+import app.lawnchair.theme.color.ColorOption;
 import app.lawnchair.theme.color.ColorTokens;
 import app.lawnchair.util.LawnchairUtilsKt;
 
@@ -154,10 +157,20 @@ public class PreviewBackground extends CellLayout.DelegatedCellDrawing {
                       int availableSpaceX, int topPadding) {
         mInvalidateDelegate = invalidateDelegate;
 
+        PreferenceManager2 preferenceManager2 = PreferenceManager2.INSTANCE.get(context);
+
+        // Load folder color
+        ColorOption colorOption = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getFolderColor());
+        int folderColor = colorOption.getColorPreferenceEntry().getLightColor().invoke(context);
+
         TypedArray ta = context.getTheme().obtainStyledAttributes(R.styleable.FolderIconPreview);
         mDotColor = ColorTokens.FolderDotColor.resolveColor(context);
         mStrokeColor = ColorTokens.FolderIconBorderColor.resolveColor(context);
-        mBgColor = ColorTokens.FolderPreviewColor.resolveColor(context);
+        if (folderColor != 0) {
+            mBgColor = folderColor;
+        } else {
+            mBgColor = ColorTokens.FolderPreviewColor.resolveColor(context);
+        }
         mBgColor = ColorUtils.setAlphaComponent(mBgColor, LawnchairUtilsKt.getFolderPreviewAlpha(context));
         ta.recycle();
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

- Adds support for custom folder icon background colors.
- Replaces `ColorOption.AppIcon` with `ColorOption.LauncherDefault` in order to make a more generic default option that can be used for any color preference (Uses `LauncherDefault` name & `launcher_default` id in order to avoid conflict with the actual default value that Notification Dot Color uses).

### Preview

![custom-folder-icon-background-color](https://user-images.githubusercontent.com/41836211/188447861-ee4822d4-e12f-4eb8-8416-ad9910933a0c.gif)

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
