### PR TITLE
Add warning to Recents settings when user doesn't set LC as the Recent provider

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -400,7 +400,9 @@
     <!-- QuickstepPreferences -->
     <!-- <string name="quickstep_label" /> -->
     <!-- <string name="general_label" /> -->
-      <string name="translucent_background">Translucent Background</string>
+    <string name="quickswitch_ignored_warning">Lawnchair isn\'t set as Recent provider, this settings will be ignored by Lawnchair</string>
+
+    <string name="translucent_background">Translucent Background</string>
 
     <string name="recents_actions_label">Quick Actions</string>
       <!-- <string name="screenshot" /> (unknown source) -->

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -400,7 +400,7 @@
     <!-- QuickstepPreferences -->
     <!-- <string name="quickstep_label" /> -->
     <!-- <string name="general_label" /> -->
-    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair is not set as Recent provider.</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair is not set as the Recents provider.</string>
 
     <string name="translucent_background">Translucent Background</string>
 

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -400,7 +400,7 @@
     <!-- QuickstepPreferences -->
     <!-- <string name="quickstep_label" /> -->
     <!-- <string name="general_label" /> -->
-    <string name="quickswitch_ignored_warning">Lawnchair isn\'t set as Recent provider, this settings will be ignored by Lawnchair</string>
+    <string name="quickswitch_ignored_warning">These settings will be ignored as Lawnchair is not set as Recent provider.</string>
 
     <string name="translucent_background">Translucent Background</string>
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/QuickstepPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/QuickstepPreferences.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
+import app.lawnchair.LawnchairApp
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.observeAsState
 import app.lawnchair.preferences.preferenceManager
@@ -23,7 +24,6 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.preferenceGraph
 import app.lawnchair.util.isOnePlusStock
-import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
 
@@ -40,7 +40,7 @@ fun QuickstepPreferences() {
         context.packageManager.getLaunchIntentForPackage("com.google.ar.lens") != null
     }
 
-    if (BuildConfig.DEBUG) SettingsIsIgnoreWarning()
+    if (!LawnchairApp.isRecentsEnabled) QuickSwitchIgnoredWarning()
 
     PreferenceLayout(label = stringResource(id = R.string.quickstep_label)) {
         PreferenceGroup(heading = stringResource(id = R.string.general_label)) {
@@ -105,14 +105,15 @@ fun QuickstepPreferences() {
 }
 
 @Composable
-fun SettingsIsIgnoreWarning() {
+fun QuickSwitchIgnoredWarning() {
     Surface(
         modifier = Modifier.padding(horizontal = 16.dp),
         shape = MaterialTheme.shapes.large,
         color = androidx.compose.material3.MaterialTheme.colorScheme.errorContainer,
     ) {
         WarningPreference(
-            text = "You are currently using a development build, this settings will be ignored by Lawnchair"
+
+            text = stringResource(id = R.string.quickswitch_ignored_warning),
         )
     }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/QuickstepPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/QuickstepPreferences.kt
@@ -112,7 +112,6 @@ fun QuickSwitchIgnoredWarning() {
         color = androidx.compose.material3.MaterialTheme.colorScheme.errorContainer,
     ) {
         WarningPreference(
-
             text = stringResource(id = R.string.quickswitch_ignored_warning),
         )
     }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/QuickstepPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/QuickstepPreferences.kt
@@ -1,10 +1,15 @@
 package app.lawnchair.ui.preferences.destinations
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.observeAsState
@@ -12,11 +17,13 @@ import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.preferences.components.controls.SliderPreference
 import app.lawnchair.ui.preferences.components.controls.SwitchPreference
+import app.lawnchair.ui.preferences.components.controls.WarningPreference
 import app.lawnchair.ui.preferences.components.layout.ExpandAndShrink
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.preferenceGraph
 import app.lawnchair.util.isOnePlusStock
+import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
 
@@ -32,6 +39,8 @@ fun QuickstepPreferences() {
     val lensAvailable = remember {
         context.packageManager.getLaunchIntentForPackage("com.google.ar.lens") != null
     }
+
+    if (BuildConfig.DEBUG) SettingsIsIgnoreWarning()
 
     PreferenceLayout(label = stringResource(id = R.string.quickstep_label)) {
         PreferenceGroup(heading = stringResource(id = R.string.general_label)) {
@@ -92,5 +101,18 @@ fun QuickstepPreferences() {
                 )
             }
         }
+    }
+}
+
+@Composable
+fun SettingsIsIgnoreWarning() {
+    Surface(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        shape = MaterialTheme.shapes.large,
+        color = androidx.compose.material3.MaterialTheme.colorScheme.errorContainer,
+    ) {
+        WarningPreference(
+            text = "You are currently using a development build, this settings will be ignored by Lawnchair"
+        )
     }
 }


### PR DESCRIPTION
## Description

Clarify why Recent settings do nothing when Lawnchair isn't set as a Recent provider.

* close: #3884

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
✅ New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
