### PR TITLE
Mark more components exported

### DIFF
--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -58,10 +58,12 @@
 
         <activity
             android:name="app.lawnchair.BlankActivity"
+            android:exported="false"
             android:theme="@style/Theme.Transparent" />
 
         <activity
             android:name="app.lawnchair.smartspace.SmartspacePreferencesShortcut"
+            android:exported="false"
             android:theme="@style/Theme.Transparent" />
 
         <receiver

--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -66,6 +66,11 @@
             android:exported="false"
             android:theme="@style/Theme.Transparent" />
 
+        <activity android:name="androidx.slice.compat.SlicePermissionActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            tools:node="replace" />
+
         <receiver
             android:name="app.lawnchair.gestures.handlers.SleepMethodDeviceAdmin$SleepDeviceAdmin"
             android:description="@string/dt2s_admin_hint"

--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -69,7 +69,7 @@
         <!--todo: We can remove this override if SlicePermissionActivity is exported in the library-->
         <activity android:name="androidx.slice.compat.SlicePermissionActivity"
             android:excludeFromRecents="true"
-            android:exported="true"
+            android:exported="false"
             tools:node="replace" />
 
         <receiver

--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -66,6 +66,7 @@
             android:exported="false"
             android:theme="@style/Theme.Transparent" />
 
+        <!--todo: We can remove this override if SlicePermissionActivity is exported in the library-->
         <activity android:name="androidx.slice.compat.SlicePermissionActivity"
             android:excludeFromRecents="true"
             android:exported="true"

--- a/quickstep/AndroidManifest.xml
+++ b/quickstep/AndroidManifest.xml
@@ -61,6 +61,7 @@
 
         <activity android:name="com.android.quickstep.RecentsActivity"
              android:excludeFromRecents="true"
+             android:exported="true"
              android:launchMode="singleTask"
              android:clearTaskOnLaunch="true"
              android:stateNotNeeded="true"

--- a/quickstep/AndroidManifest.xml
+++ b/quickstep/AndroidManifest.xml
@@ -61,7 +61,7 @@
 
         <activity android:name="com.android.quickstep.RecentsActivity"
              android:excludeFromRecents="true"
-             android:exported="true"
+             android:exported="false"
              android:launchMode="singleTask"
              android:clearTaskOnLaunch="true"
              android:stateNotNeeded="true"


### PR DESCRIPTION
## Description

Some components hadn't been declared `android:exported` in manifest.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
