### PR TITLE
Identify theme supported icon pack by intent

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -32,6 +32,7 @@
         <item>org.withouthat.acalendar</item>
         <item>ws.xsoh.etar</item>
     </string-array>
+    <string name="icon_packs_intent_name" translatable="false">app.lawnchair.icons.THEMED_ICON</string>
     <string name="clock_component_name" translatable="false">com.google.android.deskclock/com.android.deskclock.DeskClock</string>
     <string name="launcher_activity_logic_class" translatable="false">app.lawnchair.LauncherActivityCachingLogic</string>
     <string name="main_process_initializer_class" translatable="false">app.lawnchair.LawnchairProcessInitializer</string>

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -32,12 +32,6 @@
         <item>org.withouthat.acalendar</item>
         <item>ws.xsoh.etar</item>
     </string-array>
-    <string-array name="themed_icon_packs" translatable="false">
-        <!-- The package will working when lawnicons fully converted as iconpack-->
-        <item>app.lawnchair.lawnicons</item>
-        <item>com.donnnno.arcticons</item>
-        <item>com.whicons.iconpack</item>
-    </string-array>
     <string name="clock_component_name" translatable="false">com.google.android.deskclock/com.android.deskclock.DeskClock</string>
     <string name="launcher_activity_logic_class" translatable="false">app.lawnchair.LauncherActivityCachingLogic</string>
     <string name="main_process_initializer_class" translatable="false">app.lawnchair.LawnchairProcessInitializer</string>

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -51,7 +51,7 @@ import app.lawnchair.root.RootNotAvailableException
 import app.lawnchair.search.LawnchairSearchAdapterProvider
 import app.lawnchair.theme.ThemeProvider
 import app.lawnchair.ui.popup.LawnchairShortcut
-import app.lawnchair.util.isPackageInstalled
+import app.lawnchair.util.getThemedIconPackInstalled
 import com.android.launcher3.*
 import com.android.launcher3.R
 import com.android.launcher3.allapps.AllAppsContainerView
@@ -226,7 +226,7 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
         // Handle update from version 12 Alpha 4 to version 12 Alpha 5.
         if (
             prefs.themedIcons.get() &&
-            !resources.getStringArray(R.array.themed_icon_packs).any { packageManager.isPackageInstalled(it) }
+            !packageManager.getThemedIconPackInstalled(applicationInfo).isEmpty()
         ) {
             prefs.themedIcons.set(newValue = false)
         }

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -226,7 +226,7 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
         // Handle update from version 12 Alpha 4 to version 12 Alpha 5.
         if (
             prefs.themedIcons.get() &&
-            packageManager.getThemedIconPacksInstalled(this).isNotEmpty()
+            packageManager.getThemedIconPacksInstalled(this).isEmpty()
         ) {
             prefs.themedIcons.set(newValue = false)
         }

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -226,7 +226,7 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
         // Handle update from version 12 Alpha 4 to version 12 Alpha 5.
         if (
             prefs.themedIcons.get() &&
-            packageManager.getThemedIconPacksInstalled(applicationInfo).isNotEmpty()
+            packageManager.getThemedIconPacksInstalled(this).isNotEmpty()
         ) {
             prefs.themedIcons.set(newValue = false)
         }

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -51,7 +51,7 @@ import app.lawnchair.root.RootNotAvailableException
 import app.lawnchair.search.LawnchairSearchAdapterProvider
 import app.lawnchair.theme.ThemeProvider
 import app.lawnchair.ui.popup.LawnchairShortcut
-import app.lawnchair.util.getThemedIconPackInstalled
+import app.lawnchair.util.getThemedIconPacksInstalled
 import com.android.launcher3.*
 import com.android.launcher3.R
 import com.android.launcher3.allapps.AllAppsContainerView
@@ -226,7 +226,7 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
         // Handle update from version 12 Alpha 4 to version 12 Alpha 5.
         if (
             prefs.themedIcons.get() &&
-            !packageManager.getThemedIconPackInstalled(applicationInfo).isEmpty()
+            packageManager.getThemedIconPacksInstalled(applicationInfo).isNotEmpty()
         ) {
             prefs.themedIcons.set(newValue = false)
         }

