### PR TITLE
Fix settings icon in OptionsPopupView

### DIFF
--- a/src/com/android/launcher3/views/OptionsPopupView.java
+++ b/src/com/android/launcher3/views/OptionsPopupView.java
@@ -229,7 +229,7 @@ public class OptionsPopupView extends ArrowPopup<Launcher>
         }
         options.add(new OptionItem(launcher,
                 R.string.settings_button_text,
-                R.drawable.ic_setting,
+                R.drawable.ic_home_screen,
                 LAUNCHER_SETTINGS_BUTTON_TAP_OR_LONGPRESS,
                 OptionsPopupView::startSettings));
         return options;


### PR DESCRIPTION
## Description

This icon had been changed in #3295 but broken by A13 merging.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
