### PR TITLE
Always enable `GoogleQsbContainerView` if it is the current search widget

### DIFF
--- a/lawnchair/res/layout/search_container_hotseat_google_search.xml
+++ b/lawnchair/res/layout/search_container_hotseat_google_search.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.android.launcher3.qsb.QsbContainerView
+<app.lawnchair.qsb.GoogleQsbContainerView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
@@ -8,8 +8,8 @@
     android:padding="0dp" >
 
     <fragment
-        android:name="com.android.launcher3.qsb.QsbContainerView$QsbFragment"
+        android:name="app.lawnchair.qsb.GoogleQsbContainerView$QsbFragment"
         android:layout_width="match_parent"
         android:tag="qsb_view"
         android:layout_height="match_parent"/>
-</com.android.launcher3.qsb.QsbContainerView>
+</app.lawnchair.qsb.GoogleQsbContainerView>

--- a/lawnchair/src/app/lawnchair/qsb/GoogleQsbContainerView.kt
+++ b/lawnchair/src/app/lawnchair/qsb/GoogleQsbContainerView.kt
@@ -1,0 +1,14 @@
+package app.lawnchair.qsb
+
+import android.content.Context
+import android.util.AttributeSet
+import com.android.launcher3.qsb.QsbContainerView
+
+class GoogleQsbContainerView @JvmOverloads constructor(
+    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : QsbContainerView(context, attrs, defStyleAttr) {
+
+    class QsbFragment : QsbContainerView.QsbFragment() {
+        override fun isQsbEnabled(): Boolean = true
+    }
+}


### PR DESCRIPTION
## Description

Follow up #3108, closes #3210.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
