### PR TITLE
Fix sectionName order for Simplified Chinese

### DIFF
--- a/src/com/android/launcher3/allapps/AppInfoComparator.java
+++ b/src/com/android/launcher3/allapps/AppInfoComparator.java
@@ -47,6 +47,10 @@ public class AppInfoComparator implements Comparator<AppInfo> {
         int result = mLabelComparator.compare(
                 a.title == null ? "" : a.title.toString(),
                 b.title == null ? "" : b.title.toString());
+        // Group app list by sectionName before sorting for Simplified Chinese only
+        if (isSimpledChineseLocale()) {
+            result += a.sectionName.compareTo(b.sectionName) * 10;
+        }
         if (result != 0) {
             return result;
         }


### PR DESCRIPTION
## Description

This sort had been finished in #3125 but broken by A13 merging.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
