### PR TITLE
Remove LawnchairLauncher's taskAffinity attr overriding

### DIFF
--- a/quickstep/AndroidManifest-launcher.xml
+++ b/quickstep/AndroidManifest-launcher.xml
@@ -55,7 +55,6 @@
             android:configChanges="keyboard|keyboardHidden|mcc|mnc|navigation|orientation|screenSize|screenLayout|smallestScreenSize"
             android:resizeableActivity="true"
             android:resumeWhilePausing="true"
-            android:taskAffinity=""
             android:exported="true"
             android:enabled="true">
             <intent-filter>


### PR DESCRIPTION
## Description

The `app.lawnchair.LawnchairLauncher`'s `taskAffinity` should be keep the same with other activities as the default value (applicationId).

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
