### PR TITLE
Automatic icon reload on night mode change

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -53,7 +53,7 @@
             android:stateNotNeeded="true"
             android:windowSoftInputMode="adjustPan"
             android:screenOrientation="unspecified"
-            android:configChanges="keyboard|keyboardHidden|mcc|mnc|navigation|orientation|screenSize|screenLayout|smallestScreenSize"
+            android:configChanges="keyboard|keyboardHidden|mcc|mnc|navigation|orientation|screenSize|screenLayout|smallestScreenSize|uiMode"
             android:resizeableActivity="true"
             android:resumeWhilePausing="true"
             android:taskAffinity=""

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -413,15 +413,12 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
     }
 
     private fun isNightConfigChanged(newConfig: Configuration): Boolean {
-        return newConfig.diff(mOldConfig) and ActivityInfo.CONFIG_UI_MODE != 0 && isOnDarkMode(
-            newConfig
-        ) != isOnDarkMode(
-            mOldConfig!!
-        )
+        return newConfig.diff(mOldConfig) and ActivityInfo.CONFIG_UI_MODE != 0 &&
+            newConfig.isOnDarkMode() != mOldConfig?.isOnDarkMode()
     }
 
-    private fun isOnDarkMode(configuration: Configuration): Boolean {
-        return configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
+    private fun Configuration.isOnDarkMode(): Boolean {
+        return uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
     }
 
     companion object {

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -365,6 +365,8 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         if (isNightConfigChanged(newConfig)) {
+            // Reload icons when night mode changes
+            // Done to avoid incorrect icons being shown when the active icon pack is dynamic
             forceReloadIcons()
         }
         mOldConfig = newConfig

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -159,7 +159,6 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
     val gestureController by lazy { GestureController(this) }
     private val defaultOverlay by lazy { OverlayCallbackImpl(this) }
     private val prefs by lazy { PreferenceManager.getInstance(this) }
-    private val preferenceManager by lazy { PreferenceManager.getInstance(this) }
     private val preferenceManager2 by lazy { PreferenceManager2.getInstance(this) }
     private val insetsController by lazy { WindowInsetsControllerCompat(launcher.window, rootView) }
 
@@ -407,9 +406,9 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
      * Reset the value of [PreferenceManager.iconPackPackage] to force reload icons in the launcher.
      */
     private fun forceReloadIcons() {
-        val iconPack = preferenceManager.iconPackPackage.get()
-        preferenceManager.iconPackPackage.set("")
-        preferenceManager.iconPackPackage.set(iconPack)
+        val iconPack = prefs.iconPackPackage.get()
+        prefs.iconPackPackage.set("")
+        prefs.iconPackPackage.set(iconPack)
     }
 
     private fun isNightConfigChanged(newConfig: Configuration): Boolean {

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -407,8 +407,10 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
      */
     private fun forceReloadIcons() {
         val iconPack = prefs.iconPackPackage.get()
-        prefs.iconPackPackage.set("")
-        prefs.iconPackPackage.set(iconPack)
+        if (iconPack != "") {
+            prefs.iconPackPackage.set("")
+            prefs.iconPackPackage.set(iconPack)
+        }
     }
 
     private fun isNightConfigChanged(newConfig: Configuration): Boolean {

--- a/quickstep/AndroidManifest-launcher.xml
+++ b/quickstep/AndroidManifest-launcher.xml
@@ -52,7 +52,7 @@
             android:stateNotNeeded="true"
             android:windowSoftInputMode="adjustPan"
             android:screenOrientation="unspecified"
-            android:configChanges="keyboard|keyboardHidden|mcc|mnc|navigation|orientation|screenSize|screenLayout|smallestScreenSize"
+            android:configChanges="keyboard|keyboardHidden|mcc|mnc|navigation|orientation|screenSize|screenLayout|smallestScreenSize|uiMode"
             android:resizeableActivity="true"
             android:resumeWhilePausing="true"
             android:taskAffinity=""


### PR DESCRIPTION
## Description

This PR makes _Lawnchair_ listen to `uiMode` configuration changes & reload icons when night mode changes.

Fixes the night mode part of #2882

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
