### PR TITLE
Implement custom popup for Smartspacer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,8 +165,8 @@ android {
         debug {
             applicationIdSuffix ".debug"
             resValue("string", "derived_app_name", "Lawnchair (Debug)")
-            minifyEnabled true
-            shrinkResources true
+            minifyEnabled false
+            shrinkResources false
             proguardFiles "proguard-android-optimize.txt", "proguard.pro"
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -382,7 +382,7 @@ dependencies {
     implementation 'com.airbnb.android:lottie:6.1.0'
 
     // Smartspacer
-    implementation('com.kieronquinn.smartspacer:sdk-client:1.0.3') {
+    implementation('com.kieronquinn.smartspacer:sdk-client:1.0.4') {
         exclude group: "com.github.skydoves", module: "balloon"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -382,7 +382,9 @@ dependencies {
     implementation 'com.airbnb.android:lottie:6.1.0'
 
     // Smartspacer
-    implementation 'com.kieronquinn.smartspacer:sdk-client:1.0.3'
+    implementation('com.kieronquinn.smartspacer:sdk-client:1.0.3') {
+        exclude group: "com.github.skydoves", module: "balloon"
+    }
 }
 
 ksp {

--- a/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.graphics.Rect
 import android.graphics.RectF
 import android.util.AttributeSet
-import android.util.Log
 import android.view.View
 import app.lawnchair.launcher
 import app.lawnchair.ui.preferences.PreferenceActivity
@@ -17,6 +16,7 @@ import com.kieronquinn.app.smartspacer.sdk.client.views.BcSmartspaceView
 import com.kieronquinn.app.smartspacer.sdk.client.views.popup.Popup
 import com.kieronquinn.app.smartspacer.sdk.client.views.popup.PopupFactory
 import com.kieronquinn.app.smartspacer.sdk.model.SmartspaceTarget
+import com.kieronquinn.app.smartspacer.sdk.client.R as SmartspacerR
 
 class SmartspacerView(context: Context, attrs: AttributeSet?) : BcSmartspaceView(context, attrs) {
     init {
@@ -36,21 +36,93 @@ class SmartspacerView(context: Context, attrs: AttributeSet?) : BcSmartspaceView
                 val launcher = context.launcher
                 val pos = Rect()
                 launcher.dragLayer.getDescendantRectRelativeToSelf(anchorView, pos)
-                OptionsPopupView.show(launcher, RectF(pos), listOf(getCustomizeOption()), true)
+                val options = listOfNotNull(
+                    getAboutOption(launchIntent, aboutIntent),
+                    getCustomizeOption(launchIntent, settingsIntent),
+                    getFeedbackOption(launchIntent, feedbackIntent),
+                    getDismissOption(target, dismissAction)
+                ).ifEmpty { listOf(getCustomizeOptionFallback()) }
+                val popup = OptionsPopupView
+                    .show(launcher, RectF(pos), options, true)
                 return object : Popup {
                     override fun dismiss() {
-
+                        popup.close(true)
                     }
                 }
             }
         }
     }
 
-    private fun getCustomizeOption() = OptionsPopupView.OptionItem(
+    private fun getDismissOption(
+        target: SmartspaceTarget,
+        dismissAction: ((SmartspaceTarget) -> Unit)?
+    ): OptionsPopupView.OptionItem? {
+        if(dismissAction == null) return null
+        return OptionsPopupView.OptionItem(
+            context,
+            SmartspacerR.string.smartspace_long_press_popup_dismiss,
+            SmartspacerR.drawable.ic_smartspace_long_press_dismiss,
+            StatsLogManager.LauncherEvent.IGNORE
+        ) {
+            dismissAction.invoke(target)
+            true
+        }
+    }
+
+    private fun getAboutOption(
+        launchIntent: (Intent?) -> Unit,
+        aboutIntent: Intent?
+    ): OptionsPopupView.OptionItem? {
+        if(aboutIntent == null) return null
+        return OptionsPopupView.OptionItem(
+            context,
+            SmartspacerR.string.smartspace_long_press_popup_about,
+            SmartspacerR.drawable.ic_smartspace_long_press_about,
+            StatsLogManager.LauncherEvent.IGNORE
+        ) {
+            launchIntent(aboutIntent)
+            true
+        }
+    }
+
+    private fun getFeedbackOption(
+        launchIntent: (Intent?) -> Unit,
+        feedbackIntent: Intent?
+    ): OptionsPopupView.OptionItem? {
+        if(feedbackIntent == null) return null
+        return OptionsPopupView.OptionItem(
+            context,
+            SmartspacerR.string.smartspace_long_press_popup_feedback,
+            SmartspacerR.drawable.ic_smartspace_long_press_feedback,
+            StatsLogManager.LauncherEvent.IGNORE
+        ) {
+            launchIntent(feedbackIntent)
+            true
+        }
+    }
+
+    private fun getCustomizeOption(
+        launchIntent: (Intent?) -> Unit,
+        settingsIntent: Intent?
+    ): OptionsPopupView.OptionItem? {
+        if(settingsIntent == null) return null
+        return OptionsPopupView.OptionItem(
+            context,
+            R.string.customize_button_text,
+            R.drawable.ic_setting,
+            StatsLogManager.LauncherEvent.IGNORE
+        ) {
+            launchIntent(settingsIntent)
+            true
+        }
+    }
+
+    private fun getCustomizeOptionFallback() = OptionsPopupView.OptionItem(
         context, R.string.customize_button_text, R.drawable.ic_setting,
         StatsLogManager.LauncherEvent.IGNORE
     ) {
         context.startActivity(PreferenceActivity.createIntent(context, "/${Routes.SMARTSPACE}/"))
         true
     }
+
 }

--- a/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
@@ -1,0 +1,56 @@
+package app.lawnchair.smartspace
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Rect
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.util.Log
+import android.view.View
+import app.lawnchair.launcher
+import app.lawnchair.ui.preferences.PreferenceActivity
+import app.lawnchair.ui.preferences.Routes
+import com.android.launcher3.R
+import com.android.launcher3.logging.StatsLogManager
+import com.android.launcher3.views.OptionsPopupView
+import com.kieronquinn.app.smartspacer.sdk.client.views.BcSmartspaceView
+import com.kieronquinn.app.smartspacer.sdk.client.views.popup.Popup
+import com.kieronquinn.app.smartspacer.sdk.client.views.popup.PopupFactory
+import com.kieronquinn.app.smartspacer.sdk.model.SmartspaceTarget
+
+class SmartspacerView(context: Context, attrs: AttributeSet?) : BcSmartspaceView(context, attrs) {
+    init {
+        popupFactory = object : PopupFactory {
+            override fun createPopup(
+                context: Context,
+                anchorView: View,
+                target: SmartspaceTarget,
+                backgroundColor: Int,
+                textColour: Int,
+                launchIntent: (Intent?) -> Unit,
+                dismissAction: ((SmartspaceTarget) -> Unit)?,
+                aboutIntent: Intent?,
+                feedbackIntent: Intent?,
+                settingsIntent: Intent?
+            ): Popup {
+                val launcher = context.launcher
+                val pos = Rect()
+                launcher.dragLayer.getDescendantRectRelativeToSelf(anchorView, pos)
+                OptionsPopupView.show(launcher, RectF(pos), listOf(getCustomizeOption()), true)
+                return object : Popup {
+                    override fun dismiss() {
+
+                    }
+                }
+            }
+        }
+    }
+
+    private fun getCustomizeOption() = OptionsPopupView.OptionItem(
+        context, R.string.customize_button_text, R.drawable.ic_setting,
+        StatsLogManager.LauncherEvent.IGNORE
+    ) {
+        context.startActivity(PreferenceActivity.createIntent(context, "/${Routes.SMARTSPACE}/"))
+        true
+    }
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/SmartspacePreferences.kt
@@ -5,15 +5,23 @@ import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -26,6 +34,7 @@ import app.lawnchair.smartspace.model.LawnchairSmartspace
 import app.lawnchair.smartspace.model.SmartspaceCalendar
 import app.lawnchair.smartspace.model.SmartspaceMode
 import app.lawnchair.smartspace.model.SmartspaceTimeFormat
+import app.lawnchair.smartspace.model.Smartspacer
 import app.lawnchair.smartspace.provider.SmartspaceProvider
 import app.lawnchair.ui.preferences.components.DividerColumn
 import app.lawnchair.ui.preferences.components.ExpandAndShrink
@@ -36,6 +45,7 @@ import app.lawnchair.ui.preferences.components.PreferenceLayout
 import app.lawnchair.ui.preferences.components.SwitchPreference
 import app.lawnchair.ui.theme.isSelectedThemeDark
 import com.android.launcher3.R
+import com.kieronquinn.app.smartspacer.sdk.SmartspacerConstants
 
 fun NavGraphBuilder.smartspaceGraph(route: String) {
     preferenceGraph(route, { SmartspacePreferences(fromWidget = false) })
@@ -52,7 +62,8 @@ fun SmartspacePreferences(fromWidget: Boolean) {
     val smartspaceAdapter = preferenceManager2.enableSmartspace.getAdapter()
     val smartspaceModeAdapter = preferenceManager2.smartspaceMode.getAdapter()
     val smartspaceModeSelectionAdapter = preferenceManager2.smartspaceModeSelection.getAdapter()
-    val modeIsLawnchair = smartspaceModeAdapter.state.value == LawnchairSmartspace
+    val selectedMode = smartspaceModeAdapter.state.value
+    val modeIsLawnchair = selectedMode == LawnchairSmartspace
 
     PreferenceLayout(label = stringResource(id = R.string.smartspace_widget)) {
         if (!fromWidget) {
@@ -64,6 +75,12 @@ fun SmartspacePreferences(fromWidget: Boolean) {
                 ExpandAndShrink(visible = smartspaceAdapter.state.value && smartspaceModeSelectionAdapter.state.value) {
                     SmartspaceProviderPreference(
                         adapter = smartspaceModeAdapter,
+                        endWidget = when (selectedMode) {
+                            Smartspacer -> {
+                                { SmartspacerSettings() }
+                            }
+                            else -> null
+                        }
                     )
                 }
             }
@@ -101,6 +118,7 @@ fun SmartspacePreferences(fromWidget: Boolean) {
 @Composable
 fun SmartspaceProviderPreference(
     adapter: PreferenceAdapter<SmartspaceMode>,
+    endWidget: (@Composable () -> Unit)? = null,
 ) {
 
     val context = LocalContext.current
@@ -119,6 +137,7 @@ fun SmartspaceProviderPreference(
         adapter = adapter,
         entries = entries,
         label = stringResource(id = R.string.smartspace_mode_label),
+        endWidget = endWidget
     )
 }
 
@@ -233,3 +252,27 @@ fun SmartspaceCalendarPreference() {
     )
 }
 
+@Composable
+fun SmartspacerSettings() {
+    val context = LocalContext.current
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .clickable {
+                val intent = context.packageManager.getLaunchIntentForPackage(
+                    SmartspacerConstants.SMARTSPACER_PACKAGE_NAME
+                )
+                context.startActivity(intent)
+            }
+            .fillMaxHeight()
+            .padding(horizontal = 16.dp)
+            .size(32.dp)
+    ) {
+        Icon(
+            painter = painterResource(id = R.drawable.ic_setting),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+    }
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/ListPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/ListPreference.kt
@@ -17,6 +17,8 @@
 package app.lawnchair.ui.preferences.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.RadioButton
@@ -37,6 +39,7 @@ fun <T> ListPreference(
     label: String,
     enabled: Boolean = true,
     description: String? = null,
+    endWidget: (@Composable () -> Unit)? = null,
 ) {
     ListPreference(
         entries = entries,
@@ -45,6 +48,7 @@ fun <T> ListPreference(
         label = label,
         enabled = enabled,
         description = description,
+        endWidget = endWidget
     )
 }
 
@@ -56,6 +60,7 @@ fun <T> ListPreference(
     label: String,
     enabled: Boolean = true,
     description: String? = null,
+    endWidget: (@Composable () -> Unit)? = null,
 ) {
     val bottomSheetHandler = bottomSheetHandler
     val currentDescription = description ?: entries
@@ -63,9 +68,15 @@ fun <T> ListPreference(
         ?.label?.invoke()
 
     PreferenceTemplate(
+        contentModifier = Modifier
+            .fillMaxHeight()
+            .padding(vertical = 16.dp)
+            .padding(start = 16.dp),
         title = { Text(text = label) },
         description = { currentDescription?.let { Text(text = it) } },
         enabled = enabled,
+        endWidget = endWidget,
+        applyPaddings = false,
         modifier = Modifier.clickable(enabled) {
             bottomSheetHandler.show {
                 AlertBottomSheetContent(

--- a/res/layout/smartspace_smartspacer.xml
+++ b/res/layout/smartspace_smartspacer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.kieronquinn.app.smartspacer.sdk.client.views.BcSmartspaceView xmlns:android="http://schemas.android.com/apk/res/android"
+<app.lawnchair.smartspace.SmartspacerView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/bc_smartspace_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -24,4 +24,4 @@
         android:paddingBottom="@dimen/page_indicator_padding_top_bottom"
         android:visibility="visible" />
 
-</com.kieronquinn.app.smartspacer.sdk.client.views.BcSmartspaceView>
+</app.lawnchair.smartspace.SmartspacerView>


### PR DESCRIPTION
## Description

Replaced Smartspacer's popup with Launcher3's popup, and adda shortcut to Smartspacer settings in Smartspace preferences.

<img src="https://github.com/LawnchairLauncher/lawnchair/assets/8080853/6248ee77-1dd3-4271-9614-769d4cad737d" height="500">
<img src="https://github.com/LawnchairLauncher/lawnchair/assets/8080853/8d0808bc-9b41-4a3a-a808-cd4c45d3dfc6" height="500">

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
