### PR TITLE
Remove redundant variable in dashboard

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/PreferencesDashboard.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/PreferencesDashboard.kt
@@ -118,8 +118,7 @@ fun PreferencesDashboard() {
                 route = Routes.QUICKSTEP
             )
         }
-
-        val context = LocalContext.current
+        
         PreferenceCategory(
             label = stringResource(R.string.about_label),
             description = "${context.getString(R.string.derived_app_name)} ${BuildConfig.MAJOR_VERSION}",


### PR DESCRIPTION
This context variable is duplication of the already defined context variable in line 50, so there's simply no reason to put it here.

## Description

Code cleanup in `PreferencesDashboard.kt`

### Testing

📱Lawnchair was verified to be working fine on Samsung M23 5G, One UI 5.1 (33) @ August Security Patch.

👋 re-testing is still recommended, in case I don't notice something

## Type of change

✅ General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
