### PR TITLE
Tweak Pixel Search QSB UI

### DIFF
--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -23,6 +23,7 @@ import app.lawnchair.preferences2.subscribeBlocking
 import app.lawnchair.qsb.providers.AppSearch
 import app.lawnchair.qsb.providers.Google
 import app.lawnchair.qsb.providers.GoogleGo
+import app.lawnchair.qsb.providers.PixelSearch
 import app.lawnchair.qsb.providers.QsbSearchProvider
 import app.lawnchair.util.pendingIntent
 import app.lawnchair.util.recursiveChildren

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -67,8 +67,8 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         clipIconRipples()
 
         val searchProvider = getSearchProvider(context, preferenceManager2)
-        val isGoogle = searchProvider == Google || searchProvider == GoogleGo
-        val supportsLens = searchProvider == Google
+        val isGoogle = searchProvider == Google || searchProvider == GoogleGo || searchProvider == PixelSearch
+        val supportsLens = searchProvider == Google || searchProvider == PixelSearch
 
         preferenceManager2.themedHotseatQsb.subscribeBlocking(scope = viewAttachedScope) { themed ->
             setUpBackground(themed)

--- a/lawnchair/src/app/lawnchair/qsb/providers/PixelSearch.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/PixelSearch.kt
@@ -1,6 +1,6 @@
 package app.lawnchair.qsb.providers
 
-import android.context.Intent
+import android.content.Intent
 import app.lawnchair.qsb.ThemingMethod
 import com.android.launcher3.R
 

--- a/lawnchair/src/app/lawnchair/qsb/providers/PixelSearch.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/PixelSearch.kt
@@ -12,4 +12,5 @@ object PixelSearch : QsbSearchProvider(
     packageName = "rk.android.app.pixelsearch",
     website = "https://play.google.com/store/apps/details?id=rk.android.app.pixelsearch",
     type = QsbSearchProviderType.APP,
+    supportVoiceIntent = true,
 )

--- a/lawnchair/src/app/lawnchair/qsb/providers/PixelSearch.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/PixelSearch.kt
@@ -6,8 +6,9 @@ import com.android.launcher3.R
 object PixelSearch : QsbSearchProvider(
     id = "pixel_search",
     name = R.string.search_provider_pixel_search,
-    icon = R.drawable.ic_qsb_search,
-    themingMethod = ThemingMethod.TINT,
+    // Use same style as Google Search
+    icon = R.drawable.ic_super_g_color,
+    themingMethod = ThemingMethod.THEME_BY_LAYER_ID,
     packageName = "rk.android.app.pixelsearch",
     website = "https://play.google.com/store/apps/details?id=rk.android.app.pixelsearch",
     type = QsbSearchProviderType.APP,

--- a/lawnchair/src/app/lawnchair/qsb/providers/PixelSearch.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/PixelSearch.kt
@@ -1,5 +1,6 @@
 package app.lawnchair.qsb.providers
 
+import android.context.Intent
 import app.lawnchair.qsb.ThemingMethod
 import com.android.launcher3.R
 
@@ -13,4 +14,9 @@ object PixelSearch : QsbSearchProvider(
     website = "https://play.google.com/store/apps/details?id=rk.android.app.pixelsearch",
     type = QsbSearchProviderType.APP,
     supportVoiceIntent = true,
-)
+) {
+
+    override fun handleCreateVoiceIntent(): Intent =
+        Intent(Intent.ACTION_VOICE_COMMAND)
+
+}

--- a/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
@@ -119,14 +119,14 @@ sealed class QsbSearchProvider(
             AppSearch,
             Google,
             GoogleGo,
+            PixelSearch,
+            Sesame,
+            Wikipedia,
+            GitHub,
             DuckDuckGo,
             Presearch,
-            Wikipedia,
             Bing,
-            Sesame,
             Brave,
-            GitHub,
-            PixelSearch,
         )
 
         /**


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
This PR aims to make the Lawnchair QSB provider look more like the stock Pixel QSB by making the UI more similar to it.

This is done by simply allowing `PixelSearch` to use the lens and mic icons, and also changing the icon to use the Google one.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

✅ General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
