### PR TITLE
Add support for "Pixel Search" app

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -308,6 +308,7 @@
     <string name="search_provider_sesame" translatable="false">Sesame</string>
     <string name="search_provider_brave" translatable="false">Brave</string>
     <string name="search_provider_github" translatable="false">GitHub</string>
+    <string name="search_provider_pixel_search" translatable="false">Pixel Search</string>
     <string name="app_label">App</string>
     <string name="website_label">Website</string>
     <string name="qsb_search_provider_app_required">App required.</string>

--- a/lawnchair/src/app/lawnchair/qsb/providers/PixelSearch.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/PixelSearch.kt
@@ -1,0 +1,14 @@
+package app.lawnchair.qsb.providers
+
+import app.lawnchair.qsb.ThemingMethod
+import com.android.launcher3.R
+
+object PixelSearch : QsbSearchProvider(
+    id = "pixel_search",
+    name = R.string.search_provider_pixel_search,
+    icon = R.drawable.ic_qsb_search,
+    themingMethod = ThemingMethod.TINT,
+    packageName = "rk.android.app.pixelsearch",
+    website = "https://play.google.com/store/apps/details?id=rk.android.app.pixelsearch",
+    type = QsbSearchProviderType.APP,
+)

--- a/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
@@ -126,6 +126,7 @@ sealed class QsbSearchProvider(
             Sesame,
             Brave,
             GitHub,
+            PixelSearch,
         )
 
         /**


### PR DESCRIPTION
## Description

Motivation:  *I just use this app, "Pixel Search", 5 minutes later, I want this search provider on Lawnchair...*

* Search provider: https://play.google.com/store/apps/details?id=rk.android.app.pixelsearch
* Description: Google Pixel Universal Search, but for everyone

## Type of change

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
✅ New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
