### PR TITLE
Fix top bar scroll behavior

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/NestedScrollStretch.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/NestedScrollStretch.kt
@@ -121,7 +121,7 @@ private class NestedScrollStretchConnection(context: Context, invalidate: Runnab
                 bottomEdgeEffect.onRelease()
             }
         }
-        return available
+        return Offset.Zero
     }
 
     override suspend fun onPreFling(available: Velocity): Velocity {
@@ -138,6 +138,6 @@ private class NestedScrollStretchConnection(context: Context, invalidate: Runnab
         } else {
             bottomEdgeEffect.onAbsorb(-availableY.toInt())
         }
-        return Velocity(0f, availableY)
+        return Velocity.Zero
     }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/PreferenceScaffold.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/PreferenceScaffold.kt
@@ -38,7 +38,7 @@ fun PreferenceScaffold(
     bottomBar: @Composable () -> Unit = { BottomSpacer() },
     content: @Composable (PaddingValues) -> Unit
 ) {
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {


### PR DESCRIPTION
## Description

Previously, we were temporarily using the `enterAlwaysScrollBehavior` behavior for the top bar, which expands when scrolling up even when not at the top.
This PR fixes the bug in the scroll stretch effect that interferes with the top bar expansion logic, and changes the scroll behavior of the top bar to `exitUntilCollapsedScrollBehavior`.

Before:
[before.webm](https://user-images.githubusercontent.com/8080853/193392374-1c2f0d81-0006-44bb-bf7f-073308c0ba87.webm)

After:
[after.webm](https://user-images.githubusercontent.com/8080853/193392379-29c2f88e-440f-4001-b219-0bf7db16a3d3.webm)


## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
✅  Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
