### PR TITLE
Add missing Smartspacer Popup Options + fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -382,7 +382,7 @@ dependencies {
     implementation 'com.airbnb.android:lottie:6.1.0'
 
     // Smartspacer
-    implementation('com.kieronquinn.smartspacer:sdk-client:1.0.3') {
+    implementation('com.kieronquinn.smartspacer:sdk-client:1.0.4') {
         exclude group: "com.github.skydoves", module: "balloon"
     }
 }

--- a/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
@@ -37,10 +37,10 @@ class SmartspacerView(context: Context, attrs: AttributeSet?) : BcSmartspaceView
                 val pos = Rect()
                 launcher.dragLayer.getDescendantRectRelativeToSelf(anchorView, pos)
                 val options = listOfNotNull(
-                    getDismissOption(target, dismissAction),
                     getAboutOption(launchIntent, aboutIntent),
+                    getCustomizeOption(launchIntent, settingsIntent),
                     getFeedbackOption(launchIntent, feedbackIntent),
-                    getCustomizeOption(launchIntent, settingsIntent)
+                    getDismissOption(target, dismissAction)
                 ).ifEmpty { listOf(getCustomizeOptionFallback()) }
                 val popup = OptionsPopupView
                     .show(launcher, RectF(pos), options, true)

--- a/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.graphics.Rect
 import android.graphics.RectF
 import android.util.AttributeSet
-import android.util.Log
 import android.view.View
 import app.lawnchair.launcher
 import app.lawnchair.ui.preferences.PreferenceActivity
@@ -17,6 +16,7 @@ import com.kieronquinn.app.smartspacer.sdk.client.views.BcSmartspaceView
 import com.kieronquinn.app.smartspacer.sdk.client.views.popup.Popup
 import com.kieronquinn.app.smartspacer.sdk.client.views.popup.PopupFactory
 import com.kieronquinn.app.smartspacer.sdk.model.SmartspaceTarget
+import com.kieronquinn.app.smartspacer.sdk.client.R as SmartspacerR
 
 class SmartspacerView(context: Context, attrs: AttributeSet?) : BcSmartspaceView(context, attrs) {
     init {
@@ -36,21 +36,93 @@ class SmartspacerView(context: Context, attrs: AttributeSet?) : BcSmartspaceView
                 val launcher = context.launcher
                 val pos = Rect()
                 launcher.dragLayer.getDescendantRectRelativeToSelf(anchorView, pos)
-                OptionsPopupView.show(launcher, RectF(pos), listOf(getCustomizeOption()), true)
+                val options = listOfNotNull(
+                    getDismissOption(target, dismissAction),
+                    getAboutOption(launchIntent, aboutIntent),
+                    getFeedbackOption(launchIntent, feedbackIntent),
+                    getCustomizeOption(launchIntent, settingsIntent)
+                ).ifEmpty { listOf(getCustomizeOptionFallback()) }
+                val popup = OptionsPopupView
+                    .show(launcher, RectF(pos), options, true)
                 return object : Popup {
                     override fun dismiss() {
-
+                        popup.close(true)
                     }
                 }
             }
         }
     }
 
-    private fun getCustomizeOption() = OptionsPopupView.OptionItem(
+    private fun getDismissOption(
+        target: SmartspaceTarget,
+        dismissAction: ((SmartspaceTarget) -> Unit)?
+    ): OptionsPopupView.OptionItem? {
+        if(dismissAction == null) return null
+        return OptionsPopupView.OptionItem(
+            context,
+            SmartspacerR.string.smartspace_long_press_popup_dismiss,
+            SmartspacerR.drawable.ic_smartspace_long_press_dismiss,
+            StatsLogManager.LauncherEvent.IGNORE
+        ) {
+            dismissAction.invoke(target)
+            true
+        }
+    }
+
+    private fun getAboutOption(
+        launchIntent: (Intent?) -> Unit,
+        aboutIntent: Intent?
+    ): OptionsPopupView.OptionItem? {
+        if(aboutIntent == null) return null
+        return OptionsPopupView.OptionItem(
+            context,
+            SmartspacerR.string.smartspace_long_press_popup_about,
+            SmartspacerR.drawable.ic_smartspace_long_press_about,
+            StatsLogManager.LauncherEvent.IGNORE
+        ) {
+            launchIntent(aboutIntent)
+            true
+        }
+    }
+
+    private fun getFeedbackOption(
+        launchIntent: (Intent?) -> Unit,
+        feedbackIntent: Intent?
+    ): OptionsPopupView.OptionItem? {
+        if(feedbackIntent == null) return null
+        return OptionsPopupView.OptionItem(
+            context,
+            SmartspacerR.string.smartspace_long_press_popup_feedback,
+            SmartspacerR.drawable.ic_smartspace_long_press_feedback,
+            StatsLogManager.LauncherEvent.IGNORE
+        ) {
+            launchIntent(feedbackIntent)
+            true
+        }
+    }
+
+    private fun getCustomizeOption(
+        launchIntent: (Intent?) -> Unit,
+        settingsIntent: Intent?
+    ): OptionsPopupView.OptionItem? {
+        if(settingsIntent == null) return null
+        return OptionsPopupView.OptionItem(
+            context,
+            R.string.customize_button_text,
+            R.drawable.ic_setting,
+            StatsLogManager.LauncherEvent.IGNORE
+        ) {
+            launchIntent(settingsIntent)
+            true
+        }
+    }
+
+    private fun getCustomizeOptionFallback() = OptionsPopupView.OptionItem(
         context, R.string.customize_button_text, R.drawable.ic_setting,
         StatsLogManager.LauncherEvent.IGNORE
     ) {
         context.startActivity(PreferenceActivity.createIntent(context, "/${Routes.SMARTSPACE}/"))
         true
     }
+
 }


### PR DESCRIPTION
## Description

- Update Smartspacer client SDK to 1.0.4 (contains fixes for popup handling)
- Added options for dismiss, about & feedback, make them all optional and use the provided `launchIntent` method as it provides a fallback for invalid intents
- Use original Customise option as fallback if provided options are empty

Updates #3716 

## Type of change

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
