### PR TITLE
Hide hidden apps in search

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -71,7 +71,7 @@
     <bool name="config_default_lock_home_screen">false</bool>
     <bool name="config_default_lock_home_screen_on_popup">false</bool>
     <bool name="config_default_hide_app_drawer_search_bar">false</bool>
-    <bool name="config_default_show_hidden_apps_in_search_bar">false</bool>
+    <bool name="config_default_show_hidden_apps_in_search">false</bool>
     <bool name="config_default_enable_font_selection">true</bool>
     <bool name="config_default_enable_smartspace_calendar_selection">true</bool>
     <bool name="config_default_dts2">true</bool>

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -71,6 +71,7 @@
     <bool name="config_default_lock_home_screen">false</bool>
     <bool name="config_default_lock_home_screen_on_popup">false</bool>
     <bool name="config_default_hide_app_drawer_search_bar">false</bool>
+    <bool name="config_default_show_hidden_apps_in_search_bar">false</bool>
     <bool name="config_default_enable_font_selection">true</bool>
     <bool name="config_default_enable_smartspace_calendar_selection">true</bool>
     <bool name="config_default_dts2">true</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -281,7 +281,7 @@
 
     <string name="pref_category_search">Search</string>
       <string name="show_app_search_bar">Show Search Bar</string>
-      <string name="show_hidden_apps_search_bar">Show Hidden Apps In Search Bar</string>
+      <string name="show_hidden_apps_search">Show Hidden Apps In Search</string>
       <string name="pref_search_auto_show_keyboard">Automatically Show Keyboard</string>
       <string name="fuzzy_search_title">Fuzzy Search</string>
       <string name="fuzzy_search_desc">Approximate matching for app searches.</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -281,6 +281,7 @@
 
     <string name="pref_category_search">Search</string>
       <string name="show_app_search_bar">Show Search Bar</string>
+      <string name="show_hidden_apps_search_bar">Show Hidden Apps In Search Bar</string>
       <string name="pref_search_auto_show_keyboard">Automatically Show Keyboard</string>
       <string name="fuzzy_search_title">Fuzzy Search</string>
       <string name="fuzzy_search_desc">Approximate matching for app searches.</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -192,6 +192,12 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         onSet = { reloadHelper.recreate() }
     )
 
+    val showHiddenAppsInSearchBar = preference(
+        key = booleanPreferencesKey(name = "show_hidden_apps_in_search_bar"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_show_hidden_apps_in_search_bar),
+        onSet = { reloadHelper.recreate() }
+    )
+
     val enableFontSelection = preference(
         key = booleanPreferencesKey(name = "enable_font_selection"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_enable_font_selection),

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -192,9 +192,9 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         onSet = { reloadHelper.recreate() }
     )
 
-    val showHiddenAppsInSearchBar = preference(
-        key = booleanPreferencesKey(name = "show_hidden_apps_in_search_bar"),
-        defaultValue = context.resources.getBoolean(R.bool.config_default_show_hidden_apps_in_search_bar),
+    val showHiddenAppsInSearch = preference(
+        key = booleanPreferencesKey(name = "show_hidden_apps_in_search"),
+        defaultValue = context.resources.getBoolean(R.bool.config_default_show_hidden_apps_in_search),
         onSet = { reloadHelper.recreate() }
     )
 

--- a/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
@@ -162,8 +162,13 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
         return createSearchTarget(id, action, extras)
     }
 
