### PR TITLE
Add unsafeLazy to simplify thread unsafe lazy initializations

### DIFF
--- a/lawnchair/src/app/lawnchair/BlankActivity.kt
+++ b/lawnchair/src/app/lawnchair/BlankActivity.kt
@@ -23,12 +23,13 @@ import androidx.core.os.bundleOf
 import androidx.core.view.WindowCompat
 import app.lawnchair.ui.preferences.components.SystemUi
 import app.lawnchair.ui.theme.LawnchairTheme
+import app.lawnchair.util.unsafeLazy
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 
 class BlankActivity : AppCompatActivity() {
 
-    private val resultReceiver by lazy { intent.getParcelableExtra<ResultReceiver>("callback")!! }
+    private val resultReceiver by unsafeLazy { intent.getParcelableExtra<ResultReceiver>("callback")!! }
     private var resultSent = false
     private var firstResume = true
     private var targetStarted = false

--- a/lawnchair/src/app/lawnchair/LawnchairApp.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairApp.kt
@@ -41,6 +41,7 @@ import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.ui.AlertBottomSheetContent
 import app.lawnchair.ui.preferences.openAppInfo
 import app.lawnchair.util.restartLauncher
+import app.lawnchair.util.unsafeLazy
 import app.lawnchair.views.ComposeBottomSheet
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.InvariantDeviceProfile
@@ -53,11 +54,11 @@ import java.io.File
 
 class LawnchairApp : Application() {
     private val compatible = Build.VERSION.SDK_INT in BuildConfig.QUICKSTEP_MIN_SDK..BuildConfig.QUICKSTEP_MAX_SDK
-    private val isRecentsComponent: Boolean by lazy { checkRecentsComponent() }
+    private val isRecentsComponent: Boolean by unsafeLazy { checkRecentsComponent() }
     private val recentsEnabled: Boolean get() = compatible && isRecentsComponent
     private val isAtleastT = Utilities.ATLEAST_T
     internal var accessibilityService: LawnchairAccessibilityService? = null
-    val isVibrateOnIconAnimation: Boolean by lazy { getSystemUiBoolean("config_vibrateOnIconAnimation", false) }
+    val isVibrateOnIconAnimation: Boolean by unsafeLazy { getSystemUiBoolean("config_vibrateOnIconAnimation", false) }
 
     override fun onCreate() {
         super.onCreate()

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -59,6 +59,7 @@ import app.lawnchair.search.LawnchairSearchAdapterProvider
 import app.lawnchair.theme.ThemeProvider
 import app.lawnchair.ui.popup.LawnchairShortcut
 import app.lawnchair.util.getThemedIconPacksInstalled
+import app.lawnchair.util.unsafeLazy
 import com.android.launcher3.BaseActivity
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.LauncherRootView
@@ -95,11 +96,11 @@ class LawnchairLauncher :
     OnBackPressedDispatcherOwner {
 
     private val savedStateRegistryController = SavedStateRegistryController.create(this)
-    private val defaultOverlay by lazy { OverlayCallbackImpl(this) }
-    private val prefs by lazy { PreferenceManager.getInstance(this) }
-    private val preferenceManager2 by lazy { PreferenceManager2.getInstance(this) }
-    private val insetsController by lazy { WindowInsetsControllerCompat(launcher.window, rootView) }
-    private val themeProvider by lazy { ThemeProvider.INSTANCE.get(this) }
+    private val defaultOverlay by unsafeLazy { OverlayCallbackImpl(this) }
+    private val prefs by unsafeLazy { PreferenceManager.getInstance(this) }
+    private val preferenceManager2 by unsafeLazy { PreferenceManager2.getInstance(this) }
+    private val insetsController by unsafeLazy { WindowInsetsControllerCompat(launcher.window, rootView) }
+    private val themeProvider by unsafeLazy { ThemeProvider.INSTANCE.get(this) }
     private val noStatusBarStateListener = object : StateManager.StateListener<LauncherState> {
         override fun onStateTransitionStart(toState: LauncherState) {
             if (toState is OverviewState) {
@@ -115,7 +116,7 @@ class LawnchairLauncher :
     private lateinit var colorScheme: ColorScheme
     private var hasBackGesture = false
 
-    val gestureController by lazy { GestureController(this) }
+    val gestureController by unsafeLazy { GestureController(this) }
 
     override val savedStateRegistry: SavedStateRegistry = savedStateRegistryController.savedStateRegistry
     override val activityResultRegistry = object : ActivityResultRegistry() {

--- a/lawnchair/src/app/lawnchair/nexuslauncher/SmartSpaceHostView.kt
+++ b/lawnchair/src/app/lawnchair/nexuslauncher/SmartSpaceHostView.kt
@@ -10,6 +10,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnLongClickListener
 import android.view.ViewGroup
+import app.lawnchair.util.unsafeLazy
 import com.android.launcher3.CheckLongPressHelper
 import com.android.launcher3.Launcher
 import com.android.launcher3.R
@@ -20,7 +21,7 @@ import com.android.launcher3.views.OptionsPopupView
 import com.android.launcher3.views.OptionsPopupView.OptionItem
 
 open class SmartSpaceHostView(context: Context) : QsbWidgetHostView(context), OnLongClickListener, TouchCompleteListener {
-    private val mLauncher: Launcher by lazy { Launcher.getLauncher(context) }
+    private val mLauncher: Launcher by unsafeLazy { Launcher.getLauncher(context) }
 
     @Suppress("LeakingThis")
     private val mLongPressHelper: CheckLongPressHelper = CheckLongPressHelper(this, this)

--- a/lawnchair/src/app/lawnchair/util/Core.kt
+++ b/lawnchair/src/app/lawnchair/util/Core.kt
@@ -4,3 +4,7 @@ import android.content.Context
 import androidx.core.content.getSystemService
 
 inline fun <reified T : Any> Context.requireSystemService(): T = checkNotNull(getSystemService())
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <T : Any> unsafeLazy(noinline initializer: () -> T): Lazy<T> =
+    lazy(LazyThreadSafetyMode.NONE, initializer)


### PR DESCRIPTION
## Description

These fields are initialized on main thread, no need to use default `lazy`.


## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
