### PR TITLE
Warn user about using development builds

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/PreferencesDashboard.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/PreferencesDashboard.kt
@@ -9,7 +9,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Build
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
+import androidx.compose.material3.MaterialTheme as Material3Theme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -28,6 +31,7 @@ import app.lawnchair.ui.preferences.components.ClickableIcon
 import app.lawnchair.ui.preferences.components.PreferenceCategory
 import app.lawnchair.ui.preferences.components.PreferenceDivider
 import app.lawnchair.ui.preferences.components.PreferenceLayout
+import app.lawnchair.ui.preferences.components.WarningPreference
 import app.lawnchair.util.restartLauncher
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
@@ -40,6 +44,7 @@ fun PreferencesDashboard() {
         backArrowVisible = false,
         actions = { PreferencesOverflowMenu() }
     ) {
+        PreferencesDebugWarning()
         PreferenceCategory(
             label = stringResource(R.string.general_label),
             description = stringResource(R.string.general_description),
@@ -156,6 +161,25 @@ fun PreferencesOverflowMenu() {
         }
     }
 }
+
+@Composable
+fun PreferencesDebugWarning() {
+    val enableDebug by preferenceManager().enableDebugMenu.observeAsState()
+    if (BuildConfig.DEBUG && !enableDebug) {
+        Surface(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            shape = MaterialTheme.shapes.large,
+            color = Material3Theme.colorScheme.errorContainer
+        ) {
+            WarningPreference(
+                // Don't move to strings.xml, no need to translate this warning
+                modifier = Modifier,
+                text = "Warning: You are currently using a development build. These builds WILL contain bugs, broken features, and unexpected crashes. Use at your own risk!"
+            )
+        }
+    }
+}
+
 
 fun openAppInfo(context: Context) {
     val launcherApps = context.getSystemService<LauncherApps>()

--- a/lawnchair/src/app/lawnchair/ui/preferences/PreferencesDashboard.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/PreferencesDashboard.kt
@@ -44,7 +44,8 @@ fun PreferencesDashboard() {
         backArrowVisible = false,
         actions = { PreferencesOverflowMenu() }
     ) {
-        PreferencesDebugWarning()
+        if (BuildConfig.DEBUG) PreferencesDebugWarning()
+
         PreferenceCategory(
             label = stringResource(R.string.general_label),
             description = stringResource(R.string.general_description),
@@ -165,18 +166,17 @@ fun PreferencesOverflowMenu() {
 @Composable
 fun PreferencesDebugWarning() {
     val enableDebug by preferenceManager().enableDebugMenu.observeAsState()
-    if (BuildConfig.DEBUG && !enableDebug) {
-        Surface(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            shape = MaterialTheme.shapes.large,
-            color = Material3Theme.colorScheme.errorContainer
-        ) {
-            WarningPreference(
-                // Don't move to strings.xml, no need to translate this warning
-                modifier = Modifier,
-                text = "Warning: You are currently using a development build. These builds WILL contain bugs, broken features, and unexpected crashes. Use at your own risk!"
-            )
-        }
+    if (enableDebug) return
+
+    Surface(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        shape = MaterialTheme.shapes.large,
+        color = Material3Theme.colorScheme.errorContainer
+    ) {
+        WarningPreference(
+            // Don't move to strings.xml, no need to translate this warning
+            text = "Warning: You are currently using a development build. These builds WILL contain bugs, broken features, and unexpected crashes. Use at your own risk!"
+        )
     }
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
This PR adds a warning when users use a development build of the launcher. It can be disabled by enabling the Debug Menu.

Attached below are the screenshots of it:

<div>
  <img src="https://user-images.githubusercontent.com/70206496/206692803-267c3629-1732-442c-95c5-f671373aaeb4.jpg" width="200">
  <img src="https://user-images.githubusercontent.com/70206496/206693443-04b12783-f110-4898-9837-b12e4c5e3d68.jpg" width="200">
</div>

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
