### PR TITLE
Another fixed

### DIFF
--- a/lawnchair/res/layout-v30/task_desktop.xml
+++ b/lawnchair/res/layout-v30/task_desktop.xml
@@ -21,8 +21,7 @@
     android:layout_height="match_parent"
     android:clipChildren="true"
     android:clipToOutline="true"
-    android:defaultFocusHighlightEnabled="false"
-    android:focusable="true">
+    android:defaultFocusHighlightEnabled="false">
 
     <View
         android:id="@+id/background"

--- a/lawnchair/res/layout-v30/task_desktop.xml
+++ b/lawnchair/res/layout-v30/task_desktop.xml
@@ -21,7 +21,8 @@
     android:layout_height="match_parent"
     android:clipChildren="true"
     android:clipToOutline="true"
-    android:defaultFocusHighlightEnabled="false">
+    android:defaultFocusHighlightEnabled="false"
+    android:focusable="true">
 
     <View
         android:id="@+id/background"

--- a/lawnchair/res/layout-v30/task_desktop.xml
+++ b/lawnchair/res/layout-v30/task_desktop.xml
@@ -18,10 +18,7 @@
 <com.android.quickstep.views.DesktopTaskView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:clipChildren="true"
-    android:clipToOutline="true"
-    android:defaultFocusHighlightEnabled="false">
+    android:layout_height="match_parent">
 
     <View
         android:id="@+id/background"

--- a/lawnchair/res/layout-v30/task_desktop.xml
+++ b/lawnchair/res/layout-v30/task_desktop.xml
@@ -18,7 +18,10 @@
 <com.android.quickstep.views.DesktopTaskView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:clipChildren="true"
+    android:clipToOutline="true"
+    android:defaultFocusHighlightEnabled="false">
 
     <View
         android:id="@+id/background"

--- a/quickstep/src/com/android/quickstep/views/DesktopTaskView.java
+++ b/quickstep/src/com/android/quickstep/views/DesktopTaskView.java
@@ -121,7 +121,7 @@ public class DesktopTaskView extends TaskView {
         Arrays.fill(outerRadii, getTaskCornerRadius());
         RoundRectShape shape = new RoundRectShape(outerRadii, null, null);
         ShapeDrawable background = new ShapeDrawable(shape);
-        background.setTint(getResources().getColor(android.R.color.system_neutral2_300,
+        background.setTint(getResources().getColor(Utilities.ATLEAST_S ? android.R.color.system_neutral2_300 : android.R.color.transparent,
                 getContext().getTheme()));
         // TODO(b/244348395): this should be wallpaper
         mBackgroundView.setBackground(background);


### PR DESCRIPTION
## Description

```
Lawnchair (Debug) bug report 01-Dec-2023 3:00:50 pm
version: 13 Dev (#2467) (13)
commit: 0984af2
build.brand: samsung
build.device: m30s
build.display: RP1A.200720.012.M307FXXS4CWC2
build.fingerprint: samsung/m30sdd/m30s:11/RP1A.200720.012/M307FXXS4CWC2:user/release-keys
build.hardware: exynos9611
build.id: RP1A.200720.012
build.manufacturer: samsung
build.model: SM-M307F
build.security.level: 2023-04-01
build.product: m30sdd
build.type: user
version.codename: REL
version.incremental: M307FXXS4CWC2
version.release: 11
version.sdk_int: 30
display.density_dpi: 420
isRecentsEnabled: false

error: Uncaught exception

android.view.InflateException: Binary XML file line #25 in app.lawnchair.debug:layout/task_desktop: Resource ID #0x106002f
Caused by: android.content.res.Resources$NotFoundException: Resource ID #0x106002f
	at android.content.res.ResourcesImpl.getValue(ResourcesImpl.java:255)
	at android.content.res.Resources.getColor(Resources.java:1169)
	at com.android.quickstep.views.DesktopTaskView.onFinishInflate(DesktopTaskView.java:124)
	at android.view.LayoutInflater.rInflate(LayoutInflater.java:1134)
	at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:1082)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:680)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:532)
	at com.android.launcher3.util.ViewPool.inflateNewView(ViewPool.java:106)
	at com.android.launcher3.util.ViewPool.lambda$initPool$1(ViewPool.java:69)
	at com.android.launcher3.util.ViewPool.$r8$lambda$wSRnQcMZiOmM7xwf4gm88rNehhg(Unknown Source:0)
	at com.android.launcher3.util.ViewPool$$ExternalSyntheticLambda1.run(Unknown Source:8)
	at java.lang.Thread.run(Thread.java:923)
```
## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
