### PR TITLE
Custom icon shape creator/editor

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -66,10 +66,22 @@
     <!-- <string name="icons" /> -->
       <string name="icon_style">Icon Style</string>
       <string name="icon_shape_label">Icon Shape</string>
+      <string name="custom_icon_shape">Custom Icon Shape</string>
+      <string name="custom_icon_shape_create">Create Custom Icon Shape</string>
+      <string name="custom_icon_shape_edit">Edit Custom Icon Shape</string>
       <string name="auto_adaptive_icons_label">Auto Adaptive Icons</string>
       <string name="auto_adaptive_icons_description">For all non-Adaptive icons.</string>
       <string name="background_lightness_label">Background Lightness</string>
       <string name="adaptive_icon_background_description">Use 100% background lightness for white.</string>
+      <string name="icon_shape_corner">Corner Shape</string>
+      <string name="icon_shape_corner_round">Round</string>
+      <string name="icon_shape_corner_squircle">Smooth</string>
+      <string name="icon_shape_corner_cut">Cut</string>
+      <string name="icon_shape_top_left">Top Left</string>
+      <string name="icon_shape_top_right">Top Right</string>
+      <string name="icon_shape_bottom_left">Bottom Left</string>
+      <string name="icon_shape_bottom_right">Bottom Right</string>
+      <string name="create">Create</string>
 
     <string name="notification_dots">Notification Dots</string>
       <!-- <string name="notification_dots" />-->

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -66,22 +66,10 @@
     <!-- <string name="icons" /> -->
       <string name="icon_style">Icon Style</string>
       <string name="icon_shape_label">Icon Shape</string>
-      <string name="custom_icon_shape">Custom Icon Shape</string>
-      <string name="custom_icon_shape_create">Create Custom Icon Shape</string>
-      <string name="custom_icon_shape_edit">Edit Custom Icon Shape</string>
       <string name="auto_adaptive_icons_label">Auto Adaptive Icons</string>
       <string name="auto_adaptive_icons_description">For all non-Adaptive icons.</string>
       <string name="background_lightness_label">Background Lightness</string>
       <string name="adaptive_icon_background_description">Use 100% background lightness for white.</string>
-      <string name="icon_shape_corner">Corner Shape</string>
-      <string name="icon_shape_corner_round">Round</string>
-      <string name="icon_shape_corner_squircle">Smooth</string>
-      <string name="icon_shape_corner_cut">Cut</string>
-      <string name="icon_shape_top_left">Top Left</string>
-      <string name="icon_shape_top_right">Top Right</string>
-      <string name="icon_shape_bottom_left">Bottom Left</string>
-      <string name="icon_shape_bottom_right">Bottom Right</string>
-      <string name="create">Create</string>
 
     <string name="notification_dots">Notification Dots</string>
       <!-- <string name="notification_dots" />-->
@@ -104,6 +92,20 @@
       <string name="theme_system_default">System</string>
       <string name="theme_follow_wallpaper">Match Wallpaper</string>
       <string name="accent_color">Accent Color</string>
+
+    <!-- CustomIconShapePreference -->
+    <string name="custom_icon_shape">Custom Icon Shape</string>
+    <string name="custom_icon_shape_create">Create Custom Icon Shape</string>
+    <string name="custom_icon_shape_edit">Edit Custom Icon Shape</string>
+    <string name="icon_shape_corner">Corner Shape</string>
+    <string name="icon_shape_corner_round">Round</string>
+    <string name="icon_shape_corner_squircle">Smooth</string>
+    <string name="icon_shape_corner_cut">Cut</string>
+    <string name="icon_shape_top_left">Top Left</string>
+    <string name="icon_shape_top_right">Top Right</string>
+    <string name="icon_shape_bottom_left">Bottom Left</string>
+    <string name="icon_shape_bottom_right">Bottom Right</string>
+    <string name="create">Create</string>
 
     <!-- IconPackPreferences -->
     <!-- <string name="icon_style" /> -->

