### PR TITLE
Ensure unseal at the first time

### DIFF
--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -132,5 +132,10 @@
         <meta-data
             android:name="xyz.paphonb.quickstepswitcher.maxSdk"
             android:value="${quickstepMaxSdk}" />
+
+        <provider
+            android:name="org.chickenhook.restrictionbypass.BypassProvider"
+            android:authorities="${applicationId}.restrictionbypass"
+            tools:node="remove"/>
     </application>
 </manifest>

--- a/src/com/android/launcher3/MainProcessInitializer.java
+++ b/src/com/android/launcher3/MainProcessInitializer.java
@@ -19,12 +19,15 @@
 package com.android.launcher3;
 
 import android.content.Context;
+import android.util.Log;
 
 import com.android.launcher3.config.FeatureFlags;
 import com.android.launcher3.graphics.BitmapCreationCheck;
 import com.android.launcher3.graphics.IconShape;
 import com.android.launcher3.logging.FileLog;
 import com.android.launcher3.util.ResourceBasedOverride;
+
+import org.chickenhook.restrictionbypass.Unseal;
 
 import app.lawnchair.preferences.PreferenceManager;
 
@@ -33,7 +36,16 @@ import app.lawnchair.preferences.PreferenceManager;
  */
 public class MainProcessInitializer implements ResourceBasedOverride {
 
+    private static final String TAG = "MainProcessInitializer";
+
     public static void initialize(Context context) {
+        try {
+            Unseal.unseal();
+            Log.i(TAG, "Unseal success!");
+        } catch (Exception e) {
+            Log.e(TAG, "Unseal fail!");
+            e.printStackTrace();
+        }
         PreferenceManager.getInstance(context);
         Overrides.getObject(
                 MainProcessInitializer.class, context, R.string.main_process_initializer_class)


### PR DESCRIPTION
## Description

Unable to determine execution order if relying on a provider.

Follow up #3364.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
