### PR TITLE
Don't handle shortcuts dropping after home screen locked

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,10 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.java]
+# Don't trim spaces in AOSP code.
+trim_trailing_whitespace = false
+
 [*.{kt,kts}]
 ij_kotlin_imports_layout = *
 ij_kotlin_allow_trailing_comma = true

--- a/src/com/android/launcher3/popup/PopupContainerWithArrow.java
+++ b/src/com/android/launcher3/popup/PopupContainerWithArrow.java
@@ -824,6 +824,8 @@ public class PopupContainerWithArrow<T extends Context & ActivityContext>
                     mContainer, itemInfo,
                     new ShortcutDragPreviewProvider(sv.getIconView(), iconShift),
                     new DragOptions());
+            // Don't handle shortcuts dropping after home screen locked.
+            if (dv == null) return false;
             dv.animateShift(-iconShift.x, -iconShift.y);
 
             // TODO: support dragging from within folder without having to close it


### PR DESCRIPTION
## Description

Fix crashing:
```
Process: ch.deletescape.lawnchair.plah, PID: 26755
java.lang.NullPointerException: Attempt to invoke virtual method 'void com.android.launcher3.dragndrop.DragView.animateShift(int, int)' on a null object reference
    at com.android.launcher3.popup.PopupContainerWithArrow$LauncherPopupItemDragHandler.onLongClick(PopupContainerWithArrow.java:827)
    at android.view.View.performLongClickInternal(View.java:7586)
    at android.view.View.performLongClick(View.java:7544)
    at android.widget.TextView.performLongClick(TextView.java:12974)
    at android.view.View.performLongClick(View.java:7562)
    at android.view.View$CheckForLongPress.run(View.java:29292)
    at android.os.Handler.handleCallback(Handler.java:942)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:201)
    at android.os.Looper.loop(Looper.java:288)
    at android.app.ActivityThread.main(ActivityThread.java:7872)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

https://github.com/LawnchairLauncher/lawnchair/assets/10363352/996eb24d-6610-49c3-84b1-614910b4e9a2



Fixes #(issue) <!-- optional -->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
