### PR TITLE
fix AAG Battery Status for Thai language

### DIFF
--- a/lawnchair/res/values-th-rTH/strings.xml
+++ b/lawnchair/res/values-th-rTH/strings.xml
@@ -209,7 +209,7 @@
     <string name="smartspace_battery_charging">กำลังชาร์จ</string>
     <string name="smartspace_battery_full">ชาร์จแล้ว</string>
     <string name="smartspace_battery_low">แบตเตอร์รี่ต่ำ</string>
-    <string name="battery_charging_percentage_charging_time">"%1$d% — จะเต็มในอีก %2$s"</string>
+    <string name="battery_charging_percentage_charging_time">"%1$d%% — จะเต็มในอีก %2$s"</string>
     <string name="accessibility_smartspace_page">หน้าที่ %1$d จากทั้งหมด %2$d หน้า</string>
     <string name="smartspace_widget">ข้อมูลโดยย่อ</string>
     <string name="smartspace_widget_description">สิ่งที่อยากให้แสดง</string>


### PR DESCRIPTION
## Description

Fix `Java.util.UnknownFormatConversionException: Conversion = '—'` on Thai language due to a missing "%"

... *💀 what more could I say*

This seems to be an issue with only Thai language.

Fix #3473 

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
✅ Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
