### PR TITLE
Dock widget provider support

### DIFF
--- a/lawnchair/res/layout/search_container_hotseat_google_search.xml
+++ b/lawnchair/res/layout/search_container_hotseat_google_search.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.android.launcher3.qsb.QsbContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/qsb_widget_height"
+    android:id="@id/search_container_workspace"
+    android:padding="0dp" >
+
+    <fragment
+        android:name="com.android.launcher3.qsb.QsbContainerView$QsbFragment"
+        android:layout_width="match_parent"
+        android:tag="qsb_view"
+        android:layout_height="match_parent"/>
+</com.android.launcher3.qsb.QsbContainerView>

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -81,9 +81,11 @@
     <!-- which time format to use by default on smartspace -->
     <string name="config_default_smartspace_time_format" translatable="false">system</string>
 
+    <!-- which hotseat mode to use by default -->
+    <string name="config_default_hotseat_mode" translatable="false">lawnchair</string>
+
     <bool name="config_default_always_reload_icons">true</bool>
     <bool name="config_default_dark_status_bar">false</bool>
-    <bool name="config_default_dock_search_bar">true</bool>
     <bool name="config_default_show_notification_count">false</bool>
     <bool name="config_default_themed_hotseat_qsb">true</bool>
     <bool name="config_default_dock_search_bar_force_website">false</bool>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -280,8 +280,11 @@
 
     <!-- DockPreferences -->
     <!-- <string name="dock_label" /> -->
+    <string name="hotseat_mode_label">Widget Provider</string>
+    <string name="hotseat_mode_disabled">Disabled</string>
+    <string name="hotseat_mode_lawnchair">Lawnchair</string>
+    <string name="hotseat_mode_google_search">Google Search Bar</string>
     <string name="search_bar_label">Search Bar</string>
-      <string name="hotseat_qsb_label">Show Search Bar</string>
       <string name="corner_radius_label">Corner Radius</string>
       <string name="apply_accent_color_label">Apply Accent Color</string>
       <string name="search_provider">Search Provider</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -280,11 +280,11 @@
 
     <!-- DockPreferences -->
     <!-- <string name="dock_label" /> -->
-    <string name="hotseat_mode_label">Widget Provider</string>
-    <string name="hotseat_mode_disabled">Disabled</string>
-    <string name="hotseat_mode_lawnchair">Lawnchair</string>
-    <string name="hotseat_mode_google_search">Google Search Bar</string>
-    <string name="search_bar_label">Search Bar</string>
+    <string name="hotseat_mode_label">Search Bar Widget</string>
+      <string name="hotseat_mode_disabled">Disabled</string>
+      <string name="hotseat_mode_lawnchair">Lawnchair</string>
+      <string name="hotseat_mode_google_search">Google Search Bar</string>
+      <string name="search_bar_label">Search Bar</string>
       <string name="corner_radius_label">Corner Radius</string>
       <string name="apply_accent_color_label">Apply Accent Color</string>
       <string name="search_provider">Search Provider</string>

--- a/lawnchair/src/app/lawnchair/hotseat/HotseatMode.kt
+++ b/lawnchair/src/app/lawnchair/hotseat/HotseatMode.kt
@@ -1,0 +1,60 @@
+package app.lawnchair.hotseat
+
+import android.content.Context
+import androidx.annotation.LayoutRes
+import androidx.annotation.StringRes
+import app.lawnchair.util.isPackageInstalledAndEnabled
+import com.android.launcher3.R
+
+
+sealed class HotseatMode(
+    @StringRes val nameResourceId: Int,
+    @LayoutRes val layoutResourceId: Int,
+) {
+    companion object {
+        fun fromString(value: String): HotseatMode = when (value) {
+            "disabled" -> DisabledHotseat
+            "google_search" -> GoogleSearchHotseat
+            else -> LawnchairHotseat
+        }
+
+        /**
+         * @return The list of all hot seat modes.
+         */
+        fun values() = listOf(
+            DisabledHotseat,
+            LawnchairHotseat,
+            GoogleSearchHotseat,
+        )
+    }
+
+    abstract fun isAvailable(context: Context): Boolean
+}
+
+
+object LawnchairHotseat : HotseatMode(
+    nameResourceId = R.string.hotseat_mode_lawnchair,
+    layoutResourceId = R.layout.search_container_hotseat,
+) {
+    override fun toString() = "lawnchair"
+    override fun isAvailable(context: Context): Boolean = true
+}
+
+object GoogleSearchHotseat : HotseatMode(
+    nameResourceId = R.string.hotseat_mode_google_search,
+    layoutResourceId = R.layout.search_container_hotseat_google_search,
+) {
+    override fun toString(): String = "google_search"
+
+    override fun isAvailable(context: Context): Boolean =
+        context.packageManager.isPackageInstalledAndEnabled("com.google.android.googlequicksearchbox")
+}
+
+object DisabledHotseat : HotseatMode(
+    nameResourceId = R.string.hotseat_mode_disabled,
+    layoutResourceId = R.layout.empty_view,
+) {
+    override fun toString(): String = "disabled"
+
+    override fun isAvailable(context: Context): Boolean = true
+}

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -24,6 +24,7 @@ import androidx.datastore.preferences.core.*
 import androidx.datastore.preferences.preferencesDataStore
 import app.lawnchair.font.FontCache
 import app.lawnchair.gestures.config.GestureHandlerConfig
