### PR TITLE
Add an option to override max search result count in settings

### DIFF
--- a/lawnchair/res/values-zh-rCN/strings.xml
+++ b/lawnchair/res/values-zh-rCN/strings.xml
@@ -265,6 +265,7 @@
     <string name="pref_search_auto_show_keyboard">自动显示键盘</string>
     <string name="fuzzy_search_title">模糊搜索</string>
     <string name="fuzzy_search_desc">搜索应用时显示近似结果</string>
+    <string name="max_search_result_count_title">最大搜索结果数</string>
     <!-- <string name="grid" /> -->
     <string name="app_drawer_columns">应用抽屉列数</string>
     <string name="row_height_label">行高度</string>

--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -113,5 +113,6 @@
     <item name="config_default_home_icon_label_size_factor" type="dimen" format="float">1.0</item>
     <item name="config_default_drawer_icon_label_size_factor" type="dimen" format="float">1.0</item>
     <item name="config_default_drawer_cell_height_factor" type="dimen" format="float">1.0</item>
+    <item name="config_default_search_max_result_count" type="dimen" format="integer">5</item>
 
 </resources>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -322,6 +322,7 @@
       <string name="pref_search_auto_show_keyboard">Automatically Show Keyboard</string>
       <string name="fuzzy_search_title">Fuzzy Search</string>
       <string name="fuzzy_search_desc">Approximate matching for app searches.</string>
+      <string name="max_search_result_count_title">Max search result count</string>
 
     <!-- <string name="grid" /> -->
       <string name="app_drawer_columns">App Drawer Columns</string>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -322,7 +322,7 @@
       <string name="pref_search_auto_show_keyboard">Automatically Show Keyboard</string>
       <string name="fuzzy_search_title">Fuzzy Search</string>
       <string name="fuzzy_search_desc">Approximate matching for app searches.</string>
-      <string name="max_search_result_count_title">Max search result count</string>
+      <string name="max_search_result_count_title">Max Search Result Count</string>
 
     <!-- <string name="grid" /> -->
       <string name="app_drawer_columns">App Drawer Columns</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -299,6 +299,11 @@ class PreferenceManager2(private val context: Context) : PreferenceManager {
         defaultValue = context.resources.getBoolean(R.bool.config_default_enable_fuzzy_search),
     )
 
+    val maxSearchResultCount = preference(
+        key = intPreferencesKey(name = "max_search_result_count"),
+        defaultValue = resourceProvider.getInt(R.dimen.config_default_search_max_result_count),
+    )
+
     val enableSmartspace = preference(
         key = booleanPreferencesKey(name = "enable_smartspace"),
         defaultValue = context.resources.getBoolean(R.bool.config_default_enable_smartspace),

--- a/lawnchair/src/app/lawnchair/preferences2/SharedPreferencesMigration.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/SharedPreferencesMigration.kt
@@ -41,6 +41,7 @@ class SharedPreferencesMigration(private val context: Context) {
         "pref_enableMinusOne" to "enable_feed", "pref_enableIconSelection" to "enable_icon_selection",
         "pref_showComponentName" to "show_component_names", "pref_allAppsColumns" to "drawer_columns",
         "pref_folderColumns" to "folder_columns",
+        "pref_maxSearchResultCount" to "max_search_result_count",
     )
 
     fun produceMigration() = androidx.datastore.migrations.SharedPreferencesMigration(

--- a/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/LawnchairAppSearchAlgorithm.kt
@@ -35,6 +35,7 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
     private val appState = LauncherAppState.getInstance(context)
     private val resultHandler = Handler(Executors.MAIN_EXECUTOR.looper)
     private var enableFuzzySearch = false
+    private var maxResultsCount = 5
     private lateinit var hiddenApps: Set<String>
     private var showHiddenAppsInSearch = false
     private var enableSmartHide = false
@@ -45,6 +46,9 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
     init {
         pref2.enableFuzzySearch.onEach(launchIn = coroutineScope) {
             enableFuzzySearch = it
+        }
+        pref2.maxSearchResultCount.onEach(launchIn = coroutineScope) {
+            maxResultsCount = it
         }
         pref2.hiddenApps.onEach(launchIn = coroutineScope) {
             hiddenApps = it
@@ -177,9 +181,5 @@ class LawnchairAppSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm(c
         } else {
             filter { it.toComponentKey().toString() !in hiddenApps }
         }
-    }
-
-    companion object {
-        private const val maxResultsCount = 5
     }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/AppDrawerPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/AppDrawerPreferences.kt
@@ -101,6 +101,12 @@ fun AppDrawerPreferences() {
                             description = stringResource(id = R.string.fuzzy_search_desc)
                         )
                     }
+                    SliderPreference(
+                        label = stringResource(id = R.string.max_search_result_count_title),
+                        adapter = prefs2.maxSearchResultCount.getAdapter(),
+                        step = 1,
+                        valueRange = 5..15,
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Description

Would like to show more search results, but limited by the `LawnchairAppSearchAlgorithm.maxResultsCount`, we can override this value in preferences.

Follow up #3236.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
