### PR TITLE
Fix Crash on A9 - LC14

### DIFF
--- a/quickstep/src/com/android/launcher3/uioverrides/ApiWrapper.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/ApiWrapper.java
@@ -51,7 +51,7 @@ public class ApiWrapper {
     }
 
     public static Map<String, LauncherActivityInfo> getActivityOverrides(Context context) {
-        return LawnchairUtilsKt.isDefaultLauncher(context) ?
+        return LawnchairUtilsKt.isDefaultLauncher(context) && Utilities.ATLEAST_Q ?
                 context.getSystemService(LauncherApps.class).getActivityOverrides()
                 : Collections.emptyMap();
     }

--- a/quickstep/src/com/android/quickstep/RecentsAnimationDeviceState.java
+++ b/quickstep/src/com/android/quickstep/RecentsAnimationDeviceState.java
@@ -143,20 +143,22 @@ public class RecentsAnimationDeviceState implements DisplayInfoChangeListener {
             runOnDestroy(mRotationTouchHelper::destroy);
         }
 
-        // Register for exclusion updates
-        mExclusionListener = new SystemGestureExclusionListenerCompat(mDisplayId) {
-            @Override
-            @BinderThread
-            public void onExclusionChanged(Region region) {
-                if (region == null) {
-                    // Don't think this is possible but just in case, don't let it be null.
-                    region = new Region();
+        if (Utilities.ATLEAST_Q) {
+            // Register for exclusion updates
+            mExclusionListener = new SystemGestureExclusionListenerCompat(mDisplayId) {
+                @Override
+                @BinderThread
+                public void onExclusionChanged(Region region) {
+                    if (region == null) {
+                        // Don't think this is possible but just in case, don't let it be null.
+                        region = new Region();
+                    }
+                    // Assignments are atomic, it should be safe on binder thread
+                    mExclusionRegion = region;
                 }
-            }
-
-        };
-
-        runOnDestroy (()-> mExclusionListener.unregister());
+            };
+            runOnDestroy(mExclusionListener::unregister);
+        }
 
         // Register for display changes changes
         mDisplayController.addChangeListener(this);

--- a/src/com/android/launcher3/MotionEventsUtils.java
+++ b/src/com/android/launcher3/MotionEventsUtils.java
@@ -41,8 +41,10 @@ public class MotionEventsUtils {
 
     @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     public static boolean isTrackpadMultiFingerSwipe(MotionEvent event) {
-        return ENABLE_TRACKPAD_GESTURE.get()
-                && event.getClassification() == CLASSIFICATION_MULTI_FINGER_SWIPE;
+        return (Utilities.ATLEAST_U)
+                ? ENABLE_TRACKPAD_GESTURE.get()
+                && event.getClassification() == CLASSIFICATION_MULTI_FINGER_SWIPE
+                : false;
     }
 
     public static boolean isTrackpadThreeFingerSwipe(MotionEvent event) {
@@ -56,6 +58,8 @@ public class MotionEventsUtils {
     }
 
     public static boolean isTrackpadMotionEvent(MotionEvent event) {
-        return isTrackpadScroll(event) || isTrackpadMultiFingerSwipe(event);
+         return (Utilities.ATLEAST_U)
+                ? isTrackpadScroll(event) || isTrackpadMultiFingerSwipe(event)
+                : false;
     }
 }

--- a/src/com/android/launcher3/util/VibratorWrapper.java
+++ b/src/com/android/launcher3/util/VibratorWrapper.java
@@ -138,7 +138,7 @@ public class VibratorWrapper {
                     .compose();
         } else {
             // fallback for devices without composition support
-            mAssistEffect = VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK);
+            mAssistEffect = Utilities.ATLEAST_Q ? VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK) : null;
         }
     }
 


### PR DESCRIPTION
* Update VibratorWrapper.java

* Update RecentsAnimationDeviceState.java

* Update MotionEventsUtils.java

## Description

<!--  This PR fixes all crashes identified in Android 9 after updating to LC 14-->

## Type of change

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
