### PR TITLE
Show empty search text when there is no market

### DIFF
--- a/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
@@ -82,6 +82,9 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
             appResults.mapTo(results, ::createSearchTarget)
         }
         if (results.isEmpty()) {
+            if (marketSearchComponent == null) {
+                return arrayListOf(AllAppsGridAdapter.AdapterItem.asEmptySearch(0))
+            }
             results.add(getEmptySearchItem(query))
         }
         val adapterItems = transformSearchResults(results)


### PR DESCRIPTION
## Description

This fixes #2988.
When the search result is empty and there is no market app to handle the search intent, show the empty search text instead of the search more apps button.

![Screenshot_20221001_121415](https://user-images.githubusercontent.com/8080853/193393876-11b56c14-88fb-4849-ba61-92ed0719012b.png)

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
✅ Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