--- a/lawnchair/src/app/lawnchair/icons/shape/IconShape.kt
+++ b/lawnchair/src/app/lawnchair/icons/shape/IconShape.kt
@@ -159,6 +159,26 @@ open class IconShape(val topLeft: Corner,
 
     open fun getHashString() = toString()
 
+    fun copy(
+        topLeftShape: IconCornerShape = topLeft.shape,
+        topRightShape: IconCornerShape = topRight.shape,
+        bottomLeftShape: IconCornerShape = bottomLeft.shape,
+        bottomRightShape: IconCornerShape = bottomRight.shape,
+        topLeftScale: Float = topLeft.scale.x,
+        topRightScale: Float = topRight.scale.x,
+        bottomLeftScale: Float = bottomLeft.scale.x,
+        bottomRightScale: Float = bottomRight.scale.x,
+    ): IconShape = IconShape(
+        topLeftShape = topLeftShape,
+        topRightShape = topRightShape,
+        bottomLeftShape = bottomLeftShape,
+        bottomRightShape = bottomRightShape,
+        topLeftScale = topLeftScale,
+        topRightScale = topRightScale,
+        bottomLeftScale = bottomLeftScale,
+        bottomRightScale = bottomRightScale
+    )
+
     data class Corner(val shape: IconCornerShape, val scale: PointF) {
 
         constructor(shape: IconCornerShape, scale: Float) : this(shape, PointF(scale, scale))
@@ -365,6 +385,16 @@ open class IconShape(val topLeft: Corner,
                 Corner.fromString(parts[3]),
                 Corner.fromString(parts[4])
             )
+        }
+
+        fun isCustomShape(iconShape: IconShape): Boolean {
+            return try {
+                parseCustomShape(iconShape.toString())
+                true
+            } catch (ex: Exception) {
+                Log.e("IconShape", "Error creating shape $iconShape", ex)
+                false
+            }
         }
     }
 }

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -34,11 +34,11 @@ import app.lawnchair.theme.color.ColorOption
 import com.android.launcher3.InvariantDeviceProfile
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.R
-import com.android.launcher3.Utilities
 import com.android.launcher3.util.DynamicResource
 import com.android.launcher3.util.MainThreadInitializedObject
 import com.patrykmichalik.opto.core.PreferenceManager
 import com.patrykmichalik.opto.core.firstBlocking
+import com.patrykmichalik.opto.core.setBlocking
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
@@ -85,6 +85,14 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         defaultValue = IconShape.fromString(context.getString(R.string.config_default_icon_shape)) ?: IconShape.Circle,
         parse = { IconShape.fromString(it) ?: IconShapeManager.getSystemIconShape(context) },
         save = { it.toString() },
