### PR TITLE
Fix to detect older lawnicons version as themed icon pack

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
@@ -221,8 +221,7 @@ private fun getIconPackItemWidth(
     while (true) {
         gutterCount += 1f
         visibleItemCount += 1f
-        val possibleIconPackItemWidth =
-            (availableWidth - gutterCount * gutterWidth) / visibleItemCount
+        val possibleIconPackItemWidth = (availableWidth - gutterCount * gutterWidth) / visibleItemCount
         if (possibleIconPackItemWidth >= minimumWidth) {
             iconPackItemWidth = possibleIconPackItemWidth
         } else break

--- a/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/IconPackPreferences.kt
@@ -56,6 +56,7 @@ import app.lawnchair.preferences.PreferenceAdapter
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.ui.preferences.components.*
+import app.lawnchair.util.Constants
 import app.lawnchair.util.getThemedIconPacksInstalled
 import app.lawnchair.util.isPackageInstalled
 import com.android.launcher3.R
@@ -137,6 +138,8 @@ fun IconPackPreferences() {
                 val themedIconsAvailable = LocalContext.current.packageManager
                     .getThemedIconPacksInstalled(LocalContext.current)
                     .any { LocalContext.current.packageManager.isPackageInstalled(it) }
+                    || LocalContext.current.packageManager
+                    .isPackageInstalled(Constants.LAWNICONS_PACKAGE_NAME)
                 ListPreference(
                     enabled = themedIconsAvailable,
                     label = stringResource(id = R.string.themed_icon_title),
@@ -218,7 +221,8 @@ private fun getIconPackItemWidth(
     while (true) {
         gutterCount += 1f
         visibleItemCount += 1f
-        val possibleIconPackItemWidth = (availableWidth - gutterCount * gutterWidth) / visibleItemCount
+        val possibleIconPackItemWidth =
+            (availableWidth - gutterCount * gutterWidth) / visibleItemCount
         if (possibleIconPackItemWidth >= minimumWidth) {
             iconPackItemWidth = possibleIconPackItemWidth
         } else break


### PR DESCRIPTION
## Description

Currently older version of lawnicons not detected as the new themed intent is added only to new versions, this change is provide backward compatibility to older version of lawnchair untill 1.2.0. 
