### PR TITLE
Minify Apk size a bit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,6 +163,25 @@ android {
         }
     }
 
+    packagingOptions.resources.excludes += [
+        "**/*.proto",
+        "**/*.bin",
+        "**/*.java",
+        "**/*.properties",
+        "**/*.version",
+        "**/*.*_module",
+        "com/**",
+        "google/**",
+        "kotlin/**",
+        "kotlinx/**",
+        "okhttp3/**",
+        "META-INF/services/**",
+        "META-INF/com/**",
+        "META-INF/licenses/**",
+        "META-INF/AL2.0",
+        "META-INF/LGPL2.1",
+    ]
+
     buildTypes {
         debug {
             signingConfig releaseSigning

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+# https://developer.android.com/studio/build/shrink-code#full-mode
+android.enableR8.fullMode=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 

--- a/proguard-android-optimize.txt
+++ b/proguard-android-optimize.txt
@@ -20,19 +20,3 @@
 -keepclassmembers class * implements android.os.Parcelable {
   public static final ** CREATOR;
 }
-
--keep class androidx.annotation.Keep
-
--keep @androidx.annotation.Keep class * {*;}
-
--keepclasseswithmembers class * {
-    @androidx.annotation.Keep <methods>;
-}
-
--keepclasseswithmembers class * {
-    @androidx.annotation.Keep <fields>;
-}
-
--keepclasseswithmembers class * {
-    @androidx.annotation.Keep <init>(...);
-}

--- a/proguard.pro
+++ b/proguard.pro
@@ -10,17 +10,6 @@
 # Don't warn about those in case this app is linking against an older
 # platform version.  We know about them, and they are safe.
 -dontwarn android.support.**
-
-# Proguard will strip methods required for talkback to properly scroll to
-# next row when focus is on the last item of last row when using a RecyclerView
-# Keep optimized and shrunk proguard to prevent issues like this when using
-# support jar.
--keep class androidx.recyclerview.widget.RecyclerView { *; }
-
-# Fragments
--keep class ** extends androidx.fragment.app.Fragment {
-    public <init>(...);
-}
 -keep class ** extends android.app.Fragment {
     public <init>(...);
 }
@@ -66,8 +55,6 @@
 -keep class org.chickenhook.restrictionbypass.** { *; }
 
 # Silence warnings from Compose tooling
--dontwarn org.jetbrains.kotlin.**
--dontwarn androidx.compose.animation.tooling.ComposeAnimation
 -dontwarn sun.misc.Unsafe
 
 # Silence warnings about classes that are available at runtime


### PR DESCRIPTION
## Description
```bash
diffuse diff before.apk after.apk    

OLD: before.apk (signature: V2)
NEW: after.apk (signature: V2)

          │             compressed             │             uncompressed             
          ├───────────┬───────────┬────────────┼───────────┬───────────┬──────────────
 APK      │ old       │ new       │ diff       │ old       │ new       │ diff         
──────────┼───────────┼───────────┼────────────┼───────────┼───────────┼──────────────
      dex │   4.9 MiB │   4.6 MiB │ -398.7 KiB │    12 MiB │    11 MiB │ -1,020.7 KiB 
     arsc │   3.3 MiB │   3.3 MiB │        0 B │   3.3 MiB │   3.3 MiB │          0 B 
 manifest │   5.5 KiB │   5.5 KiB │       +3 B │  24.1 KiB │  24.1 KiB │          0 B 
      res │   1.9 MiB │   1.9 MiB │       +2 B │     3 MiB │     3 MiB │          0 B 
   native │ 996.5 KiB │ 994.2 KiB │   -2.3 KiB │ 980.4 KiB │ 980.4 KiB │          0 B 
    asset │  22.3 KiB │  22.2 KiB │     -136 B │  68.5 KiB │  68.4 KiB │       -130 B 
    other │  89.4 KiB │   1.6 KiB │  -87.8 KiB │ 114.7 KiB │     711 B │   -114.1 KiB 
──────────┼───────────┼───────────┼────────────┼───────────┼───────────┼──────────────
    total │  11.2 MiB │  10.8 MiB │   -489 KiB │  19.4 MiB │  18.3 MiB │     -1.1 MiB 


         │           raw           │                unique                 
         ├────────┬────────┬───────┼───────┬───────┬───────────────────────
 DEX     │ old    │ new    │ diff  │ old   │ new   │ diff                  
─────────┼────────┼────────┼───────┼───────┼───────┼───────────────────────
   files │      2 │      2 │     0 │       │       │                       
 strings │  76370 │  67915 │ -8455 │ 68269 │ 61018 │ -7251 (+7262 -14513)  
   types │  19721 │  19254 │  -467 │ 17798 │ 17459 │  -339 (+7238 -7577)   
 classes │  15877 │  15569 │  -308 │ 15877 │ 15569 │  -308 (+6997 -7305)   
 methods │ 103377 │ 100688 │ -2689 │ 98214 │ 96041 │ -2173 (+51372 -53545) 
  fields │  53634 │  52633 │ -1001 │ 52896 │ 52024 │  -872 (+25751 -26623) 


 ARSC    │ old  │ new  │ diff 
─────────┼──────┼──────┼──────
 configs │  348 │  348 │  0   
 entries │ 7255 │ 7255 │  0   


=================
====   APK   ====
=================

       compressed       │      uncompressed      │                                                                         
───────────┬────────────┼───────────┬────────────┤                                                                         
 size      │ diff       │ size      │ diff       │ path                                                                    
───────────┼────────────┼───────────┼────────────┼─────────────────────────────────────────────────────────────────────────
     3 MiB │ -201.8 KiB │   7.2 MiB │ -538.2 KiB │ ∆ classes.dex                                                           
   1.5 MiB │ -196.9 KiB │   3.8 MiB │ -482.5 KiB │ ∆ classes2.dex                                                          
           │    -37 KiB │           │  -36.8 KiB │ - okhttp3/internal/publicsuffix/publicsuffixes.gz                       
           │   -4.4 KiB │           │  -13.9 KiB │ - kotlin/kotlin.kotlin_builtins                                         
           │   -3.2 KiB │           │     -8 KiB │ - google/protobuf/field_mask.proto                                      
           │     -3 KiB │           │   -7.6 KiB │ - google/protobuf/api.proto                                             
           │   -2.9 KiB │           │   -6.3 KiB │ - google/protobuf/timestamp.proto                                       
           │   -2.6 KiB │           │   -5.8 KiB │ - google/protobuf/any.proto                                             
           │   -2.4 KiB │           │     -6 KiB │ - google/protobuf/type.proto                                            
 275.7 KiB │   -2.3 KiB │ 274.3 KiB │        0 B │ ∆ lib/arm64-v8a/libnrb.so                                               
           │   -2.1 KiB │           │   -4.8 KiB │ - google/protobuf/duration.proto                                        
           │   -1.8 KiB │           │   -3.7 KiB │ - google/protobuf/struct.proto                                          
           │   -1.6 KiB │           │   -3.6 KiB │ - kotlin/collections/collections.kotlin_builtins                        
           │   -1.6 KiB │           │   -3.9 KiB │ - google/protobuf/wrappers.proto                                        
           │   -1.3 KiB │           │   -2.3 KiB │ - kotlin/reflect/reflect.kotlin_builtins                                
           │   -1.3 KiB │           │   -2.3 KiB │ - google/protobuf/source_context.proto                                  
           │   -1.3 KiB │           │   -2.3 KiB │ - google/protobuf/empty.proto                                           
           │   -1.1 KiB │           │   -2.2 KiB │ - kotlin/ranges/ranges.kotlin_builtins                                  
           │     -892 B │           │   -1.7 KiB │ - DebugProbesKt.bin                                                     
           │     -723 B │           │     -926 B │ - kotlin/annotation/annotation.kotlin_builtins                          
           │     -708 B │           │     -939 B │ - kotlin/internal/internal.kotlin_builtins                              
           │     -321 B │           │     -200 B │ - kotlin/coroutines/coroutines.kotlin_builtins                          
           │     -297 B │           │     -218 B │ - okhttp3/internal/publicsuffix/NOTICE                                  
           │     -222 B │           │       -6 B │ - META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version 
           │     -218 B │           │      -14 B │ - META-INF/androidx.dynamicanimation_dynamicanimation-ktx.version       
           │     -216 B │           │       -6 B │ - META-INF/androidx.compose.material_material-icons-extended.version    
           │     -216 B │           │       -6 B │ - META-INF/androidx.lifecycle_lifecycle-viewmodel-savedstate.version    
           │     -214 B │           │       -6 B │ - META-INF/androidx.versionedparcelable_versionedparcelable.version     
           │     -212 B │           │       -6 B │ - META-INF/androidx.customview_customview-poolingcontainer.version      
           │     -212 B │           │       -6 B │ - META-INF/androidx.vectordrawable_vectordrawable-animated.version      
           │     -210 B │           │      -14 B │ - META-INF/androidx.dynamicanimation_dynamicanimation.version           
           │     -210 B │           │       -6 B │ - META-INF/androidx.lifecycle_lifecycle-livedata-core-ktx.version       
           │     -210 B │           │       -6 B │ - META-INF/androidx.lifecycle_lifecycle-viewmodel-compose.version       
           │     -208 B │           │       -6 B │ - META-INF/androidx.compose.foundation_foundation-layout.version        
           │     -208 B │           │       -6 B │ - META-INF/androidx.compose.material_material-icons-core.version        
           │     -206 B │           │       -6 B │ - META-INF/androidx.coordinatorlayout_coordinatorlayout.version         
           │     -206 B │           │       -6 B │ - META-INF/androidx.slidingpanelayout_slidingpanelayout.version         
           │     -204 B │           │       -6 B │ - META-INF/androidx.annotation_annotation-experimental.version          
           │     -202 B │           │       -6 B │ - META-INF/androidx.lifecycle_lifecycle-livedata-core.version           
           │     -202 B │           │       -6 B │ - META-INF/androidx.lifecycle_lifecycle-viewmodel-ktx.version           
           │     -202 B │           │       -6 B │ - META-INF/androidx.navigation_navigation-runtime-ktx.version           
           │     -202 B │           │       -6 B │ - META-INF/androidx.profileinstaller_profileinstaller.version           
           │     -200 B │           │       -6 B │ - META-INF/androidx.compose.animation_animation-core.version            
           │     -200 B │           │       -6 B │ - META-INF/androidx.compose.material_material-ripple.version            
           │     -200 B │           │       -6 B │ - META-INF/androidx.compose.runtime_runtime-livedata.version            
           │     -200 B │           │       -6 B │ - META-INF/androidx.compose.runtime_runtime-saveable.version            
           │     -200 B │           │       -6 B │ - META-INF/androidx.legacy_legacy-support-core-utils.version            
           │     -200 B │           │       -6 B │ - META-INF/androidx.navigation_navigation-common-ktx.version            
           │     -198 B │           │       -6 B │ - META-INF/androidx.compose.ui_ui-text-google-fonts.version             
           │     -198 B │           │       -6 B │ - META-INF/androidx.datastore_datastore-preferences.version             
           │     -198 B │           │       -6 B │ - META-INF/androidx.lifecycle_lifecycle-runtime-ktx.version             
           │     -197 B │           │      -13 B │ - META-INF/androidx.compose.material3_material3.version                 
           │     -194 B │           │       -6 B │ - META-INF/androidx.appcompat_appcompat-resources.version               
           │     -194 B │           │       -6 B │ - META-INF/androidx.compose.foundation_foundation.version               
           │     -194 B │           │       -6 B │ - META-INF/androidx.compose.ui_ui-tooling-preview.version               
           │     -194 B │           │       -6 B │ - META-INF/androidx.lifecycle_lifecycle-viewmodel.version               
           │     -194 B │           │       -6 B │ - META-INF/androidx.navigation_navigation-compose.version               
           │     -194 B │           │       -6 B │ - META-INF/androidx.navigation_navigation-runtime.version               
           │     -194 B │           │       -6 B │ - META-INF/androidx.vectordrawable_vectordrawable.version               
           │     -192 B │           │       -6 B │ - META-INF/androidx.lifecycle_lifecycle-livedata.version                
           │     -192 B │           │       -6 B │ - META-INF/androidx.navigation_navigation-common.version                
           │     -190 B │           │       -6 B │ - META-INF/androidx.compose.animation_animation.version                 
           │     -190 B │           │       -6 B │ - META-INF/androidx.cursoradapter_cursoradapter.version                 
           │     -190 B │           │       -6 B │ - META-INF/androidx.exifinterface_exifinterface.version                 
           │     -190 B │           │       -6 B │ - META-INF/androidx.lifecycle_lifecycle-process.version                 
           │     -190 B │           │       -6 B │ - META-INF/androidx.lifecycle_lifecycle-runtime.version                 
           │     -190 B │           │       -6 B │ - META-INF/com.google.android.material_material.version                 
           │     -188 B │           │       -6 B │ - META-INF/androidx.compose.ui_ui-tooling-data.version                  
           │     -188 B │           │       -6 B │ - META-INF/androidx.emoji2_emoji2-views-helper.version                  
           │     -187 B │           │      -13 B │ - META-INF/androidx.compose.ui_ui-geometry.version                      
           │     -187 B │           │      -13 B │ - META-INF/androidx.compose.ui_ui-graphics.version                      
           │     -186 B │           │       -6 B │ - META-INF/androidx.activity_activity-compose.version                   
           │     -186 B │           │       -6 B │ - META-INF/androidx.compose.material_material.version                   
           │     -186 B │           │       -6 B │ - META-INF/androidx.documentfile_documentfile.version                   
           │     -186 B │           │       -6 B │ - META-INF/androidx.drawerlayout_drawerlayout.version                   
           │     -186 B │           │       -6 B │ - META-INF/androidx.interpolator_interpolator.version                   
           │     -186 B │           │       -6 B │ - META-INF/androidx.preference_preference-ktx.version                   
           │     -186 B │           │       -6 B │ - META-INF/androidx.recyclerview_recyclerview.version                   
           │     -186 B │           │       -6 B │ - META-INF/androidx.savedstate_savedstate-ktx.version                   
           │     -182 B │           │       -6 B │ - META-INF/androidx.compose.runtime_runtime.version                     
           │     -182 B │           │       -6 B │ - META-INF/androidx.sqlite_sqlite-framework.version                     
           │     -182 B │           │       -6 B │ - META-INF/androidx.startup_startup-runtime.version                     
           │     -180 B │           │       -6 B │ - META-INF/androidx.arch.core_core-runtime.version                      
           │     -179 B │           │      -13 B │ - META-INF/androidx.compose.ui_ui-text.version                          
           │     -179 B │           │      -13 B │ - META-INF/androidx.compose.ui_ui-unit.version                          
           │     -179 B │           │      -13 B │ - META-INF/androidx.compose.ui_ui-util.version                          
           │     -178 B │           │       -6 B │ - META-INF/androidx.activity_activity-ktx.version                       
           │     -178 B │           │       -6 B │ - META-INF/androidx.compose.ui_ui-tooling.version                       
           │     -178 B │           │       -6 B │ - META-INF/androidx.customview_customview.version                       
           │     -178 B │           │       -6 B │ - META-INF/androidx.fragment_fragment-ktx.version                       
           │     -178 B │           │       -6 B │ - META-INF/androidx.preference_preference.version                       
           │     -178 B │           │       -6 B │ - META-INF/androidx.savedstate_savedstate.version                       
           │     -178 B │           │       -6 B │ - META-INF/androidx.transition_transition.version                       
           │     -178 B │           │       -6 B │ - META-INF/androidx.viewpager2_viewpager2.version                       
           │     -176 B │           │      -14 B │ - META-INF/androidx.slice_slice-core.version                            
           │     -174 B │           │       -6 B │ - META-INF/androidx.appcompat_appcompat.version                         
           │     -174 B │           │       -6 B │ - META-INF/androidx.datastore_datastore.version                         
           │     -174 B │           │       -6 B │ - META-INF/androidx.palette_palette-ktx.version                         
           │     -174 B │           │       -6 B │ - META-INF/androidx.viewpager_viewpager.version                         
           │     -170 B │           │       -6 B │ - META-INF/androidx.activity_activity.version                           
           │     -170 B │           │       -6 B │ - META-INF/androidx.autofill_autofill.version                           
           │     -170 B │           │       -6 B │ - META-INF/androidx.cardview_cardview.version                           
           │     -170 B │           │       -6 B │ - META-INF/androidx.fragment_fragment.version                           
           │     -170 B │           │       -6 B │ - META-INF/androidx.room_room-runtime.version                           
           │     -169 B │           │       -5 B │ - META-INF/kotlinx_coroutines_android.version                           
           │     -166 B │           │       -6 B │ - META-INF/androidx.palette_palette.version                             
           │     -166 B │           │       -6 B │ - META-INF/androidx.tracing_tracing.version                             
           │     -163 B │           │       -5 B │ - META-INF/kotlinx_coroutines_core.version                              
           │     -162 B │           │       -6 B │ - META-INF/androidx.compose.ui_ui.version                               
           │     -162 B │           │       -6 B │ - META-INF/androidx.core_core-ktx.version                               
           │     -162 B │           │       -6 B │ - META-INF/androidx.emoji2_emoji2.version                               
           │     -162 B │           │       -6 B │ - META-INF/androidx.loader_loader.version                               
           │     -162 B │           │       -6 B │ - META-INF/androidx.room_room-ktx.version                               
           │     -162 B │           │       -6 B │ - META-INF/androidx.sqlite_sqlite.version                               
           │     -162 B │           │       -6 B │ - META-INF/androidx.window_window.version                               
           │     -158 B │           │       -6 B │ - META-INF/androidx.print_print.version                                 
           │     -154 B │           │       -6 B │ - META-INF/androidx.core_core.version                                   
  11.7 KiB │     -137 B │  11.5 KiB │     -137 B │ ∆ assets/dexopt/baseline.prof                                           
     129 B │     +129 B │       5 B │       +5 B │ + META-INF/services/wb.i0                                               
           │     -129 B │           │       -5 B │ - META-INF/services/ec.j0                                               
     127 B │     +127 B │       5 B │       +5 B │ + META-INF/services/bc.t                                                
           │     -127 B │           │       -5 B │ - META-INF/services/jc.t                                                
   5.5 KiB │       +3 B │  24.1 KiB │        0 B │ ∆ AndroidManifest.xml                                                   
  24.7 KiB │       +2 B │  24.6 KiB │        0 B │ ∆ res/-T.png                                                            
     880 B │       +1 B │     748 B │       +7 B │ ∆ assets/dexopt/baseline.profm                                          
───────────┼────────────┼───────────┼────────────┼─────────────────────────────────────────────────────────────────────────
   4.9 MiB │   -489 KiB │  11.3 MiB │   -1.1 MiB │ (total)                                                                 



======================
====   MANIFEST   ====
======================

              │ old                  │ new                  
──────────────┼──────────────────────┼──────────────────────
 package      │ app.lawnchair        │ app.lawnchair        
 version code │ 12010005             │ 12010005             
 version name │ 12.1.0 Dev (504648b) │ 12.1.0 Dev (84a1c2a) 


@@ -4,3 +4,3 @@
     android:versionCode="12010005"
-    android:versionName="12.1.0 Dev (504648b)"
+    android:versionName="12.1.0 Dev (84a1c2a)"
     package="app.lawnchair"



=================
====   DEX   ====
=================

STRINGS:

   old   │ new   │ diff                 
  ───────┼───────┼──────────────────────
   68269 │ 61018 │ -7251 (+7262 -14513) 
```


## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