+    )
+
+    val customIconShape = preference(
+        key = stringPreferencesKey(name = "custom_icon_shape"),
+        defaultValue = null,
+        parse = { IconShape.fromString(it) ?: IconShapeManager.getSystemIconShape(context) },
+        save = { it.toString() },
+        onSet = { it?.let { iconShape.setBlocking(value = it) } },
     )
 
     val alwaysReloadIcons = preference(

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -92,7 +92,7 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         defaultValue = null,
         parse = { IconShape.fromString(it) ?: IconShapeManager.getSystemIconShape(context) },
         save = { it.toString() },
-        onSet = { it?.let { iconShape.setBlocking(value = it) } },
+        onSet = { it?.let(iconShape::setBlocking) },
     )
 
     val alwaysReloadIcons = preference(

--- a/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapeCreator.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapeCreator.kt
@@ -58,8 +58,7 @@ fun NavGraphBuilder.customIconShapeCreatorGraph(route: String) {
 }
 
 @Composable
-private fun CustomIconShapeCreator(
-) {
+private fun CustomIconShapeCreator() {
 
     val preferenceManager2 = preferenceManager2()
 
@@ -317,9 +316,8 @@ private fun CornerSlider(
 }
 
 @Composable
-private fun IconCornerShape.getLabel() =
-    when (this) {
-        IconCornerShape.squircle -> stringResource(id = R.string.icon_shape_corner_squircle)
-        IconCornerShape.cut -> stringResource(id = R.string.icon_shape_corner_cut)
-        else -> stringResource(id = R.string.icon_shape_corner_round)
-    }
+private fun IconCornerShape.getLabel() = when (this) {
+    IconCornerShape.squircle -> stringResource(id = R.string.icon_shape_corner_squircle)
+    IconCornerShape.cut -> stringResource(id = R.string.icon_shape_corner_cut)
+    else -> stringResource(id = R.string.icon_shape_corner_round)
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapeCreator.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapeCreator.kt
@@ -1,0 +1,325 @@
+package app.lawnchair.ui.preferences
+
+import android.graphics.PointF
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.RadioButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowDropDown
+import androidx.compose.material3.Button
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavGraphBuilder
+import app.lawnchair.icons.shape.IconCornerShape
+import app.lawnchair.icons.shape.IconShape
+import app.lawnchair.preferences.getAdapter
+import app.lawnchair.preferences2.preferenceManager2
+import app.lawnchair.ui.AlertBottomSheetContent
+import app.lawnchair.ui.preferences.components.BottomSpacer
+import app.lawnchair.ui.preferences.components.IconShapePreview
+import app.lawnchair.ui.preferences.components.PreferenceDivider
+import app.lawnchair.ui.preferences.components.PreferenceGroup
+import app.lawnchair.ui.preferences.components.PreferenceLayout
+import app.lawnchair.ui.preferences.components.PreferenceTemplate
+import app.lawnchair.ui.preferences.components.getSteps
+import app.lawnchair.ui.preferences.components.snapSliderValue
+import app.lawnchair.ui.util.LocalBottomSheetHandler
+import com.android.launcher3.R
+import kotlin.math.roundToInt
+
+fun NavGraphBuilder.customIconShapeCreatorGraph(route: String) {
+    preferenceGraph(route, { CustomIconShapeCreator() })
+}
+
+@Composable
+private fun CustomIconShapeCreator(
+) {
+
+    val preferenceManager2 = preferenceManager2()
+
+    val customIconShapeAdapter = preferenceManager2.customIconShape.getAdapter()
+
+    val appliedIconShape = customIconShapeAdapter.state.value
+    val selectedIconShape = remember { mutableStateOf(appliedIconShape ?: IconShape.Circle) }
+    val selectedIconShapeApplied = derivedStateOf {
+        appliedIconShape.toString() == selectedIconShape.value.toString()
+    }
+
+    PreferenceLayout(
+        label = stringResource(id = R.string.custom_icon_shape),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        bottomBar = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.End
+            ) {
+                Button(
+                    enabled = !selectedIconShapeApplied.value,
+                    onClick = {
+                        customIconShapeAdapter.onChange(newValue = selectedIconShape.value)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(all = 16.dp),
+                ) {
+                    Text(
+                        text = if (appliedIconShape != null) stringResource(id = R.string.apply_grid)
+                        else stringResource(id = R.string.create),
+                    )
+                }
+                BottomSpacer()
+            }
+        },
+    ) {
+
+        IconShapePreview(
+            modifier = Modifier,
+            iconShape = selectedIconShape.value,
+        )
+
+        IconShapeCornerPreferenceGroup(
+            selectedIconShape = selectedIconShape.value,
+            onSelectedIconShapeChange = { newIconShape ->
+                selectedIconShape.value = newIconShape
+            }
+        )
+    }
+
+}
+
+@Composable
+private fun IconShapeCornerPreferenceGroup(
+    selectedIconShape: IconShape,
+    onSelectedIconShapeChange: (IconShape) -> Unit,
+) {
+    PreferenceGroup {
+        IconShapeCornerPreference(
+            title = stringResource(id = R.string.icon_shape_top_left),
+            scale = selectedIconShape.topLeft.scale.x,
+            onScaleChange = {
+                onSelectedIconShapeChange(selectedIconShape.copy(topLeftScale = it))
+            },
+            cornerShape = selectedIconShape.topLeft.shape,
+            onCornerShapeChange = {
+                onSelectedIconShapeChange(selectedIconShape.copy(topLeftShape = it))
+            },
+        )
+        IconShapeCornerPreference(
+            title = stringResource(id = R.string.icon_shape_top_right),
+            scale = selectedIconShape.topRight.scale.x,
+            onScaleChange = {
+                onSelectedIconShapeChange(selectedIconShape.copy(topRightScale = it))
+            },
+            cornerShape = selectedIconShape.topRight.shape,
+            onCornerShapeChange = {
+                onSelectedIconShapeChange(selectedIconShape.copy(topRightShape = it))
+            },
+        )
+        IconShapeCornerPreference(
+            title = stringResource(id = R.string.icon_shape_bottom_left),
+            scale = selectedIconShape.bottomLeft.scale.x,
+            onScaleChange = {
+                onSelectedIconShapeChange(selectedIconShape.copy(bottomLeftScale = it))
+            },
+            cornerShape = selectedIconShape.bottomLeft.shape,
+            onCornerShapeChange = {
+                onSelectedIconShapeChange(selectedIconShape.copy(bottomLeftShape = it))
+            },
+        )
+        IconShapeCornerPreference(
+            title = stringResource(id = R.string.icon_shape_bottom_right),
+            scale = selectedIconShape.bottomRight.scale.x,
+            onScaleChange = {
+                onSelectedIconShapeChange(selectedIconShape.copy(bottomRightScale = it))
+            },
+            cornerShape = selectedIconShape.bottomRight.shape,
+            onCornerShapeChange = {
+                onSelectedIconShapeChange(selectedIconShape.copy(bottomRightShape = it))
+            },
+        )
+    }
+}
+
+@Composable
+private fun IconShapeCornerPreference(
+    modifier: Modifier = Modifier,
+    title: String,
+    scale: Float,
+    onScaleChange: (Float) -> Unit,
+    cornerShape: IconCornerShape,
+    onCornerShapeChange: (IconCornerShape) -> Unit,
+) {
+    CornerSlider(
+        modifier = modifier,
+        label = title,
+        value = scale,
+        onValueChange = { newValue ->
+            onScaleChange(newValue)
+        },
+        cornerShape = cornerShape,
+        onCornerShapeChange = onCornerShapeChange,
+    )
+}
+
+@Composable
+private fun CornerSlider(
+    modifier: Modifier = Modifier,
+    label: String,
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    cornerShape: IconCornerShape,
+    onCornerShapeChange: (IconCornerShape) -> Unit,
+) {
+    val bottomSheetHandler = LocalBottomSheetHandler.current
+    val options = listOf<IconCornerShape>(
+        IconCornerShape.arc,
+        IconCornerShape.squircle,
+        IconCornerShape.cut,
+    )
+
+    val step = 0.1f
+    val valueRange = 0f..1f
+
+    PreferenceTemplate(
+        modifier = modifier
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 12.dp),
+        title = {
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+            ) {
+                Text(text = label)
+                CompositionLocalProvider(
+                    LocalContentAlpha provides ContentAlpha.medium,
+                    LocalContentColor provides MaterialTheme.colorScheme.onBackground,
+                ) {
+                    val valueText = stringResource(
+                        id = R.string.n_percent,
+                        (snapSliderValue(valueRange.start, value, step) * 100).roundToInt()
+                    )
+                    Text(text = valueText)
+                }
+            }
+        },
+        description = {
+            Row(
+                modifier = Modifier.padding(top = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Slider(
+                    value = value,
+                    onValueChange = onValueChange,
+                    valueRange = valueRange,
+                    steps = getSteps(valueRange, step),
+                    modifier = Modifier
+                        .height(24.dp)
+                        .weight(1f)
+                        .padding(horizontal = 3.dp),
+                )
+            }
+        },
+        endWidget = {
+            Row(
+                modifier = Modifier
+                    .padding(
+                        start = 16.dp,
+                        top = 12.dp,
+                    )
+                    .clip(shape = MaterialTheme.shapes.small)
+                    .clickable {
+                        bottomSheetHandler.show {
+                            AlertBottomSheetContent(
+                                title = { Text(stringResource(id = R.string.icon_shape_corner)) },
+                                buttons = {
+                                    OutlinedButton(onClick = { bottomSheetHandler.hide() }) {
+                                        Text(text = stringResource(id = android.R.string.cancel))
+                                    }
+                                }
+                            ) {
+                                LazyColumn {
+                                    itemsIndexed(options) { index, option ->
+                                        if (index > 0) {
+                                            PreferenceDivider(startIndent = 40.dp)
+                                        }
+                                        val selected = cornerShape::class.java == option::class.java
+                                        PreferenceTemplate(
+                                            title = {
+                                                Text(
+                                                    text = option.getLabel(),
+                                                )
+                                            },
+                                            modifier = Modifier.clickable {
+                                                bottomSheetHandler.hide()
+                                                onCornerShapeChange(option)
+                                            },
+                                            startWidget = {
+                                                RadioButton(
+                                                    selected = selected,
+                                                    onClick = null
+                                                )
+                                            },
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(
+                        start = 8.dp,
+                        top = 4.dp,
+                        bottom = 4.dp,
+                    ),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    modifier = Modifier.requiredWidthIn(min = 48.dp),
+                    text = cornerShape.getLabel(),
+                    fontSize = 14.sp,
+                )
+                Icon(
+                    imageVector = Icons.Rounded.ArrowDropDown,
+                    contentDescription = null,
+                )
+            }
+        },
+        applyPaddings = false,
+    )
+}
+
+@Composable
+private fun IconCornerShape.getLabel() =
+    when (this) {
+        IconCornerShape.squircle -> stringResource(id = R.string.icon_shape_corner_squircle)
+        IconCornerShape.cut -> stringResource(id = R.string.icon_shape_corner_cut)
+        else -> stringResource(id = R.string.icon_shape_corner_round)
+    }

--- a/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapePreference.kt
@@ -1,10 +1,8 @@
 package app.lawnchair.ui.preferences
 
-import android.graphics.PointF
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -53,12 +51,12 @@ import app.lawnchair.ui.util.LocalBottomSheetHandler
 import com.android.launcher3.R
 import kotlin.math.roundToInt
 
-fun NavGraphBuilder.customIconShapeCreatorGraph(route: String) {
-    preferenceGraph(route, { CustomIconShapeCreator() })
+fun NavGraphBuilder.customIconShapePreferenceGraph(route: String) {
+    preferenceGraph(route, { CustomIconShapePreference() })
 }
 
 @Composable
-private fun CustomIconShapeCreator() {
+private fun CustomIconShapePreference() {
 
     val preferenceManager2 = preferenceManager2()
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
@@ -87,6 +87,7 @@ fun GeneralPreferences() {
     val iconShapeSubtitle = iconShapeEntries(context)
         .firstOrNull { it.value == iconShapeAdapter.state.value }
         ?.label?.invoke()
+        ?: stringResource(id = R.string.custom)
 
     PreferenceLayout(label = stringResource(id = R.string.general_label)) {
         PreferenceGroup {

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/IconShapePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/IconShapePreference.kt
@@ -55,7 +55,7 @@ import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences2.asState
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.preferences.LocalNavController
-import app.lawnchair.ui.preferences.customIconShapeCreatorGraph
+import app.lawnchair.ui.preferences.customIconShapePreferenceGraph
 import app.lawnchair.ui.preferences.preferenceGraph
 import app.lawnchair.ui.preferences.subRoute
 import com.android.launcher3.R
@@ -66,7 +66,7 @@ object IconShapeRoutes {
 
 fun NavGraphBuilder.iconShapeGraph(route: String) {
     preferenceGraph(route, { IconShapePreference() }) { subRoute ->
-        customIconShapeCreatorGraph(subRoute(IconShapeRoutes.CUSTOM_ICON_SHAPE_CREATOR))
+        customIconShapePreferenceGraph(subRoute(IconShapeRoutes.CUSTOM_ICON_SHAPE_CREATOR))
     }
 }
 
@@ -103,7 +103,9 @@ fun IconShapePreference(
     val customIconShape = preferenceManager2.customIconShape.asState()
 
     PreferenceLayout(label = stringResource(id = R.string.icon_shape_label)) {
-        PreferenceGroup {
+        PreferenceGroup(
+            heading = stringResource(id = R.string.presets),
+        ) {
             entries.forEach { item ->
                 PreferenceTemplate(
                     enabled = item.enabled,
@@ -123,6 +125,10 @@ fun IconShapePreference(
                     },
                 )
             }
+        }
+        PreferenceGroup(
+            heading = stringResource(id = R.string.custom),
+        ) {
             CustomIconShapePreference(
                 iconShapeAdapter = iconShapeAdapter,
             )
@@ -131,7 +137,6 @@ fun IconShapePreference(
             )
         }
     }
-
 }
 
 @Composable


### PR DESCRIPTION
## Description

Adds a brand new **_Custom Icon Shape creator/editor screen_** that lets users create their own unique icon shapes to use.

- The general UI and how two separate _applied_ and _selected_ states are handled in the code is done similarly to how it is done for the _Custom Color Picker_.
- In order to minimize code duplication, I had to write a custom implementation of `copy()` for `IconShape` as we cannot convert it to a `data class`. 
- `iconShapeSubtitle` now shows "Custom" if no icon shape label is found (the label is null).
- All the buttons' texts change based on if the custom icon shape is created or not.
- The three corner shape options are the exact options available on the previous versions of _Lawnchair_.

The complete workflow of the feature is demonstrated in the gif below:

![custom-icon-shape](https://user-images.githubusercontent.com/41836211/195195644-27018bee-59c0-451c-a472-c2bdf16fe307.gif)

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
