### PR TITLE
Implement Smartspacer as an alternative At a Glance provider

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -19,9 +19,10 @@
 ** Modifications copyright 2021, Lawnchair
 */
 -->
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-sdk android:targetSdkVersion="30" android:minSdkVersion="26"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-sdk android:targetSdkVersion="30" android:minSdkVersion="26"
+        tools:overrideLibrary="com.kieronquinn.app.smartspacer.sdk.client"/>
     <!--
     Manifest entries specific to Launcher3. This is merged with AndroidManifest-common.xml.
     Refer comments around specific entries on how to extend individual components.

--- a/build.gradle
+++ b/build.gradle
@@ -380,6 +380,9 @@ dependencies {
     implementation 'com.github.samanzamani:PersianDate:1.7.1'
 
     implementation 'com.airbnb.android:lottie:6.1.0'
+
+    //Smartspacer
+    implementation 'com.kieronquinn.smartspacer:sdk-client:1.0.3'
 }
 
 ksp {

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ final def ciRunNumber = System.getenv("GITHUB_RUN_NUMBER") ?: ""
 final def isReleaseBuild = ciBuild && ciRef.contains("alpha")
 final def devReleaseName = ciBuild ? "Dev (#${ciRunNumber})" : "Dev (${buildCommit})"
 final def version = "13"
-final def releaseName = "Alpha 1"
+final def releaseName = "Alpha 4"
 final def versionDisplayName = "${version} ${isReleaseBuild ? releaseName : devReleaseName}"
 final def majorVersion = versionDisplayName.split("\\.")[0]
 

--- a/build.gradle
+++ b/build.gradle
@@ -381,7 +381,7 @@ dependencies {
 
     implementation 'com.airbnb.android:lottie:6.1.0'
 
-    //Smartspacer
+    // Smartspacer
     implementation 'com.kieronquinn.smartspacer:sdk-client:1.0.3'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -371,6 +371,9 @@ dependencies {
 
     implementation 'com.airbnb.android:lottie:6.1.0'
 
+    //Smartspacer
+    implementation 'com.kieronquinn.smartspacer:sdk-client:1.0.1'
+
     debugImplementation "com.squareup.leakcanary:leakcanary-android:2.12"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ final def ciRunNumber = System.getenv("GITHUB_RUN_NUMBER") ?: ""
 final def isReleaseBuild = ciBuild && ciRef.contains("alpha")
 final def devReleaseName = ciBuild ? "Dev (#${ciRunNumber})" : "Dev (${buildCommit})"
 final def version = "13"
-final def releaseName = "Alpha 4"
+final def releaseName = "Alpha 1"
 final def versionDisplayName = "${version} ${isReleaseBuild ? releaseName : devReleaseName}"
 final def majorVersion = versionDisplayName.split("\\.")[0]
 

--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="com.google.android.apps.nexuslauncher.permission.QSB" />
+    <uses-permission android:name="com.kieronquinn.app.smartspacer.permission.ACCESS_SMARTSPACER"/>
 
     <permission
         android:name="${packageName}.permission.READ_SETTINGS"

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -281,6 +281,7 @@
     <string name="smartspace_mode_lawnchair">Lawnchair</string>
     <string name="smartspace_mode_google">Google</string>
     <string name="smartspace_mode_google_search">Google Search</string>
+    <string name="smartspace_mode_smartspacer">Smartspacer</string>
 
     <!-- DockPreferences -->
     <!-- <string name="dock_label" /> -->

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -66,6 +66,7 @@ import com.android.launcher3.util.TouchController
 import com.android.launcher3.widget.RoundedCornerEnforcement
 import com.android.systemui.plugins.shared.LauncherOverlayManager
 import com.android.systemui.shared.system.QuickStepContract
+import com.kieronquinn.app.smartspacer.sdk.client.SmartspacerClient
 import com.patrykmichalik.opto.core.firstBlocking
 import com.patrykmichalik.opto.core.onEach
 import dev.kdrag0n.monet.theme.ColorScheme
@@ -320,6 +321,8 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
     override fun onDestroy() {
         super.onDestroy()
         lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        //Only actually closes if required, safe to call if not enabled
+        SmartspacerClient.close()
     }
 
     @Suppress("OVERRIDE_DEPRECATION")

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -321,7 +321,7 @@ class LawnchairLauncher : QuickstepLauncher(), LifecycleOwner,
     override fun onDestroy() {
         super.onDestroy()
         lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-        //Only actually closes if required, safe to call if not enabled
+        // Only actually closes if required, safe to call if not enabled
         SmartspacerClient.close()
     }
 

--- a/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceMode.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceMode.kt
@@ -1,6 +1,7 @@
 package app.lawnchair.smartspace.model
 
 import android.content.Context
+import android.os.Build
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import app.lawnchair.util.isPackageInstalledAndEnabled
@@ -15,6 +16,7 @@ sealed class SmartspaceMode(
         fun fromString(value: String): SmartspaceMode = when (value) {
             "google" -> GoogleSmartspace
             "google_search" -> GoogleSearchSmartspace
+            "smartspacer" -> Smartspacer
             else -> LawnchairSmartspace
         }
 
@@ -25,6 +27,7 @@ sealed class SmartspaceMode(
             LawnchairSmartspace,
             GoogleSmartspace,
             GoogleSearchSmartspace,
+            Smartspacer,
         )
     }
 
@@ -58,4 +61,17 @@ object GoogleSmartspace : SmartspaceMode(
 
     override fun isAvailable(context: Context): Boolean =
         context.packageManager.isPackageInstalledAndEnabled("com.google.android.googlequicksearchbox")
+}
+
+object Smartspacer : SmartspaceMode(
+    nameResourceId = R.string.smartspace_mode_smartspacer,
+    layoutResourceId = R.layout.smartspace_smartspacer,
+) {
+    override fun toString(): String = "smartspacer"
+
+    override fun isAvailable(context: Context): Boolean {
+        //Smartspacer requires Android 10+
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+            context.packageManager.isPackageInstalledAndEnabled("com.kieronquinn.app.smartspacer")
+    }
 }

--- a/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceMode.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/model/SmartspaceMode.kt
@@ -70,7 +70,7 @@ object Smartspacer : SmartspaceMode(
     override fun toString(): String = "smartspacer"
 
     override fun isAvailable(context: Context): Boolean {
-        //Smartspacer requires Android 10+
+        // Smartspacer requires Android 10+
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
             context.packageManager.isPackageInstalledAndEnabled("com.kieronquinn.app.smartspacer")
     }

--- a/proguard.pro
+++ b/proguard.pro
@@ -159,3 +159,6 @@
 -keep class com.android.** {
   *;
 }
+
+# Keep Smartspacer's client SDK
+-keep class com.kieronquinn.app.smartspacer.sdk.**  { *; }

--- a/quickstep/AndroidManifest-launcher.xml
+++ b/quickstep/AndroidManifest-launcher.xml
@@ -19,9 +19,10 @@
 ** Modifications copyright 2021, Lawnchair
 */
 -->
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-sdk android:targetSdkVersion="29" android:minSdkVersion="26"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-sdk android:targetSdkVersion="29" android:minSdkVersion="26"
+        tools:overrideLibrary="com.kieronquinn.app.smartspacer.sdk.client"/>
     <!--
     Manifest entries specific to Launcher3. This is merged with AndroidManifest-common.xml.
     Refer comments around specific entries on how to extend individual components.

--- a/quickstep/AndroidManifest-launcher.xml
+++ b/quickstep/AndroidManifest-launcher.xml
@@ -20,8 +20,12 @@
 */
 -->
 <manifest
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-sdk android:targetSdkVersion="33" android:minSdkVersion="26"/>
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-sdk android:targetSdkVersion="33" android:minSdkVersion="26"
+        tools:overrideLibrary="com.kieronquinn.app.smartspacer.sdk.client"/>
+
     <!--
     Manifest entries specific to Launcher3. This is merged with AndroidManifest-common.xml.
     Refer comments around specific entries on how to extend individual components.

--- a/res/layout/smartspace_smartspacer.xml
+++ b/res/layout/smartspace_smartspacer.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.kieronquinn.app.smartspacer.sdk.client.views.BcSmartspaceView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/bc_smartspace_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:layout_marginStart="@dimen/enhanced_smartspace_margin_start_launcher">
+
+    <androidx.viewpager.widget.ViewPager
+        android:id="@+id/smartspace_card_pager"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/enhanced_smartspace_height"
+        android:layout_marginBottom="@dimen/smartspace_page_margin_16"
+        android:layout_gravity="center" />
+
+    <com.kieronquinn.app.smartspacer.sdk.client.views.PageIndicator
+        android:id="@+id/smartspace_page_indicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|left|center_vertical|center_horizontal|center|start"
+        android:importantForAccessibility="no"
+        android:paddingStart="@dimen/page_indicator_padding_start"
+        android:paddingTop="@dimen/page_indicator_padding_top_bottom"
+        android:paddingBottom="@dimen/page_indicator_padding_top_bottom"
+        android:visibility="visible" />
+
+</com.kieronquinn.app.smartspacer.sdk.client.views.BcSmartspaceView>


### PR DESCRIPTION
## Description

This pull request integrates the Smartspacer Client SDK, following the [implementation guide](https://github.com/KieronQuinn/Smartspacer/wiki/9.-SDK:-Client-SDK-(for-Launchers)). 

As well as allowing native-quality access to Smartspacer (multiple pages, better support for many of the templates, the ability to long press pages), this would also allow Lawnchair users to access full At a Glance on Pixels, via Smartspacer.

The Smartspacer Client SDK was actually intended to be as simple to implement in Launcher3 based launchers as possible, and indeed contains code derived from Lawnchair, so that's why there's barely any code changes. The only potential issue I can see is the minSDK requirement - the SmartspaceMode `isAvailable` method does verify it's compatible, but since the library still requires a higher minSDK, `overrideLibrary` is required in the relevant manifest tags.

One thing you may wish to look at is the long press menu, which Smartspacer's Client SDK provides using the popular [Balloon library](https://github.com/skydoves/Balloon). This requires zero changes from a client perspective, but does differ from Lawnchair's styling:

![image](https://i.imgur.com/mNucKNEl.png)

If you wish to change this, the implementation guide has a section on doing so, but it would require implementation of a custom popup which can handle all the requirements.

Also, if #3559 gets implemented, Smartspacer provides a Discover Feed replacement, in the form of Expanded Smartspace. So long as the list of feeds isn't hardcoded, this should just work with no further changes.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

![image](https://i.imgur.com/QwukOfGl.png)

![image](https://i.imgur.com/a0jXl4jl.png)

![image](https://i.imgur.com/ZsDRgy8l.png)

![image](https://i.imgur.com/71mtMUKl.png)