+import app.lawnchair.hotseat.HotseatMode
 import app.lawnchair.icons.CustomAdaptiveIconDrawable
 import app.lawnchair.icons.shape.IconShape
 import app.lawnchair.icons.shape.IconShapeManager
@@ -76,9 +77,11 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         defaultValue = context.resources.getBoolean(R.bool.config_default_dark_status_bar),
     )
 
-    val hotseatQsb = preference(
-        key = booleanPreferencesKey(name = "dock_search_bar"),
-        defaultValue = context.resources.getBoolean(R.bool.config_default_dock_search_bar),
+    val hotseatMode = preference(
+        key = stringPreferencesKey("hotseat_mode"),
+        defaultValue = HotseatMode.fromString(context.getString(R.string.config_default_hotseat_mode)),
+        parse = { HotseatMode.fromString(it) },
+        save = { it.toString() },
         onSet = { reloadHelper.restart() },
     )
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/DockPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/DockPreferences.kt
@@ -17,14 +17,21 @@
 package app.lawnchair.ui.preferences
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavGraphBuilder
+import app.lawnchair.hotseat.HotseatMode
+import app.lawnchair.hotseat.LawnchairHotseat
+import app.lawnchair.preferences.PreferenceAdapter
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.qsb.providers.QsbSearchProvider
 import app.lawnchair.ui.preferences.components.DividerColumn
 import app.lawnchair.ui.preferences.components.ExpandAndShrink
+import app.lawnchair.ui.preferences.components.ListPreference
+import app.lawnchair.ui.preferences.components.ListPreferenceEntry
 import app.lawnchair.ui.preferences.components.NavigationActionPreference
 import app.lawnchair.ui.preferences.components.PreferenceGroup
 import app.lawnchair.ui.preferences.components.PreferenceLayout
@@ -47,13 +54,14 @@ fun DockPreferences() {
     val prefs = preferenceManager()
     val prefs2 = preferenceManager2()
     PreferenceLayout(label = stringResource(id = R.string.dock_label)) {
-        PreferenceGroup(heading = stringResource(id = R.string.search_bar_label)) {
-            val hotseatQsbAdapter = prefs2.hotseatQsb.getAdapter()
-            SwitchPreference(
-                adapter = hotseatQsbAdapter,
-                label = stringResource(id = R.string.hotseat_qsb_label),
+        val hotseatModeAdapter = prefs2.hotseatMode.getAdapter()
+        PreferenceGroup(heading = stringResource(id = R.string.what_to_show)) {
+            HotseatModePreference(
+                adapter = hotseatModeAdapter,
             )
-            ExpandAndShrink(visible = hotseatQsbAdapter.state.value) {
+        }
+        ExpandAndShrink(visible = hotseatModeAdapter.state.value == LawnchairHotseat) {
+            PreferenceGroup(heading = stringResource(id = R.string.search_bar_label)) {
                 DividerColumn {
                     SwitchPreference(
                         adapter = prefs2.themedHotseatQsb.getAdapter(),
@@ -88,4 +96,28 @@ fun DockPreferences() {
             )
         }
     }
+}
+
+@Composable
+private fun HotseatModePreference(
+    adapter: PreferenceAdapter<HotseatMode>,
+) {
+
+    val context = LocalContext.current
+
+    val entries = remember {
+        HotseatMode.values().map { mode ->
+            ListPreferenceEntry(
+                value = mode,
+                label = { stringResource(id = mode.nameResourceId) },
+                enabled = mode.isAvailable(context = context),
+            )
+        }
+    }
+
+    ListPreference(
+        adapter = adapter,
+        entries = entries,
+        label = stringResource(id = R.string.hotseat_mode_label),
+    )
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/DockPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/DockPreferences.kt
@@ -54,36 +54,36 @@ fun DockPreferences() {
     val prefs = preferenceManager()
     val prefs2 = preferenceManager2()
     PreferenceLayout(label = stringResource(id = R.string.dock_label)) {
-        val hotseatModeAdapter = prefs2.hotseatMode.getAdapter()
-        PreferenceGroup(heading = stringResource(id = R.string.what_to_show)) {
-            HotseatModePreference(
-                adapter = hotseatModeAdapter,
-            )
-        }
-        ExpandAndShrink(visible = hotseatModeAdapter.state.value == LawnchairHotseat) {
-            PreferenceGroup(heading = stringResource(id = R.string.search_bar_label)) {
-                DividerColumn {
-                    SwitchPreference(
-                        adapter = prefs2.themedHotseatQsb.getAdapter(),
-                        label = stringResource(id = R.string.apply_accent_color_label),
-                    )
-                    SliderPreference(
-                        label = stringResource(id = R.string.corner_radius_label),
-                        adapter = prefs.hotseatQsbCornerRadius.getAdapter(),
-                        step = 0.05F,
-                        valueRange = 0F..1F,
-                        showAsPercentage = true,
-                    )
-                    val hotseatQsbProviderAdapter by preferenceManager2().hotseatQsbProvider.getAdapter()
-                    NavigationActionPreference(
-                        label = stringResource(R.string.search_provider),
-                        destination = subRoute(DockRoutes.SEARCH_PROVIDER),
-                        subtitle = stringResource(
-                            id = QsbSearchProvider.values()
-                                .first { it == hotseatQsbProviderAdapter }
-                                .name,
-                        ),
-                    )
+        PreferenceGroup(heading = stringResource(id = R.string.search_bar_label)) {
+            DividerColumn {
+                val hotseatModeAdapter = prefs2.hotseatMode.getAdapter()
+                HotseatModePreference(
+                    adapter = hotseatModeAdapter,
+                )
+                ExpandAndShrink(visible = hotseatModeAdapter.state.value == LawnchairHotseat) {
+                    DividerColumn {
+                        SwitchPreference(
+                            adapter = prefs2.themedHotseatQsb.getAdapter(),
+                            label = stringResource(id = R.string.apply_accent_color_label),
+                        )
+                        SliderPreference(
+                            label = stringResource(id = R.string.corner_radius_label),
+                            adapter = prefs.hotseatQsbCornerRadius.getAdapter(),
+                            step = 0.05F,
+                            valueRange = 0F..1F,
+                            showAsPercentage = true,
+                        )
+                        val hotseatQsbProviderAdapter by preferenceManager2().hotseatQsbProvider.getAdapter()
+                        NavigationActionPreference(
+                            label = stringResource(R.string.search_provider),
+                            destination = subRoute(DockRoutes.SEARCH_PROVIDER),
+                            subtitle = stringResource(
+                                id = QsbSearchProvider.values()
+                                    .first { it == hotseatQsbProviderAdapter }
+                                    .name,
+                            ),
+                        )
+                    }
                 }
             }
         }

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -51,6 +51,7 @@ import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
 import java.io.PrintWriter;
 
 import app.lawnchair.DeviceProfileOverrides;
+import app.lawnchair.hotseat.DisabledHotseat;
 import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.theme.color.ColorOption;
 
@@ -351,7 +352,7 @@ public class DeviceProfile {
         int hotseatBottomPaddingRes;
         int hotseatBottomNonTallPaddingRes;
         int hotseatExtraVerticalSizeRes;
-        boolean hotseatQsb = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getHotseatQsb());
+        boolean hotseatQsb = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getHotseatMode()) != DisabledHotseat.INSTANCE;
         if (hotseatQsb) {
             hotseatTopPaddingRes = R.dimen.dynamic_grid_hotseat_top_padding;
             hotseatBottomPaddingRes = R.dimen.dynamic_grid_hotseat_bottom_padding;

--- a/src/com/android/launcher3/Hotseat.java
+++ b/src/com/android/launcher3/Hotseat.java
@@ -35,7 +35,10 @@ import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
 
 import java.util.function.Consumer;
 
+import app.lawnchair.hotseat.HotseatMode;
+import app.lawnchair.hotseat.LawnchairHotseat;
 import app.lawnchair.preferences2.PreferenceManager2;
+import app.lawnchair.smartspace.model.LawnchairSmartspace;
 
 /**
  * View class that represents the bottom row of the home screen.
@@ -67,8 +70,15 @@ public class Hotseat extends CellLayout implements Insettable {
         super(context, attrs, defStyle);
 
         PreferenceManager2 preferenceManager2 = PreferenceManager2.getInstance(context);
-        boolean hotseatQsb = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getHotseatQsb());
-        int layoutId = hotseatQsb ? R.layout.search_container_hotseat : R.layout.empty_view;
+        HotseatMode hotseatMode = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getHotseatMode());
+        if (!hotseatMode.isAvailable(context)) {
+            // The current hotseat mode is not available,
+            // setting the hotseat mode to one that is always available
+            hotseatMode = LawnchairHotseat.INSTANCE;
+            PreferenceExtensionsKt.setBlocking(mPreferenceManager2.getHotseatMode(), hotseatMode);
+        }
+        int layoutId = hotseatMode.getLayoutResourceId();
+
         mQsb = LayoutInflater.from(context).inflate(layoutId, this, false);
         mQsbHeight = mQsb.getLayoutParams().height;
         addView(mQsb);


### PR DESCRIPTION
## Description

Adds the option to change the custom Lawnchair dock widget with the Google search widget (from the Google app). 

- Dock widget provider is called `HotseatMode` in the code.
- Resets back to LawnchairHotseat mode automatically if the selected mode is no longer available e.g. google app getting uninstalled or disabled.
- `hotseatQsb` boolean preference is now removed. To disable the search bar the user can select `HotseatMode.Disabled` on `hotseatMode`.

While this only gives the users 2 options, it's now possible to easily add new widget styles/providers for the dock. We can also look into allowing any widget to be shown on the dock in the future.

![hotseat-mode-selection](https://user-images.githubusercontent.com/41836211/201509251-d25c86ca-2ab0-43a9-b425-bb137f6998c8.gif)

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
