### PR TITLE
Unify all data class fields to values

### DIFF
--- a/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
+++ b/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
@@ -60,9 +60,9 @@ class DeviceProfileOverrides(context: Context) {
     fun getTextFactors() = TextFactors(preferenceManager2)
 
     data class DBGridInfo(
-        var numHotseatColumns: Int,
-        var numRows: Int,
-        var numColumns: Int,
+        val numHotseatColumns: Int,
+        val numRows: Int,
+        val numColumns: Int,
     ) {
         val dbFile get() = "launcher_${numRows}_${numColumns}_${numHotseatColumns}.db"
 
@@ -74,14 +74,14 @@ class DeviceProfileOverrides(context: Context) {
     }
 
     data class Options(
-        var numAllAppsColumns: Int,
-        var numFolderRows: Int,
-        var numFolderColumns: Int,
+        val numAllAppsColumns: Int,
+        val numFolderRows: Int,
+        val numFolderColumns: Int,
 
-        var iconSizeFactor: Float,
-        var allAppsIconSizeFactor: Float,
+        val iconSizeFactor: Float,
+        val allAppsIconSizeFactor: Float,
 
-        var enableTaskbarOnPhone: Boolean,
+        val enableTaskbarOnPhone: Boolean,
     ) {
         constructor(
             prefs: PreferenceManager,
@@ -117,8 +117,8 @@ class DeviceProfileOverrides(context: Context) {
     }
 
     data class TextFactors(
-        var iconTextSizeFactor: Float,
-        var allAppsIconTextSizeFactor: Float,
+        val iconTextSizeFactor: Float,
+        val allAppsIconTextSizeFactor: Float,
     ) {
         constructor(
             prefs2: PreferenceManager2,

--- a/lawnchair/src/app/lawnchair/bugreport/BugReport.kt
+++ b/lawnchair/src/app/lawnchair/bugreport/BugReport.kt
@@ -10,7 +10,7 @@ import com.android.launcher3.R
 import java.io.File
 
 data class BugReport(val timestamp: Long, val id: Int, val type: String, val description: String, val contents: String,
-                     var link: String?, var uploadError: Boolean = false, val file: File?) : Parcelable {
+                     val link: String?, val uploadError: Boolean = false, val file: File?) : Parcelable {
 
     constructor(id: Int, type: String, description: String, contents: String, file: File?) : this(
         System.currentTimeMillis(), id, type, description, contents, null, false, file)

--- a/lawnchair/src/app/lawnchair/bugreport/UploaderService.kt
+++ b/lawnchair/src/app/lawnchair/bugreport/UploaderService.kt
@@ -34,12 +34,12 @@ class UploaderService : Service() {
 
     private suspend fun startUpload() {
         while (uploadQueue.isNotEmpty()) {
-            val report = uploadQueue.poll()!!
+            var report = uploadQueue.poll()!!
             try {
-                report.link = UploaderUtils.upload(report)
+                report = report.copy(link = UploaderUtils.upload(report))
             } catch (e: Throwable) {
                 Log.d("UploaderService", "failed to upload bug report", e)
-                report.uploadError = true
+                report = report.copy(uploadError = true)
             } finally {
                 sendBroadcast(Intent(this, BugReportReceiver::class.java)
                     .setAction(BugReportReceiver.UPLOAD_COMPLETE_ACTION)

--- a/lawnchair/src/app/lawnchair/ui/preferences/HomeScreenGridPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/HomeScreenGridPreferences.kt
@@ -60,8 +60,7 @@ fun HomeScreenGridPreferences() {
                     .align(Alignment.CenterHorizontally)
                     .clip(MaterialTheme.shapes.large)
             ) {
-                numColumns = columns.value
-                numRows = rows.value
+                copy(numColumns = columns.value, numRows = rows.value)
             }
         }
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/GridOverridesPreview.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/GridOverridesPreview.kt
@@ -14,7 +14,7 @@ import com.android.launcher3.InvariantDeviceProfile
 @Composable
 fun GridOverridesPreview(
     modifier: Modifier = Modifier,
-    updateGridOptions: DeviceProfileOverrides.DBGridInfo.() -> Unit
+    updateGridOptions: DeviceProfileOverrides.DBGridInfo.() -> DeviceProfileOverrides.DBGridInfo
 ) {
     DummyLauncherBox(modifier = modifier) {
         WallpaperPreview(modifier = Modifier.fillMaxSize())
@@ -26,15 +26,14 @@ fun GridOverridesPreview(
 }
 
 @Composable
-fun createPreviewIdp(updateGridOptions: DeviceProfileOverrides.DBGridInfo.() -> Unit): InvariantDeviceProfile {
+fun createPreviewIdp(updateGridOptions: DeviceProfileOverrides.DBGridInfo.() -> DeviceProfileOverrides.DBGridInfo): InvariantDeviceProfile {
     val context = LocalContext.current
     val prefs = preferenceManager()
 
     val newIdp by remember {
         derivedStateOf {
             val options = DeviceProfileOverrides.DBGridInfo(prefs)
-            updateGridOptions(options)
-            InvariantDeviceProfile(context, options)
+            InvariantDeviceProfile(context, updateGridOptions(options))
         }
     }
     return newIdp


### PR DESCRIPTION
## Description

Make sure all fields in data classes are values instead of variables, just use `.copy()` to change the contents.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
