### PR TITLE
Distinguish between release and debug via `applicationIdSuffix` & `label`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,7 @@ android {
 
     buildTypes {
         debug {
+            applicationIdSuffix ".debug"
             signingConfig releaseSigning
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -184,10 +184,12 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".debug"
+            resValue("string", "derived_app_name", "Lawnchair (Debug)")
             signingConfig releaseSigning
         }
 
         release {
+            resValue("string", "derived_app_name", "Lawnchair")
             signingConfig releaseSigning
             minifyEnabled true
             shrinkResources true

--- a/lawnchair/res/values-en-rGB/strings.xml
+++ b/lawnchair/res/values-en-rGB/strings.xml
@@ -17,7 +17,6 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="iconPackPackageDefault" translatable="false">""</string>
-    <string name="derived_app_name" tools:override="true" translatable="false">Lawnchair</string>
     <string name="twitter" translatable="false">Twitter</string>
     <string name="github" translatable="false">GitHub</string>
 

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -17,7 +17,6 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="iconPackPackageDefault" translatable="false">""</string>
-    <string name="derived_app_name" tools:override="true" translatable="false">Lawnchair</string>
 
     <!-- PreferenceDashboard -->
     <string name="settings">Settings</string>

--- a/quickstep/res/values/strings.xml
+++ b/quickstep/res/values/strings.xml
@@ -18,9 +18,6 @@
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
-    <!-- Application name -->
-    <string name="derived_app_name" translatable="false">Quickstep</string>
-
     <!-- Options for recent tasks -->
     <!-- Title for an option to keep an app pinned to the screen until it is unpinned -->
     <string name="recent_task_option_pin">Pin</string>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -4,10 +4,6 @@
 
     <integer name="extracted_color_gradient_alpha">153</integer>
 
-    <!-- A string pointer to the original app name string. This allows derived projects to
-     easily override the app name without providing all translations -->
-    <string name="derived_app_name" translatable="false">@string/app_name</string>
-
     <!-- String representing the intent for search on the apps market. To specify a query, add
     q=<query> to the data to the intent -->
     <string name="market_search_intent" translatable="false">market://search?c=apps</string>


### PR DESCRIPTION
## Description

To divide the debug with the release, easy to test the debug app instead of covering the release one installed.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