--- a/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
@@ -51,7 +51,7 @@ class IconPackProvider(private val context: Context) {
         iconPack.loadBlocking()
         val packageManager =  context.packageManager
         val drawable = iconPack.getIcon(iconEntry, iconDpi) ?: return null
-        val themedIconPacks = packageManager.getThemedIconPacksInstalled(context.applicationInfo)
+        val themedIconPacks = packageManager.getThemedIconPacksInstalled(context)
         if (
             context.isThemedIconsEnabled() && iconEntry.packPackageName in themedIconPacks
         ) {

--- a/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
@@ -53,7 +53,7 @@ class IconPackProvider(private val context: Context) {
         val drawable = iconPack.getIcon(iconEntry, iconDpi) ?: return null
         val themedIconPacks = packageManager.getThemedIconPacksInstalled(context.applicationInfo)
         if (
-            context.isThemedIconsEnabled() &&  iconEntry.packPackageName in themedIconPacks
+            context.isThemedIconsEnabled() && iconEntry.packPackageName in themedIconPacks
         ) {
             val themedColors: IntArray = ThemedIconDrawable.getThemedColors(context)
             val res = packageManager.getResourcesForApplication(iconEntry.packPackageName)

--- a/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
@@ -9,14 +9,12 @@ import android.os.Process
 import android.os.UserHandle
 import com.android.launcher3.icons.ClockDrawableWrapper
 import com.android.launcher3.util.MainThreadInitializedObject
-import com.android.launcher3.icons.R
 import android.graphics.drawable.InsetDrawable
 import android.graphics.drawable.AdaptiveIconDrawable
-import app.lawnchair.icons.CustomAdaptiveIconDrawable
 import com.android.launcher3.icons.ThemedIconDrawable
 import android.graphics.drawable.ColorDrawable
 import app.lawnchair.icons.*
-import app.lawnchair.util.getThemedIconPackInstalled
+import app.lawnchair.util.getThemedIconPacksInstalled
 
 
 
@@ -53,7 +51,7 @@ class IconPackProvider(private val context: Context) {
         iconPack.loadBlocking()
         val packageManager =  context.packageManager
         val drawable = iconPack.getIcon(iconEntry, iconDpi) ?: return null
-        val themedIconPacks = packageManager.getThemedIconPackInstalled(context.applicationInfo)
+        val themedIconPacks = packageManager.getThemedIconPacksInstalled(context.applicationInfo)
         if (
             context.isThemedIconsEnabled() &&  iconEntry.packPackageName in themedIconPacks
         ) {

--- a/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/IconPackProvider.kt
@@ -16,7 +16,7 @@ import app.lawnchair.icons.CustomAdaptiveIconDrawable
 import com.android.launcher3.icons.ThemedIconDrawable
 import android.graphics.drawable.ColorDrawable
 import app.lawnchair.icons.*
-import app.lawnchair.util.Constants.LAWNICONS_PACKAGE_NAME
+import app.lawnchair.util.getThemedIconPackInstalled
 
 
 
@@ -24,7 +24,6 @@ class IconPackProvider(private val context: Context) {
 
     private val systemIconPack = SystemIconPack(context)
     private val iconPacks = mutableMapOf<String, IconPack?>()
-    private val themedIconPacks = context.resources.getStringArray(R.array.themed_icon_packs)
 
     fun getIconPackOrSystem(packageName: String): IconPack? {
         if (packageName.isEmpty()) return systemIconPack
@@ -52,12 +51,14 @@ class IconPackProvider(private val context: Context) {
     fun getDrawable(iconEntry: IconEntry, iconDpi: Int, user: UserHandle): Drawable? {
         val iconPack = getIconPackOrSystem(iconEntry.packPackageName) ?: return null
         iconPack.loadBlocking()
+        val packageManager =  context.packageManager
         val drawable = iconPack.getIcon(iconEntry, iconDpi) ?: return null
+        val themedIconPacks = packageManager.getThemedIconPackInstalled(context.applicationInfo)
         if (
-            context.isThemedIconsEnabled() && iconEntry.packPackageName in themedIconPacks
+            context.isThemedIconsEnabled() &&  iconEntry.packPackageName in themedIconPacks
         ) {
             val themedColors: IntArray = ThemedIconDrawable.getThemedColors(context)
-            val res = context.packageManager.getResourcesForApplication(iconEntry.packPackageName)
+            val res = packageManager.getResourcesForApplication(iconEntry.packPackageName)
             @SuppressLint("DiscouragedApi")
             val resId = res.getIdentifier(iconEntry.name, "drawable", iconEntry.packPackageName)
             val bg: Drawable = ColorDrawable(themedColors[0])

--- a/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairIconProvider.kt
@@ -58,7 +58,7 @@ class LawnchairIconProvider @JvmOverloads constructor(
         lawniconsVersion =
             if (isSupported) context.packageManager.getPackageVersionCode(LAWNICONS_PACKAGE_NAME)
             else 0L
-        _themeMap = if (isSupported) null else DISABLED_MAP
+        _themeMap = if (isSupported && lawniconsVersion in 1..3) null else DISABLED_MAP
     }
 
     private fun resolveIconEntry(componentName: ComponentName, user: UserHandle): IconEntry? {

--- a/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
@@ -57,6 +57,7 @@ import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.ui.preferences.components.*
 import app.lawnchair.util.isPackageInstalled
+import app.lawnchair.util.getThemedIconPackInstalled
 import com.android.launcher3.R
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 
@@ -133,8 +134,8 @@ fun IconPackPreferences() {
                 modifier = Modifier.padding(bottom = 8.dp),
             )
             PreferenceGroup {
-                val themedIconsAvailable = LocalContext.current.resources
-                    .getStringArray(R.array.themed_icon_packs)
+                val themedIconsAvailable = LocalContext.current.packageManager
+                    .getThemedIconPackInstalled(LocalContext.current.applicationInfo)
                     .any { LocalContext.current.packageManager.isPackageInstalled(it) }
                 ListPreference(
                     enabled = themedIconsAvailable,

--- a/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
@@ -135,7 +135,7 @@ fun IconPackPreferences() {
             )
             PreferenceGroup {
                 val themedIconsAvailable = LocalContext.current.packageManager
-                    .getThemedIconPacksInstalled(LocalContext.current.applicationInfo)
+                    .getThemedIconPacksInstalled(LocalContext.current)
                     .any { LocalContext.current.packageManager.isPackageInstalled(it) }
                 ListPreference(
                     enabled = themedIconsAvailable,

--- a/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
@@ -56,8 +56,8 @@ import app.lawnchair.preferences.PreferenceAdapter
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.ui.preferences.components.*
+import app.lawnchair.util.getThemedIconPacksInstalled
 import app.lawnchair.util.isPackageInstalled
-import app.lawnchair.util.getThemedIconPackInstalled
 import com.android.launcher3.R
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 
@@ -135,7 +135,7 @@ fun IconPackPreferences() {
             )
             PreferenceGroup {
                 val themedIconsAvailable = LocalContext.current.packageManager
-                    .getThemedIconPackInstalled(LocalContext.current.applicationInfo)
+                    .getThemedIconPacksInstalled(LocalContext.current.applicationInfo)
                     .any { LocalContext.current.packageManager.isPackageInstalled(it) }
                 ListPreference(
                     enabled = themedIconsAvailable,

--- a/lawnchair/src/app/lawnchair/util/Constants.kt
+++ b/lawnchair/src/app/lawnchair/util/Constants.kt
@@ -2,4 +2,5 @@ package app.lawnchair.util
 
 object Constants {
     const val LAWNICONS_PACKAGE_NAME = "app.lawnchair.lawnicons"
+    const val LAWNCHAIR_INTENT = "app.lawnchair.icons.THEMED_ICON"
 }

--- a/lawnchair/src/app/lawnchair/util/Constants.kt
+++ b/lawnchair/src/app/lawnchair/util/Constants.kt
@@ -2,5 +2,4 @@ package app.lawnchair.util
 
 object Constants {
     const val LAWNICONS_PACKAGE_NAME = "app.lawnchair.lawnicons"
-    const val LAWNCHAIR_INTENT = "app.lawnchair.icons.THEMED_ICON"
 }

--- a/lawnchair/src/app/lawnchair/util/PackageManagerExtensions.kt
+++ b/lawnchair/src/app/lawnchair/util/PackageManagerExtensions.kt
@@ -2,6 +2,12 @@ package app.lawnchair.util
 
 import android.content.pm.PackageManager
 import com.android.launcher3.Utilities
+import app.lawnchair.util.Constants.LAWNCHAIR_INTENT
+import android.content.Intent
+import android.content.pm.ResolveInfo
+import android.content.pm.ApplicationInfo
+import app.lawnchair.util.Constants
+import android.content.ComponentName
 
 fun PackageManager.isPackageInstalled(packageName: String): Boolean =
     try {
@@ -26,4 +32,18 @@ fun PackageManager.isPackageInstalledAndEnabled(packageName: String) = try {
     getApplicationInfo(packageName, 0).enabled
 } catch (_: PackageManager.NameNotFoundException) {
     false
+}
+fun PackageManager.getThemedIconPackInstalled(applicationIfo: ApplicationInfo) : List<String> = try {
+    val launchables: List<ResolveInfo> = queryIntentActivityOptions(
+        ComponentName(
+            applicationIfo.packageName,
+            applicationIfo.className
+        ),
+        null,
+        Intent(LAWNCHAIR_INTENT),
+        PackageManager.GET_RESOLVED_FILTER
+    )
+      launchables.map { it.activityInfo.packageName }
+} catch (_: PackageManager.NameNotFoundException) {
+    emptyList()
 }

--- a/lawnchair/src/app/lawnchair/util/PackageManagerExtensions.kt
+++ b/lawnchair/src/app/lawnchair/util/PackageManagerExtensions.kt
@@ -4,9 +4,7 @@ import android.content.pm.PackageManager
 import com.android.launcher3.Utilities
 import app.lawnchair.util.Constants.LAWNCHAIR_INTENT
 import android.content.Intent
-import android.content.pm.ResolveInfo
 import android.content.pm.ApplicationInfo
-import app.lawnchair.util.Constants
 import android.content.ComponentName
 
 fun PackageManager.isPackageInstalled(packageName: String): Boolean =
@@ -33,17 +31,14 @@ fun PackageManager.isPackageInstalledAndEnabled(packageName: String) = try {
 } catch (_: PackageManager.NameNotFoundException) {
     false
 }
-fun PackageManager.getThemedIconPackInstalled(applicationIfo: ApplicationInfo) : List<String> = try {
-    val launchables: List<ResolveInfo> = queryIntentActivityOptions(
-        ComponentName(
-            applicationIfo.packageName,
-            applicationIfo.className
-        ),
+
+fun PackageManager.getThemedIconPacksInstalled(applicationIfo: ApplicationInfo) : List<String> = try {
+    queryIntentActivityOptions(
+        ComponentName(applicationIfo.packageName, applicationIfo.className),
         null,
         Intent(LAWNCHAIR_INTENT),
         PackageManager.GET_RESOLVED_FILTER
-    )
-      launchables.map { it.activityInfo.packageName }
+    ).map { it.activityInfo.packageName }
 } catch (_: PackageManager.NameNotFoundException) {
     emptyList()
 }

--- a/lawnchair/src/app/lawnchair/util/PackageManagerExtensions.kt
+++ b/lawnchair/src/app/lawnchair/util/PackageManagerExtensions.kt
@@ -2,10 +2,11 @@ package app.lawnchair.util
 
 import android.content.pm.PackageManager
 import com.android.launcher3.Utilities
-import app.lawnchair.util.Constants.LAWNCHAIR_INTENT
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.ComponentName
+import android.content.Context
+import com.android.launcher3.icons.R
 
 fun PackageManager.isPackageInstalled(packageName: String): Boolean =
     try {
@@ -32,13 +33,14 @@ fun PackageManager.isPackageInstalledAndEnabled(packageName: String) = try {
     false
 }
 
-fun PackageManager.getThemedIconPacksInstalled(applicationIfo: ApplicationInfo) : List<String> = try {
-    queryIntentActivityOptions(
-        ComponentName(applicationIfo.packageName, applicationIfo.className),
-        null,
-        Intent(LAWNCHAIR_INTENT),
-        PackageManager.GET_RESOLVED_FILTER
-    ).map { it.activityInfo.packageName }
-} catch (_: PackageManager.NameNotFoundException) {
-    emptyList()
-}
+fun PackageManager.getThemedIconPacksInstalled(context: Context): List<String> =
+    try {
+        queryIntentActivityOptions(
+            ComponentName(context.applicationInfo.packageName, context.applicationInfo.className),
+            null,
+            Intent(context.resources.getString(R.string.icon_packs_intent_name)),
+            PackageManager.GET_RESOLVED_FILTER
+        ).map { it.activityInfo.packageName }
+    } catch (_: PackageManager.NameNotFoundException) {
+        emptyList()
+    }

--- a/src/com/android/launcher3/model/PackageUpdatedTask.java
+++ b/src/com/android/launcher3/model/PackageUpdatedTask.java
@@ -83,7 +83,7 @@ public class PackageUpdatedTask extends BaseModelUpdateTask {
     public static final int OP_UNSUSPEND = 6; // package unsuspended
     public static final int OP_USER_AVAILABILITY_CHANGE = 7; // user available/unavailable
 
-    public static final String LAWNCHAIR_INTENT = "app.lawnchair.icons.THEMED_ICON";
+    private static final String LAWNCHAIR_INTENT = "app.lawnchair.icons.THEMED_ICON";
     private final int mOp;
     private final UserHandle mUser;
     private final String[] mPackages;
@@ -153,13 +153,13 @@ public class PackageUpdatedTask extends BaseModelUpdateTask {
                     if (packages[i].equals(pm.getIconPackPackage().get())) {
                         pm.getIconPackPackage().set("");
                     };
-                    Boolean isThemedIconsAvailable = context.getPackageManager()
+                    final boolean isThemedIconsAvailable = context.getPackageManager()
                         .queryIntentActivityOptions(
-                            new ComponentName(context.getApplicationInfo().packageName,
-                                context.getApplicationInfo().className), null, new Intent(LAWNCHAIR_INTENT),
+                            new ComponentName(context.getApplicationInfo().packageName, context.getApplicationInfo().className),
+                            null,
+                            new Intent(LAWNCHAIR_INTENT),
                             PackageManager.GET_RESOLVED_FILTER).stream().map(it -> it.activityInfo.packageName)
                         .noneMatch(it -> packageManagerHelper.isAppInstalled(it, mUser));
-
                     if (isThemedIconsAvailable) {
                         pm.getThemedIcons().set(false);
                     }

--- a/src/com/android/launcher3/model/PackageUpdatedTask.java
+++ b/src/com/android/launcher3/model/PackageUpdatedTask.java
@@ -83,7 +83,6 @@ public class PackageUpdatedTask extends BaseModelUpdateTask {
     public static final int OP_UNSUSPEND = 6; // package unsuspended
     public static final int OP_USER_AVAILABILITY_CHANGE = 7; // user available/unavailable
 
-    private static final String LAWNCHAIR_INTENT = "app.lawnchair.icons.THEMED_ICON";
     private final int mOp;
     private final UserHandle mUser;
     private final String[] mPackages;
@@ -157,7 +156,7 @@ public class PackageUpdatedTask extends BaseModelUpdateTask {
                         .queryIntentActivityOptions(
                             new ComponentName(context.getApplicationInfo().packageName, context.getApplicationInfo().className),
                             null,
-                            new Intent(LAWNCHAIR_INTENT),
+                            new Intent(context.getResources().getString(R.string.icon_packs_intent_name)),
                             PackageManager.GET_RESOLVED_FILTER).stream().map(it -> it.activityInfo.packageName)
                         .noneMatch(it -> packageManagerHelper.isAppInstalled(it, mUser));
                     if (isThemedIconsAvailable) {

--- a/src/com/android/launcher3/model/PackageUpdatedTask.java
+++ b/src/com/android/launcher3/model/PackageUpdatedTask.java
@@ -83,6 +83,7 @@ public class PackageUpdatedTask extends BaseModelUpdateTask {
     public static final int OP_UNSUSPEND = 6; // package unsuspended
     public static final int OP_USER_AVAILABILITY_CHANGE = 7; // user available/unavailable
 
+    public static final String LAWNCHAIR_INTENT = "app.lawnchair.icons.THEMED_ICON";
     private final int mOp;
     private final UserHandle mUser;
     private final String[] mPackages;
@@ -152,8 +153,14 @@ public class PackageUpdatedTask extends BaseModelUpdateTask {
                     if (packages[i].equals(pm.getIconPackPackage().get())) {
                         pm.getIconPackPackage().set("");
                     };
-                    if (Arrays.stream(context.getResources().getStringArray(R.array.themed_icon_packs))
-                        .noneMatch(it -> packageManagerHelper.isAppInstalled(it, mUser))) {
+                    Boolean isThemedIconsAvailable = context.getPackageManager()
+                        .queryIntentActivityOptions(
+                            new ComponentName(context.getApplicationInfo().packageName,
+                                context.getApplicationInfo().className), null, new Intent(LAWNCHAIR_INTENT),
+                            PackageManager.GET_RESOLVED_FILTER).stream().map(it -> it.activityInfo.packageName)
+                        .noneMatch(it -> packageManagerHelper.isAppInstalled(it, mUser));
+
+                    if (isThemedIconsAvailable) {
                         pm.getThemedIcons().set(false);
                     }
                 }


### PR DESCRIPTION
## Description

This is a feature request which was discussed on #3091 and https://github.com/LawnchairLauncher/lawnchair/pull/3091#discussion_r1016498818

Identify icon packs that supports themed based on intent , same way every other icon pack adds support for launcher.

If an Icon can supports lawnchair theme , they need to add below intent to AndroidManifest.xml
```xml
    <intent-filter>
        <action android:name="app.lawnchair.icons.THEMED_ICON" />
        <category android:name="android.intent.category.DEFAULT" />
    </intent-filter>
```

Added Theme support for Lawnicon on https://github.com/LawnchairLauncher/lawnicons/pull/815


## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
