### PR TITLE
Icon shape sharing via clipboard

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -109,6 +109,10 @@
     <string name="icon_shape_bottom_left">Bottom Left</string>
     <string name="icon_shape_bottom_right">Bottom Right</string>
     <string name="create">Create</string>
+    <string name="clipboard">Clipboard</string>
+    <string name="export_to_clipboard">Export to Clipboard</string>
+    <string name="import_from_clipboard">Import from Clipboard</string>
+    <string name="icon_shape_clipboard_import_error">Clipboard does not contain a valid icon shape</string>
 
     <!-- IconPackPreferences -->
     <!-- <string name="icon_style" /> -->

--- a/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapePreference.kt
@@ -204,7 +204,9 @@ private fun IconShapeClipboardPreferenceGroup(
             imageVector = Icons.Rounded.ContentPaste,
             label = stringResource(id = R.string.import_from_clipboard),
         ) {
-            getClipboardContent(context = context)?.let { IconShape.fromString(value = it) }?.let {
+            context.getClipboardContent()?.let {
+                IconShape.fromString(value = it)
+            }?.let {
                 onSelectedIconShapeChange(it)
             } ?: run {
                 Toast.makeText(context, importErrorMessage, Toast.LENGTH_SHORT).show()

--- a/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapePreference.kt
@@ -1,5 +1,7 @@
 package app.lawnchair.ui.preferences
 
+import android.widget.Toast
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -16,6 +18,8 @@ import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.RadioButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowDropDown
+import androidx.compose.material.icons.rounded.ContentCopy
+import androidx.compose.material.icons.rounded.ContentPaste
 import androidx.compose.material3.Button
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -25,11 +29,14 @@ import androidx.compose.material3.Slider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -48,6 +55,8 @@ import app.lawnchair.ui.preferences.components.PreferenceTemplate
 import app.lawnchair.ui.preferences.components.getSteps
 import app.lawnchair.ui.preferences.components.snapSliderValue
 import app.lawnchair.ui.util.LocalBottomSheetHandler
+import app.lawnchair.util.copyToClipboard
+import app.lawnchair.util.getClipboardContent
 import com.android.launcher3.R
 import kotlin.math.roundToInt
 
@@ -106,6 +115,13 @@ private fun CustomIconShapePreference() {
                 selectedIconShape.value = newIconShape
             }
         )
+
+        IconShapeClipboardPreferenceGroup(
+            selectedIconShape = selectedIconShape.value,
+            onSelectedIconShapeChange = { newIconShape ->
+                selectedIconShape.value = newIconShape
+            },
+        )
     }
 
 }
@@ -163,6 +179,66 @@ private fun IconShapeCornerPreferenceGroup(
             },
         )
     }
