### PR TITLE
Transparent background for themed icons

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -57,6 +57,8 @@
     <string name="workspace_increase_max_grid_size_description">Increase the max allowed Home Screen grid size from 10 x 10 to 20 x 20.</string>
     <string name="always_reload_icons_label">Always Reload Icons</string>
     <string name="always_reload_icons_description">Avoid using cached icons from icon packs</string>
+    <string name="transparent_background_icons">Transparent Background</string>
+    <string name="transparent_background_icons_description">Icon color might updated to match with background in Light Theme</string>
 
     <!-- GeneralPreferences -->
     <string name="home_screen_rotation_label">Home Screen Rotation</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -57,8 +57,8 @@
     <string name="workspace_increase_max_grid_size_description">Increase the max allowed Home Screen grid size from 10 x 10 to 20 x 20.</string>
     <string name="always_reload_icons_label">Always Reload Icons</string>
     <string name="always_reload_icons_description">Avoid using cached icons from icon packs</string>
-    <string name="transparent_background_icons">Transparent Background</string>
-    <string name="transparent_background_icons_description">Icon color might updated to match with background in Light Theme</string>
+    <string name="transparent_background_icons">Transparent Themed Icons</string>
+    <string name="transparent_background_icons_description">Use transparent background on themed icons</string>
 
     <!-- GeneralPreferences -->
     <string name="home_screen_rotation_label">Home Screen Rotation</string>

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
@@ -40,6 +40,7 @@ class PreferenceManager private constructor(private val context: Context) : Base
     val iconPackPackage = StringPref("pref_iconPackPackage", "", reloadIcons)
     val allowRotation = BoolPref("pref_allowRotation", false)
     val wrapAdaptiveIcons = BoolPref("prefs_wrapAdaptive", false, reloadIcons)
+    val transparentIconBackground = BoolPref("prefs_transparentIconBackground", false, reloadIcons)
     val addIconToHome = BoolPref("pref_add_icon_to_home", true)
     val hotseatColumns = IntPref("pref_hotseatColumns", 4, reloadGrid)
     val workspaceColumns = IntPref("pref_workspaceColumns", 4)

--- a/lawnchair/src/app/lawnchair/ui/preferences/ExperimentalFeaturesPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/ExperimentalFeaturesPreferences.kt
@@ -41,6 +41,11 @@ fun ExperimentalFeaturesPreferences() {
                 label = stringResource(id = R.string.always_reload_icons_label),
                 description = stringResource(id = R.string.always_reload_icons_description),
             )
+            SwitchPreference(
+                adapter = prefs.transparentIconBackground.getAdapter(),
+                label = stringResource(id = R.string.transparent_background_icons),
+                description = stringResource(id = R.string.transparent_background_icons_description),
+            )
         }
     }
 }


### PR DESCRIPTION
## Description

It would be nice to have an option to make icon background transparent when themed icons (with Lawnicons) used.

Closes #3003

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
 :white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)


Impementation step.

- Added switch to enable `Transparent Background` as Experimental option.
- If `Transparent Background` Enabled background would be set to transparent.
     - No other change applied to dark mode
     - Previous Icon color will be odd or to transparent in light theme without icon background. So composite color will be calculared for current Icon color and same will be applied.


