### PR TITLE
Use sectionName in fuzzy search to display more related results

### DIFF
--- a/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
@@ -118,20 +118,19 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
         val queryTextLower = query.lowercase(Locale.getDefault())
         val matcher = StringMatcherUtility.StringMatcher.getInstance()
         return apps.asSequence()
-            .filter { StringMatcherUtility.matches(queryTextLower, it.title.toString(), matcher) }
+            .filter { StringMatcherUtility.matches(queryTextLower, it.sectionName + it.title, matcher) }
             .filterHiddenApps(queryTextLower)
             .take(maxResultsCount)
             .toList()
     }
 
     private fun fuzzySearch(apps: List<AppInfo>, query: String): List<AppInfo> {
-
         val queryTextLower = query.lowercase(Locale.getDefault())
         val filteredApps = apps.asSequence()
             .filterHiddenApps(queryTextLower)
             .toList()
         val matches = FuzzySearch.extractSorted(
-            queryTextLower, filteredApps, { it.title.toString() }, WeightedRatio(), 65
+            queryTextLower, filteredApps, { it.sectionName + it.title }, WeightedRatio(), 65
         )
 
         return matches.take(maxResultsCount)

--- a/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
@@ -118,7 +118,7 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
         val queryTextLower = query.lowercase(Locale.getDefault())
         val matcher = StringMatcherUtility.StringMatcher.getInstance()
         return apps.asSequence()
-            .filter { StringMatcherUtility.matches(queryTextLower, it.sectionName + it.title, matcher) }
+            .filter { StringMatcherUtility.matches(queryTextLower, it.title.toString(), matcher) }
             .filterHiddenApps(queryTextLower)
             .take(maxResultsCount)
             .toList()


### PR DESCRIPTION
## Description

The apps' `sectionName`s are converted to ascii chars in Simplified Chinese locale, if we can search keywords containing `sectionName`s, it will show more results.

before:
<img src="https://user-images.githubusercontent.com/10363352/211188172-efb348a7-9509-48dd-9048-079743b2c967.jpg" width="25%" height="25%">

after:
<img src="https://user-images.githubusercontent.com/10363352/211188198-ddd5dc51-4411-4935-b76d-56385c45e669.jpg" width="25%" height="25%">


## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
