### PR TITLE
Move transparent background to icon preferences

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/ExperimentalFeaturesPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/ExperimentalFeaturesPreferences.kt
@@ -42,11 +42,6 @@ fun ExperimentalFeaturesPreferences() {
                 description = stringResource(id = R.string.always_reload_icons_description),
             )
             SwitchPreference(
-                adapter = prefs.transparentIconBackground.getAdapter(),
-                label = stringResource(id = R.string.transparent_background_icons),
-                description = stringResource(id = R.string.transparent_background_icons_description),
-            )
-            SwitchPreference(
                 adapter = prefs2.smartspaceModeSelection.getAdapter(),
                 label = stringResource(id = R.string.smartspace_mode_selection),
             )

--- a/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
@@ -124,23 +124,19 @@ fun GeneralPreferences() {
                     description = stringResource(id = R.string.transparent_background_icons_description),
                 )
             }
-            ExpandAndShrink(visible = !transparentIconBackground.state.value || !themedIconsEnabled) {
-                DividerColumn {
-                    NavigationActionPreference(
-                        label = stringResource(id = R.string.icon_shape_label),
-                        destination = subRoute(name = GeneralRoutes.ICON_SHAPE),
-                        subtitle = iconShapeSubtitle,
-                        endWidget = {
-                            IconShapePreview(iconShape = iconShapeAdapter.state.value)
-                        }
-                    )
-                    SwitchPreference(
-                        adapter = wrapAdaptiveIcons,
-                        label = stringResource(id = R.string.auto_adaptive_icons_label),
-                        description = stringResource(id = R.string.auto_adaptive_icons_description),
-                    )
+            NavigationActionPreference(
+                label = stringResource(id = R.string.icon_shape_label),
+                destination = subRoute(name = GeneralRoutes.ICON_SHAPE),
+                subtitle = iconShapeSubtitle,
+                endWidget = {
+                    IconShapePreview(iconShape = iconShapeAdapter.state.value)
                 }
-            }
+            )
+            SwitchPreference(
+                adapter = wrapAdaptiveIcons,
+                label = stringResource(id = R.string.auto_adaptive_icons_label),
+                description = stringResource(id = R.string.auto_adaptive_icons_description),
+            )
 
             ExpandAndShrink(visible = wrapAdaptiveIcons.state.value) {
                 SliderPreference(

--- a/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
@@ -125,19 +125,21 @@ fun GeneralPreferences() {
                 )
             }
             ExpandAndShrink(visible = !transparentIconBackground.state.value) {
-                NavigationActionPreference(
-                    label = stringResource(id = R.string.icon_shape_label),
-                    destination = subRoute(name = GeneralRoutes.ICON_SHAPE),
-                    subtitle = iconShapeSubtitle,
-                    endWidget = {
-                        IconShapePreview(iconShape = iconShapeAdapter.state.value)
-                    }
-                )
-                SwitchPreference(
-                    adapter = wrapAdaptiveIcons,
-                    label = stringResource(id = R.string.auto_adaptive_icons_label),
-                    description = stringResource(id = R.string.auto_adaptive_icons_description),
-                )
+                DividerColumn {
+                    NavigationActionPreference(
+                        label = stringResource(id = R.string.icon_shape_label),
+                        destination = subRoute(name = GeneralRoutes.ICON_SHAPE),
+                        subtitle = iconShapeSubtitle,
+                        endWidget = {
+                            IconShapePreview(iconShape = iconShapeAdapter.state.value)
+                        }
+                    )
+                    SwitchPreference(
+                        adapter = wrapAdaptiveIcons,
+                        label = stringResource(id = R.string.auto_adaptive_icons_label),
+                        description = stringResource(id = R.string.auto_adaptive_icons_description),
+                    )
+                }
             }
 
             ExpandAndShrink(visible = wrapAdaptiveIcons.state.value) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
@@ -106,6 +106,7 @@ fun GeneralPreferences() {
         }
 
         val wrapAdaptiveIcons = prefs.wrapAdaptiveIcons.getAdapter()
+        val transparentIconBackground = prefs.transparentIconBackground.getAdapter()
         PreferenceGroup(
             heading = stringResource(id = R.string.icons),
             description = stringResource(id = (R.string.adaptive_icon_background_description)),
@@ -116,19 +117,29 @@ fun GeneralPreferences() {
                 destination = subRoute(name = GeneralRoutes.ICON_PACK),
                 subtitle = iconStyleSubtitle,
             )
-            NavigationActionPreference(
-                label = stringResource(id = R.string.icon_shape_label),
-                destination = subRoute(name = GeneralRoutes.ICON_SHAPE),
-                subtitle = iconShapeSubtitle,
-                endWidget = {
-                    IconShapePreview(iconShape = iconShapeAdapter.state.value)
-                }
-            )
-            SwitchPreference(
-                adapter = wrapAdaptiveIcons,
-                label = stringResource(id = R.string.auto_adaptive_icons_label),
-                description = stringResource(id = R.string.auto_adaptive_icons_description),
-            )
+            ExpandAndShrink(visible = themedIconsEnabled) {
+                SwitchPreference(
+                    adapter = prefs.transparentIconBackground.getAdapter(),
+                    label = stringResource(id = R.string.transparent_background_icons),
+                    description = stringResource(id = R.string.transparent_background_icons_description),
+                )
+            }
+            ExpandAndShrink(visible = !transparentIconBackground.state.value) {
+                NavigationActionPreference(
+                    label = stringResource(id = R.string.icon_shape_label),
+                    destination = subRoute(name = GeneralRoutes.ICON_SHAPE),
+                    subtitle = iconShapeSubtitle,
+                    endWidget = {
+                        IconShapePreview(iconShape = iconShapeAdapter.state.value)
+                    }
+                )
+                SwitchPreference(
+                    adapter = wrapAdaptiveIcons,
+                    label = stringResource(id = R.string.auto_adaptive_icons_label),
+                    description = stringResource(id = R.string.auto_adaptive_icons_description),
+                )
+            }
+
             ExpandAndShrink(visible = wrapAdaptiveIcons.state.value) {
                 SliderPreference(
                     label = stringResource(id = R.string.background_lightness_label),

--- a/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/GeneralPreferences.kt
@@ -124,7 +124,7 @@ fun GeneralPreferences() {
                     description = stringResource(id = R.string.transparent_background_icons_description),
                 )
             }
-            ExpandAndShrink(visible = !transparentIconBackground.state.value) {
+            ExpandAndShrink(visible = !transparentIconBackground.state.value || !themedIconsEnabled) {
                 DividerColumn {
                     NavigationActionPreference(
                         label = stringResource(id = R.string.icon_shape_label),


### PR DESCRIPTION
## Description
Change 1:
Move `transparent background` option from `experimetal feature` to `Icon preferences`.
Added shrink option to` Icon shape` and `Adaptive icons` when `Transparanet background `is enabled.

Change 2:
Removed changing icons colors in light mode (ie, getting composite color for icon color and black)


**Layout Ddesign:**

**Default Layout:**

Icons
 - Icons style (Themed off)
 - icons Shape
 - Auto Adpative

**When Themed Icons Enables**
Icons
 - Icons style (Themed on)
 - Transparant background -off 
 - icons Shape
 - Auto Adpative

**When Transparant background Enabled**
Icons
 - Icons style (Themed on)
 - Transparant background -on




## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark:  General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
