### PR TITLE
Minor tweaks in AppInfoComparator

### DIFF
--- a/src/com/android/launcher3/allapps/AppInfoComparator.java
+++ b/src/com/android/launcher3/allapps/AppInfoComparator.java
@@ -47,7 +47,7 @@ public class AppInfoComparator implements Comparator<AppInfo> {
         int result = mLabelComparator.compare(a.title.toString(), b.title.toString());
         // Group app list by sectionName before sorting for Simplified Chinese only
         if (isSimpledChineseLocale()) {
-            result += a.sectionName.compareTo(b.sectionName);
+            result += a.sectionName.compareTo(b.sectionName) * 10;
         }
         if (result != 0) {
             return result;

--- a/src/com/android/launcher3/allapps/AppInfoComparator.java
+++ b/src/com/android/launcher3/allapps/AppInfoComparator.java
@@ -70,7 +70,7 @@ public class AppInfoComparator implements Comparator<AppInfo> {
 
     private boolean isSimpledChineseLocale() {
         final Locale defaultLocale = Locale.getDefault();
-        return defaultLocale.getLanguage().equals("zh") &&
-            (defaultLocale.getCountry().equals("CN") || defaultLocale.getScript().equals("Hans"));
+        return "zh".equals(defaultLocale.getLanguage()) &&
+            ("CN".equals(defaultLocale.getCountry()) || "Hans".equals(defaultLocale.getScript()));
     }
 }


### PR DESCRIPTION
## Description

Follow up #3125.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
