### PR TITLE
Migrate to Licensee

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,15 @@ android {
     }
 
     applicationVariants.configureEach { variant ->
+        def copyArtifactList = tasks.register("copy${variant.name.capitalize()}ArtifactList", Copy) {
+            dependsOn "licensee${variant.name.capitalize()}"
+            from project.extensions.getByType(ReportingExtension).file("licensee/${variant.name}/artifacts.json")
+            into layout.buildDirectory.dir("generated/dependencyAssets/")
+        }
+        tasks.named("merge${variant.name.capitalize()}Assets").configure {
+            dependsOn copyArtifactList
+        }
+
         variant.outputs.configureEach {
             outputFileName = "Lawnchair ${variant.versionName}.apk"
         }
@@ -280,6 +289,7 @@ android {
 
         lawnWithQuickstep {
             manifest.srcFile "quickstep/AndroidManifest-launcher.xml"
+            assets.srcDir layout.buildDirectory.dir("generated/dependencyAssets/")
         }
 
         withoutQuickstep {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.serialization' version "1.8.21"
     id "com.google.devtools.ksp" version "1.8.21-1.0.11"
     id 'com.google.protobuf' version "0.9.3"
-    id 'com.google.android.gms.oss-licenses-plugin' version "0.10.6"
     id 'app.cash.licensee' version "1.7.0"
     id 'dev.rikka.tools.refine' version "4.3.0"
 }
@@ -369,7 +368,6 @@ dependencies {
     implementation "com.github.topjohnwu.libsu:service:$libsu_version"
 
     implementation "com.google.protobuf:protobuf-javalite:$protocVersion"
-    implementation 'com.github.LawnchairLauncher:oss-notices:1.0.2'
 
     // Persian Date
     implementation 'com.github.samanzamani:PersianDate:1.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id "com.google.devtools.ksp" version "1.8.21-1.0.11"
     id 'com.google.protobuf' version "0.9.3"
     id 'com.google.android.gms.oss-licenses-plugin' version "0.10.6"
-    id 'app.cash.licensee' version "1.7.0-SNAPSHOT"
+    id 'app.cash.licensee' version "1.7.0"
     id 'dev.rikka.tools.refine' version "4.3.0"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ android {
 
     applicationVariants.configureEach { variant ->
         def copyArtifactList = tasks.register("copy${variant.name.capitalize()}ArtifactList", Copy) {
-            dependsOn "licensee${variant.name.capitalize()}"
+            dependsOn tasks.named("licensee${variant.name.capitalize()}")
             from project.extensions.getByType(ReportingExtension).file("licensee/${variant.name}/artifacts.json")
             into layout.buildDirectory.dir("generated/dependencyAssets/")
         }

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id "com.google.devtools.ksp" version "1.8.21-1.0.11"
     id 'com.google.protobuf' version "0.9.3"
     id 'com.google.android.gms.oss-licenses-plugin' version "0.10.6"
+    id 'app.cash.licensee' version "1.7.0-SNAPSHOT"
     id 'dev.rikka.tools.refine' version "4.3.0"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -390,3 +390,14 @@ protobuf {
         }
     }
 }
+
+licensee {
+    allow("Apache-2.0")
+    allow("BSD-3-Clause")
+    allowUrl("https://api.github.com/licenses/apache-2.0")
+    allowUrl("https://api.github.com/licenses/bsd-3-clause")
+    allowUrl("https://github.com/patrykmichalik/opto/blob/master/LICENSE")
+    allowUrl("https://github.com/RikkaApps/HiddenApiRefinePlugin/blob/main/LICENSE")
+    allowUrl("https://github.com/stleary/JSON-java/blob/master/LICENSE")
+    allowUrl("https://www.gnu.org/licenses/old-licenses/gpl-2.0.html")
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/PreferenceInteractor.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/PreferenceInteractor.kt
@@ -16,7 +16,7 @@
 
 package app.lawnchair.ui.preferences
 
-import app.lawnchair.ossnotices.OssLibrary
+import app.lawnchair.ui.preferences.about.acknowledgements.OssLibrary
 import kotlinx.coroutines.flow.StateFlow
 
 sealed interface PreferenceInteractor {

--- a/lawnchair/src/app/lawnchair/ui/preferences/PreferenceViewModel.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/PreferenceViewModel.kt
@@ -22,8 +22,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import app.lawnchair.icons.CustomAdaptiveIconDrawable
-import app.lawnchair.ossnotices.OssLibrary
-import app.lawnchair.ossnotices.getOssLibraries
+import app.lawnchair.ui.preferences.about.acknowledgements.OssLibrary
 import com.android.launcher3.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
@@ -33,6 +32,7 @@ import kotlinx.coroutines.flow.stateIn
 import app.lawnchair.util.getPackageVersionCode
 import app.lawnchair.util.Constants.LAWNICONS_PACKAGE_NAME
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.json.Json
 
 private val iconPackIntents = listOf(
     Intent("com.novalauncher.THEME"),
@@ -109,10 +109,11 @@ class PreferenceViewModel(private val app: Application) : AndroidViewModel(app),
         .stateIn(viewModelScope, SharingStarted.Lazily, listOf())
 
     override val ossLibraries: StateFlow<List<OssLibrary>> = flow {
-        val ossLibraries = app.getOssLibraries(R.raw.third_party_license_metadata)
-            .distinctBy { it.name }
-        emit(ossLibraries)
+        val jsonString = app.resources.assets.open("artifacts.json")
+            .bufferedReader().use { it.readText() }
+        val artifacts: List<OssLibrary> = Json.decodeFromString(jsonString)
+        emit(artifacts)
     }
-        .flowOn(Dispatchers.Default)
+        .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/PreferenceViewModel.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/PreferenceViewModel.kt
@@ -41,11 +41,9 @@ private val iconPackIntents = listOf(
     Intent("android.intent.action.MAIN").addCategory("com.anddoes.launcher.THEME")
 )
 
-class PreferenceViewModel(private val app: Application) : AndroidViewModel(app),
-    PreferenceInteractor {
+class PreferenceViewModel(private val app: Application) : AndroidViewModel(app), PreferenceInteractor {
 
-    private val themedIconPackIntents =
-        listOf(Intent(app.getString(R.string.icon_packs_intent_name)))
+    private val themedIconPackIntents = listOf(Intent(app.getString(R.string.icon_packs_intent_name)))
     override val iconPacks = flow {
         val pm = app.packageManager
         val iconPacks = iconPackIntents
@@ -113,12 +111,12 @@ class PreferenceViewModel(private val app: Application) : AndroidViewModel(app),
     override val ossLibraries: StateFlow<List<OssLibrary>> = flow {
         val jsonString = app.resources.assets.open("artifacts.json")
             .bufferedReader().use { it.readText() }
-        val artifacts = Json.decodeFromString<List<OssLibrary>>(jsonString)
+        val ossLibraries = Json.decodeFromString<List<OssLibrary>>(jsonString)
             .asSequence()
             .distinctBy { "${it.groupId}:${it.artifactId}" }
             .sortedBy { it.name }
             .toList()
-        emit(artifacts)
+        emit(ossLibraries)
     }
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/acknowledgements/Acknowledgements.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/acknowledgements/Acknowledgements.kt
@@ -100,35 +100,34 @@ fun NoticePage(index: Int) {
         label = ossLibrary?.name ?: stringResource(id = R.string.loading)
     ) {
         Crossfade(targetState = data, label = "") { it ->
-            if (it != null) {
-                val uriHandler = LocalUriHandler.current
-                val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
-                val pressIndicator = Modifier.pointerInput(Unit) {
-                    detectTapGestures { pos ->
-                        layoutResult.value?.let { layoutResult ->
-                            val position = layoutResult.getOffsetForPosition(pos)
-                            val annotation =
-                                it.notice.getStringAnnotations(position, position).firstOrNull()
-                            if (annotation?.tag == "URL") {
-                                uriHandler.openUri(annotation.item)
-                            }
+            it ?: return@Crossfade
+            val uriHandler = LocalUriHandler.current
+            val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
+            val pressIndicator = Modifier.pointerInput(Unit) {
+                detectTapGestures { pos ->
+                    layoutResult.value?.let { layoutResult ->
+                        val position = layoutResult.getOffsetForPosition(pos)
+                        val annotation =
+                            it.notice.getStringAnnotations(position, position).firstOrNull()
+                        if (annotation?.tag == "URL") {
+                            uriHandler.openUri(annotation.item)
                         }
                     }
                 }
-
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp)
-                        .then(pressIndicator),
-                    text = it.notice,
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 14.sp,
-                    onTextLayout = {
-                        layoutResult.value = it
-                    }
-                )
             }
+
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp)
+                    .then(pressIndicator),
+                text = it.notice,
+                fontFamily = FontFamily.Monospace,
+                fontSize = 14.sp,
+                onTextLayout = {
+                    layoutResult.value = it
+                }
+            )
         }
     }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/acknowledgements/Acknowledgements.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/acknowledgements/Acknowledgements.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
-import app.lawnchair.ossnotices.OssLibrary
 import app.lawnchair.ui.preferences.LocalNavController
 import app.lawnchair.ui.preferences.LocalPreferenceInteractor
 import app.lawnchair.ui.preferences.components.*
@@ -44,9 +43,6 @@ import app.lawnchair.ui.preferences.preferenceGraph
 import app.lawnchair.ui.preferences.subRoute
 import com.android.launcher3.R
 import com.google.accompanist.navigation.animation.composable
-import com.google.accompanist.placeholder.PlaceholderHighlight
-import com.google.accompanist.placeholder.material.fade
-import com.google.accompanist.placeholder.material.placeholder
 
 @OptIn(ExperimentalAnimationApi::class)
 fun NavGraphBuilder.licensesGraph(route: String) {
@@ -103,7 +99,7 @@ fun NoticePage(index: Int) {
     PreferenceLayout(
         label = ossLibrary?.name ?: stringResource(id = R.string.loading)
     ) {
-        Crossfade(targetState = data) { it ->
+        Crossfade(targetState = data, label = "") { it ->
             if (it != null) {
                 val uriHandler = LocalUriHandler.current
                 val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
@@ -131,18 +127,6 @@ fun NoticePage(index: Int) {
                     onTextLayout = {
                         layoutResult.value = it
                     }
-                )
-            } else {
-                Text(
-                    modifier = Modifier
-                        .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp)
-                        .placeholder(
-                            visible = true,
-                            highlight = PlaceholderHighlight.fade(),
-                        ),
-                    text = "a".repeat(ossLibrary?.noticeLength ?: 20),
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 14.sp
                 )
             }
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/acknowledgements/loadNotice.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/acknowledgements/loadNotice.kt
@@ -74,9 +74,9 @@ data class OssLibrary(
     val artifactId: String,
     val version: String,
     val name: String,
+    val scm: Scm? = null,
     val spdxLicenses: List<License>? = null,
     val unknownLicenses: List<License>? = null,
-    val scm: Scm? = null,
 ) {
     @Serializable
     data class License(

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/acknowledgements/loadNotice.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/acknowledgements/loadNotice.kt
@@ -20,22 +20,24 @@ import android.text.SpannableString
 import android.text.style.URLSpan
 import android.text.util.Linkify
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.*
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
-import app.lawnchair.ossnotices.OssLibrary
-import com.android.launcher3.R
+import kotlinx.serialization.Serializable
 
 @Composable
 fun loadNotice(ossLibrary: OssLibrary): State<OssLibraryWithNotice?> {
-    val context = LocalContext.current
     val noticeStringState = remember { mutableStateOf<OssLibraryWithNotice?>(null) }
     val accentColor = MaterialTheme.colorScheme.primary
     DisposableEffect(Unit) {
-        val string = ossLibrary.getNotice(context = context, thirdPartyLicensesId = R.raw.third_party_licenses)
+        val string = (ossLibrary.spdxLicenses ?: ossLibrary.unknownLicenses)
+            ?.firstOrNull()?.url.orEmpty()
         val spannable = SpannableString(string)
         Linkify.addLinks(spannable, Linkify.WEB_URLS)
         val spans = spannable.getSpans(0, string.length, URLSpan::class.java)
@@ -64,6 +66,27 @@ fun loadNotice(ossLibrary: OssLibrary): State<OssLibraryWithNotice?> {
         onDispose { }
     }
     return noticeStringState
+}
+
+@Serializable
+data class OssLibrary(
+    val groupId: String,
+    val artifactId: String,
+    val version: String,
+    val name: String,
+    val spdxLicenses: List<License>? = null,
+    val unknownLicenses: List<License>? = null,
+    val scm: Scm? = null,
+) {
+    @Serializable
+    data class License(
+        val identifier: String? = null,
+        val name: String,
+        val url: String,
+    )
+
+    @Serializable
+    data class Scm(val url: String)
 }
 
 data class OssLibraryWithNotice(

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ pluginManagement {
     repositories {
         google()
         gradlePluginPortal()
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
     }
     resolutionStrategy {
         eachPlugin {

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,6 @@ pluginManagement {
     repositories {
         google()
         gradlePluginPortal()
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
     }
     resolutionStrategy {
         eachPlugin {


### PR DESCRIPTION
## Description

As Licensee had supported Gradle config cache (oss-licenses-plugin doesn't), we can migrate to Licensee so that all of our plugins can be CC compatible.

https://github.com/cashapp/licensee/releases/tag/1.7.0
https://www.jbamberger.de/development/2021/07/03/android-generating-asset-files.html


## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