-    private fun Sequence<AppInfo>.filterHiddenApps(): Sequence<AppInfo> =
-        filter { showHiddenAppsInSearch || it.toComponentKey().toString() !in hiddenApps }
+    private fun Sequence<AppInfo>.filterHiddenApps(): Sequence<AppInfo> {
+        return if (showHiddenAppsInSearch) {
+            this
+        } else {
+            filter { it.toComponentKey().toString() !in hiddenApps }
+        }
+    }
 
     companion object {
         private const val maxResultsCount = 5

--- a/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
@@ -6,11 +6,8 @@ import android.graphics.drawable.Icon
 import android.os.Bundle
 import android.os.Handler
 import android.os.Process
-import android.util.Log
-import androidx.lifecycle.lifecycleScope
 import app.lawnchair.allapps.SearchResultView
 import app.lawnchair.launcher
-import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences2.PreferenceManager2
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.R
@@ -27,12 +24,11 @@ import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.util.Executors
 import com.android.launcher3.util.PackageManagerHelper
 import com.patrykmichalik.opto.core.onEach
+import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import me.xdrop.fuzzywuzzy.FuzzySearch
 import me.xdrop.fuzzywuzzy.algorithms.WeightedRatio
-import java.util.*
-import java.util.stream.Collectors
 
 class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(context) {
 
@@ -119,7 +115,7 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
         val matcher = StringMatcherUtility.StringMatcher.getInstance()
         return apps.asSequence()
             .filter { StringMatcherUtility.matches(queryTextLower, it.title.toString(), matcher) }
-            .filter { showHiddenAppsInSearch || !hiddenApps.contains(it.toComponentKey().toString()) }
+            .filter { showHiddenAppsInSearch || it.toComponentKey().toString() !in hiddenApps }
             .take(maxResultsCount)
             .toList()
     }
@@ -127,7 +123,9 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
     private fun fuzzySearch(apps: List<AppInfo>, query: String): List<AppInfo> {
 
         val filteredApps = apps.asSequence()
-            .filter { showHiddenAppsInSearch || !hiddenApps.contains(it.toComponentKey().toString()) }
+            .filter {
+                showHiddenAppsInSearch || it.toComponentKey().toString() !in hiddenApps
+            }
             .toList()
         val matches = FuzzySearch.extractSorted(
             query.lowercase(Locale.getDefault()), filteredApps,

--- a/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
@@ -115,7 +115,7 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
         val matcher = StringMatcherUtility.StringMatcher.getInstance()
         return apps.asSequence()
             .filter { StringMatcherUtility.matches(queryTextLower, it.title.toString(), matcher) }
-            .filter { showHiddenAppsInSearch || it.toComponentKey().toString() !in hiddenApps }
+            .showHiddenApps()
             .take(maxResultsCount)
             .toList()
     }
@@ -123,9 +123,7 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
     private fun fuzzySearch(apps: List<AppInfo>, query: String): List<AppInfo> {
 
         val filteredApps = apps.asSequence()
-            .filter {
-                showHiddenAppsInSearch || it.toComponentKey().toString() !in hiddenApps
-            }
+            .showHiddenApps()
             .toList()
         val matches = FuzzySearch.extractSorted(
             query.lowercase(Locale.getDefault()), filteredApps,
@@ -163,6 +161,9 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
         }
         return createSearchTarget(id, action, extras)
     }
+
+    private fun Sequence<AppInfo>.showHiddenApps(): Sequence<AppInfo> =
+        filter { showHiddenAppsInSearch || it.toComponentKey().toString() !in hiddenApps }
 
     companion object {
         private const val maxResultsCount = 5

--- a/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
@@ -115,7 +115,7 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
         val matcher = StringMatcherUtility.StringMatcher.getInstance()
         return apps.asSequence()
             .filter { StringMatcherUtility.matches(queryTextLower, it.title.toString(), matcher) }
-            .showHiddenApps()
+            .filterHiddenApps()
             .take(maxResultsCount)
             .toList()
     }
@@ -123,7 +123,7 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
     private fun fuzzySearch(apps: List<AppInfo>, query: String): List<AppInfo> {
 
         val filteredApps = apps.asSequence()
-            .showHiddenApps()
+            .filterHiddenApps()
             .toList()
         val matches = FuzzySearch.extractSorted(
             query.lowercase(Locale.getDefault()), filteredApps,
@@ -162,7 +162,7 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
         return createSearchTarget(id, action, extras)
     }
 
-    private fun Sequence<AppInfo>.showHiddenApps(): Sequence<AppInfo> =
+    private fun Sequence<AppInfo>.filterHiddenApps(): Sequence<AppInfo> =
         filter { showHiddenAppsInSearch || it.toComponentKey().toString() !in hiddenApps }
 
     companion object {

--- a/lawnchair/src/app/lawnchair/ui/preferences/AppDrawerPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/AppDrawerPreferences.kt
@@ -63,10 +63,15 @@ fun AppDrawerPreferences() {
         }
         val deviceSearchEnabled = LawnchairSearchAlgorithm.isDeviceSearchEnabled(LocalContext.current)
         val showDrawerSearchBar = !prefs2.hideAppDrawerSearchBar.getAdapter()
+        val showHiddenAppsInSearchBar = prefs2.showHiddenAppsInSearchBar.getAdapter()
         PreferenceGroup(heading = stringResource(id = R.string.pref_category_search)) {
             SwitchPreference(
                 label = stringResource(id = R.string.show_app_search_bar),
                 adapter = showDrawerSearchBar,
+            )
+            SwitchPreference(
+                label = stringResource(id = R.string.show_hidden_apps_search_bar),
+                adapter = showHiddenAppsInSearchBar,
             )
             ExpandAndShrink(visible = showDrawerSearchBar.state.value) {
                 DividerColumn {

--- a/lawnchair/src/app/lawnchair/ui/preferences/AppDrawerPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/AppDrawerPreferences.kt
@@ -63,15 +63,15 @@ fun AppDrawerPreferences() {
         }
         val deviceSearchEnabled = LawnchairSearchAlgorithm.isDeviceSearchEnabled(LocalContext.current)
         val showDrawerSearchBar = !prefs2.hideAppDrawerSearchBar.getAdapter()
-        val showHiddenAppsInSearchBar = prefs2.showHiddenAppsInSearchBar.getAdapter()
+        val showHiddenAppsInSearch = prefs2.showHiddenAppsInSearch.getAdapter()
         PreferenceGroup(heading = stringResource(id = R.string.pref_category_search)) {
             SwitchPreference(
                 label = stringResource(id = R.string.show_app_search_bar),
                 adapter = showDrawerSearchBar,
             )
             SwitchPreference(
-                label = stringResource(id = R.string.show_hidden_apps_search_bar),
-                adapter = showHiddenAppsInSearchBar,
+                label = stringResource(id = R.string.show_hidden_apps_search),
+                adapter = showHiddenAppsInSearch,
             )
             ExpandAndShrink(visible = showDrawerSearchBar.state.value) {
                 DividerColumn {


### PR DESCRIPTION
- Hide apps in search by default.
- Added switch to show hidden apps in search, If needed for someone.

Note :
I have give option as `Show Hidden Apps In Search Bar`  but rather can be used as `Show Hidden Apps` alone since this option falls below search menu, I will update it based in comments.

## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->


Fixes #2981 

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
 :white_check_mark:  Bug fix (non-breaking change which fixes an issue)
 :white_check_mark:  New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
