### PR TITLE
Prioritize battery status when device battery is low

### DIFF
--- a/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceScores.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceScores.kt
@@ -5,4 +5,5 @@ object SmartspaceScores {
     const val SCORE_BATTERY = 1f
     const val SCORE_MEDIA = 2f
     const val SCORE_CALENDAR = 3f
+    const val SCORE_LOW_BATTERY = 10f
 }

--- a/lawnchair/src/app/lawnchair/smartspace/provider/BatteryStatusProvider.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/provider/BatteryStatusProvider.kt
@@ -38,6 +38,11 @@ class BatteryStatusProvider(context: Context) : SmartspaceDataSource(
             level <= 15 -> context.getString(R.string.smartspace_battery_low)
             else -> return null
         }
+        val score = if (level <= 15) {
+            SmartspaceScores.SCORE_LOW_BATTERY
+        } else {
+            SmartspaceScores.SCORE_BATTERY
+        }
         val chargingTimeRemaining = computeChargeTimeRemaining()
         val subtitle = if (charging && chargingTimeRemaining > 0) {
             val chargingTime = formatShortElapsedTimeRoundingUpToMinutes(context, chargingTimeRemaining)
@@ -55,7 +60,7 @@ class BatteryStatusProvider(context: Context) : SmartspaceDataSource(
                 title = title,
                 subtitle = subtitle
             ),
-            score = SmartspaceScores.SCORE_BATTERY,
+            score = score,
             featureType = SmartspaceTarget.FeatureType.FEATURE_CALENDAR
         )
     }


### PR DESCRIPTION
## Description

Battery Status when battery is low (15%) will take priority over any At a Glance features.

This bring user's attention to device's battery when it's reaching low/critical level.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
✅ New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
