### PR TITLE
Catch RemoteAnimationTarget.rotationChange

### DIFF
--- a/quickstep/src/com/android/launcher3/QuickstepTransitionManager.java
+++ b/quickstep/src/com/android/launcher3/QuickstepTransitionManager.java
@@ -1273,8 +1273,11 @@ public class QuickstepTransitionManager implements OnDeviceProfileChangeListener
     private static int getRotationChange(RemoteAnimationTarget[] appTargets) {
         int rotationChange = 0;
         for (RemoteAnimationTarget target : appTargets) {
-            if (Math.abs(target.rotationChange) > Math.abs(rotationChange)) {
-                rotationChange = target.rotationChange;
+            try {
+                if (Math.abs(target.rotationChange) > Math.abs(rotationChange)) {
+                    rotationChange = target.rotationChange;
+                }
+            } catch (NoSuchFieldError ignored) {
             }
         }
         return rotationChange;

--- a/quickstep/src/com/android/quickstep/AbsSwipeUpHandler.java
+++ b/quickstep/src/com/android/quickstep/AbsSwipeUpHandler.java
@@ -1576,12 +1576,16 @@ public abstract class AbsSwipeUpHandler<T extends StatefulActivity<S>, Q extends
 
     private int calculateWindowRotation(RemoteAnimationTarget runningTaskTarget,
                                         RecentsOrientedState orientationState) {
-        if (runningTaskTarget.rotationChange != 0
+        try {
+            if (runningTaskTarget.rotationChange != 0
                 && TaskAnimationManager.ENABLE_SHELL_TRANSITIONS) {
-            return Math.abs(runningTaskTarget.rotationChange) == ROTATION_90
+                return Math.abs(runningTaskTarget.rotationChange) == ROTATION_90
                     ? ROTATION_270
                     : ROTATION_90;
-        } else {
+            } else {
+                return orientationState.getDisplayRotation();
+            }
+        } catch (NoSuchFieldError ignored) {
             return orientationState.getDisplayRotation();
         }
     }


### PR DESCRIPTION
## Description

- Closes #3733.
- Closes #3775.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
