### PR TITLE
Fix crash on One UI Android 11

### DIFF
--- a/lawnchair/res/layout-v30/task_desktop.xml
+++ b/lawnchair/res/layout-v30/task_desktop.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2022 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<com.android.quickstep.views.DesktopTaskView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipChildren="true"
+    android:clipToOutline="true"
+    android:defaultFocusHighlightEnabled="false"
+    android:focusable="true">
+
+    <View
+        android:id="@+id/background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <!--
+         TODO(b249371338): DesktopTaskView extends from TaskView. TaskView expects TaskThumbnailView
+         and IconView with these ids to be present. Need to refactor RecentsView to accept child
+         views that do not inherint from TaskView only or create a generic TaskView that have
+         N number of tasks.
+     -->
+    <com.android.quickstep.views.TaskThumbnailView
+        android:id="@+id/snapshot"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
+
+    <com.android.quickstep.views.IconView
+        android:id="@+id/icon"
+        android:layout_width="@dimen/task_thumbnail_icon_size"
+        android:layout_height="@dimen/task_thumbnail_icon_size"
+        android:focusable="false"
+        android:importantForAccessibility="no" />
+
+</com.android.quickstep.views.DesktopTaskView>


### PR DESCRIPTION
android.view.InflateException: Binary XML file line #27 in app.lawnchair.debug:layout/task_desktop: Resource

What's causing the crash : [https://i.imgur.com/TUBiLxi.png](https://i.imgur.com/TUBiLxi.png) the patched, since it's using android 11 instead of modifying the legacy layout we created and added one in layout-v30 without `launcher:borderColor="?attr/colorAccentPrimary"`

## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->


Fixes #3787

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
