### PR TITLE
Support themed icons for 3rd party icon packs

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -18,7 +18,7 @@
 <resources>
     <string name="app_filter_class" translatable="false">app.lawnchair.DefaultAppFilter</string>
     <string name="calendar_component_name" translatable="false">com.google.android.calendar/com.android.calendar.AllInOneActivity</string>
-    <string-array name="dynamic_calendar_components_name" translatable="false">
+    <string-array name="dynamic_calendar_components_name">
         <item>com.android.calendar</item>
         <item>com.blackberry.calendar</item>
         <item>com.huawei.calendar</item>

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -18,7 +18,7 @@
 <resources>
     <string name="app_filter_class" translatable="false">app.lawnchair.DefaultAppFilter</string>
     <string name="calendar_component_name" translatable="false">com.google.android.calendar/com.android.calendar.AllInOneActivity</string>
-    <string-array name="dynamic_calendar_components_name">
+    <string-array name="dynamic_calendar_components_name" translatable="false">
         <item>com.android.calendar</item>
         <item>com.blackberry.calendar</item>
         <item>com.huawei.calendar</item>
@@ -31,6 +31,12 @@
         <item>org.withouthat.acalendarplus</item>
         <item>org.withouthat.acalendar</item>
         <item>ws.xsoh.etar</item>
+    </string-array>
+    <string-array name="themed_icon_packs" translatable="false">
+        <!-- The package will working when lawnicons fully converted as iconpack-->
+        <item>com.lawnchair.lawnicons</item>
+        <item>com.donnnno.arcticons</item>
+        <item>com.whicons.iconpack</item>
     </string-array>
     <string name="clock_component_name" translatable="false">com.google.android.deskclock/com.android.deskclock.DeskClock</string>
     <string name="launcher_activity_logic_class" translatable="false">app.lawnchair.LauncherActivityCachingLogic</string>

--- a/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
@@ -1,5 +1,6 @@
 package app.lawnchair.icons
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable

