### PR TITLE
Rename QsbLayout to LawnQsbLayout

### DIFF
--- a/lawnchair/res/layout/search_container_hotseat.xml
+++ b/lawnchair/res/layout/search_container_hotseat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<app.lawnchair.qsb.QsbLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<app.lawnchair.qsb.LawnQsbLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/qsb_widget_height"
@@ -62,4 +62,4 @@
 
     </FrameLayout>
 
-</app.lawnchair.qsb.QsbLayout>
+</app.lawnchair.qsb.LawnQsbLayout>

--- a/lawnchair/src/app/lawnchair/gestures/handlers/OpenSearchGestureHandler.kt
+++ b/lawnchair/src/app/lawnchair/gestures/handlers/OpenSearchGestureHandler.kt
@@ -3,13 +3,13 @@ package app.lawnchair.gestures.handlers
 import android.content.Context
 import app.lawnchair.LawnchairLauncher
 import app.lawnchair.preferences2.PreferenceManager2
-import app.lawnchair.qsb.QsbLayout
+import app.lawnchair.qsb.LawnQsbLayout
 
 class OpenSearchGestureHandler(context: Context) : GestureHandler(context) {
 
     override suspend fun onTrigger(launcher: LawnchairLauncher) {
         val prefs = PreferenceManager2.getInstance(launcher)
-        val searchProvider = QsbLayout.getSearchProvider(launcher, prefs)
+        val searchProvider = LawnQsbLayout.getSearchProvider(launcher, prefs)
         searchProvider.launch(launcher)
     }
 }

--- a/lawnchair/src/app/lawnchair/qsb/AssistantIconView.kt
+++ b/lawnchair/src/app/lawnchair/qsb/AssistantIconView.kt
@@ -12,10 +12,10 @@ import com.android.launcher3.R
 class AssistantIconView(context: Context, attrs: AttributeSet?) : ImageButton(context, attrs) {
 
     init {
-        val provider = QsbLayout.getSearchProvider(context, PreferenceManager2.getInstance(context))
+        val provider = LawnQsbLayout.getSearchProvider(context, PreferenceManager2.getInstance(context))
         val intent = if (provider.supportVoiceIntent) provider.createVoiceIntent() else null
 
-        if (intent == null || !QsbLayout.resolveIntent(context, intent)) isVisible = false
+        if (intent == null || !LawnQsbLayout.resolveIntent(context, intent)) isVisible = false
 
         setOnClickListener {
             context.startActivity(intent)

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -56,20 +56,18 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
     override fun onFinishInflate() {
         super.onFinishInflate()
 
-        gIcon = ViewCompat.requireViewById<ImageView>(this, R.id.g_icon)
+        gIcon = ViewCompat.requireViewById(this, R.id.g_icon)
         micIcon = ViewCompat.requireViewById(this, R.id.mic_icon)
         lensIcon = ViewCompat.requireViewById(this, R.id.lens_icon)
         inner = ViewCompat.requireViewById(this, R.id.inner)
         preferenceManager = PreferenceManager.getInstance(context)
         preferenceManager2 = PreferenceManager2.getInstance(context)
 
-        val searchProvider = getSearchProvider(context, preferenceManager2)
         setUpBackground()
         clipIconRipples()
 
-        val isGoogle = searchProvider == Google ||
-                searchProvider == GoogleGo
-
+        val searchProvider = getSearchProvider(context, preferenceManager2)
+        val isGoogle = searchProvider == Google || searchProvider == GoogleGo
         val supportsLens = searchProvider == Google
 
         preferenceManager2.themedHotseatQsb.subscribeBlocking(scope = viewAttachedScope) { themed ->

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -41,7 +41,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 
-class QsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(context, attrs) {
+class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(context, attrs) {
 
     private val activity: ActivityContext = ActivityContext.lookupContext<BaseActivity>(context)
     private lateinit var gIcon: ImageView

--- a/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
@@ -8,7 +8,7 @@ import android.widget.Toast
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import app.lawnchair.preferences2.PreferenceManager2
-import app.lawnchair.qsb.QsbLayout
+import app.lawnchair.qsb.LawnQsbLayout
 import app.lawnchair.qsb.ThemingMethod
 import app.lawnchair.resolveIntent
 import app.lawnchair.util.isPackageInstalled
@@ -142,7 +142,7 @@ sealed class QsbSearchProvider(
                 context.getString(R.string.config_default_qsb_search_provider_id)
             val defaultProvider = fromId(defaultProviderId)
             val isDefaultProviderIntentResolved =
-                QsbLayout.resolveIntent(context, defaultProvider.createSearchIntent())
+                LawnQsbLayout.resolveIntent(context, defaultProvider.createSearchIntent())
 
             // Return the default value from config.xml if the value is valid
             if (isDefaultProviderIntentResolved) {
@@ -156,7 +156,7 @@ sealed class QsbSearchProvider(
             // Return the best default option if the config.xml value is invalid
             return values()
                 .filterNot { it == AppSearch }
-                .firstOrNull { QsbLayout.resolveIntent(context, it.createSearchIntent()) }
+                .firstOrNull { LawnQsbLayout.resolveIntent(context, it.createSearchIntent()) }
                 ?: AppSearch
 
         }


### PR DESCRIPTION
## Description

Follow up #3273.

Distinguish between `GoogleQsbContainerView` and `QsbLayout` (of Lawnchair's own).

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