+}
+
+@Composable
+private fun IconShapeClipboardPreferenceGroup(
+    selectedIconShape: IconShape,
+    onSelectedIconShapeChange: (IconShape) -> Unit,
+) {
+    val context = LocalContext.current
+    val importErrorMessage = stringResource(id = R.string.icon_shape_clipboard_import_error)
+    PreferenceGroup(
+        heading = stringResource(id = R.string.clipboard),
+    ) {
+        ClipboardButton(
+            imageVector = Icons.Rounded.ContentCopy,
+            label = stringResource(id = R.string.export_to_clipboard),
+        ) {
+            copyToClipboard(
+                context = context,
+                text = selectedIconShape.toString(),
+            )
+        }
+        ClipboardButton(
+            imageVector = Icons.Rounded.ContentPaste,
+            label = stringResource(id = R.string.import_from_clipboard),
+        ) {
+            getClipboardContent(context = context)?.let { IconShape.fromString(value = it) }?.let {
+                onSelectedIconShapeChange(it)
+            } ?: run {
+                Toast.makeText(context, importErrorMessage, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}
+
+@Composable
+private fun ClipboardButton(
+    modifier: Modifier = Modifier,
+    label: String,
+    description: String? = null,
+    enabled: Boolean = true,
+    imageVector: ImageVector,
+    onClick: () -> Unit,
+) {
+    PreferenceTemplate(
+        modifier = modifier.clickable(enabled = enabled, onClick = onClick),
+        contentModifier = Modifier,
+        title = { Text(text = label) },
+        description = { description?.let { Text(text = it) } },
+        startWidget = {
+            val tint = LocalContentColor.current
+            val contentAlpha = if (enabled) tint.alpha else ContentAlpha.disabled
+            val alpha by animateFloatAsState(targetValue = contentAlpha)
+            Icon(
+                imageVector = imageVector,
+                contentDescription = null,
+                tint = tint.copy(alpha = alpha)
+            )
+        },
+        enabled = enabled,
+    )
 }
 
 @Composable

--- a/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapePreference.kt
@@ -204,7 +204,7 @@ private fun IconShapeClipboardPreferenceGroup(
             imageVector = Icons.Rounded.ContentPaste,
             label = stringResource(id = R.string.import_from_clipboard),
         ) {
-            context.getClipboardContent()?.let {
+            getClipboardContent(context)?.let {
                 IconShape.fromString(value = it)
             }?.let {
                 onSelectedIconShapeChange(it)

--- a/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapePreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/CustomIconShapePreference.kt
@@ -96,7 +96,7 @@ private fun CustomIconShapePreference() {
     ) {
 
         IconShapePreview(
-            modifier = Modifier,
+            modifier = Modifier.padding(top = 12.dp),
             iconShape = selectedIconShape.value,
         )
 
@@ -115,7 +115,9 @@ private fun IconShapeCornerPreferenceGroup(
     selectedIconShape: IconShape,
     onSelectedIconShapeChange: (IconShape) -> Unit,
 ) {
-    PreferenceGroup {
+    PreferenceGroup(
+        heading = stringResource(id = R.string.color_sliders),
+    ) {
         IconShapeCornerPreference(
             title = stringResource(id = R.string.icon_shape_top_left),
             scale = selectedIconShape.topLeft.scale.x,

--- a/lawnchair/src/app/lawnchair/util/ClipboardUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/ClipboardUtils.kt
@@ -1,0 +1,45 @@
+package app.lawnchair.util
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
+import com.android.launcher3.R
+
+fun copyToClipboard(
+    context: Context,
+    text: String,
+    label: String = text,
+    toastMessage: String? = context.getString(R.string.copied_toast),
+) {
+    val clipboardManager: ClipboardManager = context.requireSystemService()
+    val clip = ClipData.newPlainText(label, text)
+    clipboardManager.setPrimaryClip(clip)
+    toastMessage?.let {
+        Toast.makeText(
+            context,
+            it,
+            Toast.LENGTH_SHORT,
+        ).show()
+    }
+}
+
+fun String.copyToClipboard(
+    context: Context,
+    label: String = this,
+    toastMessage: String? = context.getString(R.string.copied_toast),
+) {
+    copyToClipboard(
+        context = context,
+        text = this,
+        label = label,
+        toastMessage = toastMessage,
+    )
+}
+
+fun getClipboardContent(
+    context: Context,
+): String? {
+    val clipboardManager: ClipboardManager = context.requireSystemService()
+    return clipboardManager.primaryClip?.getItemAt(0)?.text?.toString()
+}

--- a/lawnchair/src/app/lawnchair/util/ClipboardUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/ClipboardUtils.kt
@@ -16,11 +16,7 @@ fun copyToClipboard(
     val clip = ClipData.newPlainText(label, text)
     clipboardManager.setPrimaryClip(clip)
     toastMessage?.let {
-        Toast.makeText(
-            context,
-            it,
-            Toast.LENGTH_SHORT,
-        ).show()
+        Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
     }
 }
 

--- a/lawnchair/src/app/lawnchair/util/ClipboardUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/ClipboardUtils.kt
@@ -20,19 +20,6 @@ fun copyToClipboard(
     }
 }
 
-fun String.copyToClipboard(
-    context: Context,
-    label: String = this,
-    toastMessage: String? = context.getString(R.string.copied_toast),
-) {
-    copyToClipboard(
-        context = context,
-        text = this,
-        label = label,
-        toastMessage = toastMessage,
-    )
-}
-
 fun getClipboardContent(
     context: Context,
 ): String? {


### PR DESCRIPTION
## Description

Allows users to import/export the icon shapes from/to the clipboard.

To reduce boilerplate code, I have created a few new helper functions in `ClipboardUtils.kt`. As I didn't want to include unrelated code in this PR, it is only used for the code related to this feature; I will refactor the rest of the code to use these helpers after this is merged.

![icon-shape-clipboard-sharing](https://user-images.githubusercontent.com/41836211/198946107-a36abcc4-acd9-4e71-bb0f-c536dfd7171a.gif)

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
