### PR TITLE
Release apk with uploading mapping file

### DIFF
--- a/.github/workflows/build_release_apk.yml
+++ b/.github/workflows/build_release_apk.yml
@@ -38,7 +38,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Release APK
-          path: build/outputs/apk/lawnWithQuickstep/release/*.apk
+          path: |
+            build/outputs/apk/lawnWithQuickstep/release/*.apk
+            build/outputs/mapping/lawnWithQuickstepRelease/mapping.txt
 
   send-notifications:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

We can easily retrace obfuscated stack traces with the mapping file.

https://github.com/actions/upload-artifact#upload-using-multiple-paths-and-exclusions

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