--- a/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
@@ -23,7 +23,7 @@ class IconPackProvider(private val context: Context) {
 
     private val systemIconPack = SystemIconPack(context)
     private val iconPacks = mutableMapOf<String, IconPack?>()
-    private val themedIconPacks = context.getResources().getStringArray( R.array.themed_icon_packs)
+    private val themedIconPacks = context.resources.getStringArray(R.array.themed_icon_packs)
 
     fun getIconPackOrSystem(packageName: String): IconPack? {
         if (packageName.isEmpty()) return systemIconPack

--- a/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
@@ -64,12 +64,10 @@ class IconPackProvider(private val context: Context) {
             val td = ThemedIconDrawable.ThemeData(res, iconEntry.packPackageName, resId)
             val fg = td.wrapDrawable(drawable, 0)
             return if (fg is AdaptiveIconDrawable) {
-                val foregroundDr: Drawable = fg.getForeground()
-                foregroundDr.setTint(themedColors[1])
+                val foregroundDr = fg.foreground.apply { setTint(themedColors[1]) }
                 CustomAdaptiveIconDrawable(bg, foregroundDr)
             } else {
-                val iconFromPack = InsetDrawable(drawable, .3f)
-                iconFromPack.setTint(themedColors[1])
+                val iconFromPack = InsetDrawable(drawable, .3f).apply { setTint(themedColors[1]) }
                 td.wrapDrawable(CustomAdaptiveIconDrawable(bg, iconFromPack), 0)
             }
         }

--- a/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
@@ -52,23 +52,24 @@ class IconPackProvider(private val context: Context) {
         val iconPack = getIconPackOrSystem(iconEntry.packPackageName) ?: return null
         iconPack.loadBlocking()
         val drawable = iconPack.getIcon(iconEntry, iconDpi) ?: return null
-        if(context.isThemedIconsEnabled() && !iconEntry.packPackageName.isEmpty()
-            && (iconEntry.packPackageName.startsWith(LAWNICONS_PACKAGE_NAME)
-                || themedIconPacks.contains(iconEntry.packPackageName))) {
-        val themedColors: IntArray = ThemedIconDrawable.getThemedColors(context)
-        val res = context.packageManager.getResourcesForApplication(iconEntry.packPackageName)
-        val resId = res.getIdentifier(iconEntry.name, "drawable", iconEntry.packPackageName)
-        val bg: Drawable = ColorDrawable(themedColors[0])
-        val td = ThemedIconDrawable.ThemeData(res, iconEntry.packPackageName, resId)
-        val fg = td.wrapDrawable(drawable,0)
-            if (fg is AdaptiveIconDrawable) {
+        if (
+            context.isThemedIconsEnabled() && iconEntry.packPackageName in themedIconPacks
+        ) {
+            val themedColors: IntArray = ThemedIconDrawable.getThemedColors(context)
+            val res = context.packageManager.getResourcesForApplication(iconEntry.packPackageName)
+            @SuppressLint("DiscouragedApi")
+            val resId = res.getIdentifier(iconEntry.name, "drawable", iconEntry.packPackageName)
+            val bg: Drawable = ColorDrawable(themedColors[0])
+            val td = ThemedIconDrawable.ThemeData(res, iconEntry.packPackageName, resId)
+            val fg = td.wrapDrawable(drawable, 0)
+            return if (fg is AdaptiveIconDrawable) {
                 val foregroundDr: Drawable = fg.getForeground()
                 foregroundDr.setTint(themedColors[1])
-                return CustomAdaptiveIconDrawable(bg,foregroundDr)
-            }else{
+                CustomAdaptiveIconDrawable(bg, foregroundDr)
+            } else {
                 val iconFromPack = InsetDrawable(drawable, .3f)
                 iconFromPack.setTint(themedColors[1])
-                return td.wrapDrawable(CustomAdaptiveIconDrawable(bg,iconFromPack), 0)
+                td.wrapDrawable(CustomAdaptiveIconDrawable(bg, iconFromPack), 0)
             }
         }
         val clockMetadata = if (user == Process.myUserHandle()) iconPack.getClock(iconEntry) else null

--- a/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
@@ -134,8 +134,15 @@ fun IconPackPreferences() {
                 modifier = Modifier.padding(bottom = 8.dp),
             )
             PreferenceGroup {
-                val themedIconsAvailable = LocalContext.current.packageManager
+                var themedIconsAvailable = LocalContext.current.packageManager
                     .isPackageInstalled(Constants.LAWNICONS_PACKAGE_NAME)
+                val themedIconPacks = LocalContext.current.resources.getStringArray(R.array.themed_icon_packs)
+                for (themedIconPack in themedIconPacks) {
+                    if(LocalContext.current.packageManager.isPackageInstalled(themedIconPack)) {
+                        themedIconsAvailable = true
+                        break
+                    }
+                }
                 ListPreference(
                     enabled = themedIconsAvailable,
                     label = stringResource(id = R.string.themed_icon_title),

--- a/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
@@ -56,7 +56,6 @@ import app.lawnchair.preferences.PreferenceAdapter
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.ui.preferences.components.*
-import app.lawnchair.util.Constants
 import app.lawnchair.util.isPackageInstalled
 import com.android.launcher3.R
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
@@ -134,15 +133,9 @@ fun IconPackPreferences() {
                 modifier = Modifier.padding(bottom = 8.dp),
             )
             PreferenceGroup {
-                var themedIconsAvailable = LocalContext.current.packageManager
-                    .isPackageInstalled(Constants.LAWNICONS_PACKAGE_NAME)
-                val themedIconPacks = LocalContext.current.resources.getStringArray(R.array.themed_icon_packs)
-                for (themedIconPack in themedIconPacks) {
-                    if(LocalContext.current.packageManager.isPackageInstalled(themedIconPack)) {
-                        themedIconsAvailable = true
-                        break
-                    }
-                }
+                val themedIconsAvailable = LocalContext.current.resources
+                    .getStringArray(R.array.themed_icon_packs)
+                    .any { LocalContext.current.packageManager.isPackageInstalled(it) }
                 ListPreference(
                     enabled = themedIconsAvailable,
                     label = stringResource(id = R.string.themed_icon_title),


### PR DESCRIPTION
## Description
Here I'm planning to cover three feature 

- In app Customisiation for themed Icons(lawnicons)
- LawnIcons as Iconpack (So Lawnicon can be used for icon pack , We can still use lawnicons as Monochromic icons in lwanchair, may be same can be used for othe rlaucnhers too)
- Add Themed Icons support for other icons pack as well apart from lawncions.

Sample:

Lawnicons

https://user-images.githubusercontent.com/7315975/200399398-99cb333b-9f0c-4b06-8a47-bc7484ba0726.mp4


App customisiation from 3rd party icons


https://user-images.githubusercontent.com/7315975/200399425-e024bdc1-d6be-4f7a-aada-97589c62245e.mp4


I have tested with own version of lawnicons (I copied lawicons file to other open source icon pack) to test .

https://github.com/naveenccmsd/lawnicons/releases/download/test/app-debug.apk

Based on this PR  I can work Lawnicons as iconpack




Closes #3007
Closes #2678

 :white_check_mark:  New feature (non-breaking change which adds functionality)

