### PR TITLE
Secure Gradle wrapper

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=9d926787066a081739e8200858338b4a69e837c3a821a33aca9db09dd4a41026
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
## Description

Since we already have Renovate Bot automatically updating the Gradle Wrapper, I've seen a reason why not to secure the Gradle Wrapper used in building Lawnchair, it unrelated but, this also fixes one of the f-droid security issues to secure Gradle if you're planning to release it.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

✅ General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
