### PR TITLE
Bring back allapps bulk icon loading make it toggleable

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -326,6 +326,9 @@
     <string name="show_enable_smart_hide">Show when Full Name is Typed</string>
     <string name="hide_hidden_apps_search">Hide in Search Results</string>
 
+    <string name="pref_all_apps_bulk_icon_loading_title">Bulk loading</string>
+    <string name="pref_all_apps_bulk_icon_loading_description">Enable loading all apps icons in bulk</string>
+
     <string name="pref_category_search">Search</string>
       <string name="show_app_search_bar">Show Search Bar</string>
       <string name="pref_search_auto_show_keyboard">Automatically Show Keyboard</string>

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
@@ -84,6 +84,8 @@ class PreferenceManager private constructor(private val context: Context) : Base
     val searchResultSettingsEntry = BoolPref("pref_searchResultSettingsEntry", false, recreate)
     val searchResulRecentSuggestion = BoolPref("pref_searchResultRecentSuggestion", false, recreate)
 
+    val allAppBulkIconLoading = BoolPref("pref_allapps_bulk_icon_loading", false, recreate)
+
     val themedIcons = BoolPref("themed_icons", true, recreate)
     val drawerThemedIcons = BoolPref("drawer_themed_icons", false, recreate)
     val hotseatQsbCornerRadius = FloatPref("pref_hotseatQsbCornerRadius", 1F, recreate)

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/AppDrawerPreferences.kt
@@ -66,6 +66,11 @@ fun AppDrawerPreferences() {
                 valueRange = 0F..1F,
                 showAsPercentage = true,
             )
+            SwitchPreference(
+                label = stringResource(id = R.string.pref_all_apps_bulk_icon_loading_title),
+                description = stringResource(id = R.string.pref_all_apps_bulk_icon_loading_description),
+                adapter = prefs.allAppBulkIconLoading.getAdapter(),
+            )
             SuggestionsPreference()
         }
 


### PR DESCRIPTION
## Description

Bring back allapps bulk icon loading option since making it default causing all apps disorder list in some oem

Fixes #3872

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
 :white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
