### PR TITLE
Fix work mode switch inflation

### DIFF
--- a/quickstep/res/values-night/colors.xml
+++ b/quickstep/res/values-night/colors.xml
@@ -27,5 +27,5 @@
     <!-- Turn on work apps button -->
     <color name="work_turn_on_stroke">?attr/colorAccentPrimary</color>
     <color name="work_fab_bg_color">?attr/materialColorPrimaryFixedDim</color>
-    <color name="work_fab_icon_color">?attr/materialColorOnPrimaryFixed</color>
+    <color name="work_fab_icon_color">@color/material_color_on_primary_fixed</color>
 </resources>

--- a/quickstep/res/values/colors.xml
+++ b/quickstep/res/values/colors.xml
@@ -95,5 +95,5 @@
     <!-- Turn on work apps button -->
     <color name="work_turn_on_stroke">?attr/colorAccentPrimary</color>
     <color name="work_fab_bg_color">?attr/materialColorPrimaryFixedDim</color>
-    <color name="work_fab_icon_color">?attr/materialColorOnPrimaryFixed</color>
+    <color name="work_fab_icon_color">@color/material_color_on_primary_fixed</color>
 </resources>

--- a/src/com/android/launcher3/allapps/WorkProfileManager.java
+++ b/src/com/android/launcher3/allapps/WorkProfileManager.java
@@ -166,8 +166,7 @@ public class WorkProfileManager implements PersonalWorkSlidingTabStrip.OnActiveP
      */
     public boolean attachWorkModeSwitch() {
         if (!mAllApps.getAppsStore().hasModelFlag(
-                FLAG_HAS_SHORTCUT_PERMISSION | FLAG_QUIET_MODE_CHANGE_PERMISSION)
-            || !Utilities.ATLEAST_Q) {
+                FLAG_HAS_SHORTCUT_PERMISSION | FLAG_QUIET_MODE_CHANGE_PERMISSION)) {
             Log.e(TAG, "unable to attach work mode switch; Missing required permissions");
             return false;
         }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

#3876 fixed #3873 by disabling the work mode switch. This means users won't be able to toggle work mode.
This PR reverts that change, and fixes the inflation of the work mode switch.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
