### PR TITLE
Introducing Task Lock in Overview

### DIFF
--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -28,6 +28,9 @@
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_HISTORY_BOOKMARKS" />
     <uses-permission android:name="android.permission.WRITE_HISTORY_BOOKMARKS" />
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS"/>
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL"/>
+    <uses-permission android:name="android.permission.MANAGE_USERS"/>
 
 
     <permission

--- a/lawnchair/res/drawable/ic_locked_recents.xml
+++ b/lawnchair/res/drawable/ic_locked_recents.xml
@@ -1,0 +1,26 @@
+<!--
+     Copyright (C) 2019 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?android:attr/textColorPrimary"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1s3.1,1.39 3.1,3.1v2L8.9,8L8.9,6zM18,20L6,20L6,10h12v10z"/>
+</vector>

--- a/lawnchair/res/drawable/ic_unlocked_recents.xml
+++ b/lawnchair/res/drawable/ic_unlocked_recents.xml
@@ -1,0 +1,26 @@
+<!--
+     Copyright (C) 2019 The LineageOS Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?android:attr/textColorPrimary"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h1.9c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM18,20L6,20L6,10h12v10z"/>
+</vector>

--- a/lawnchair/res/layout/overview_actions_container.xml
+++ b/lawnchair/res/layout/overview_actions_container.xml
@@ -107,6 +107,22 @@
             android:layout_height="1dp"
             android:layout_weight="1"
             android:visibility="gone" />
+
+        <app.lawnchair.views.CustomButton
+            style="@style/OverviewActionButton"
+            android:id="@+id/action_locked"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/action_lock"
+            android:drawableStart="@drawable/ic_locked_recents"
+            android:visibility="gone" />
+
+        <Space
+            android:id="@+id/locked_space"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_weight="1"
+            android:visibility="gone" />
     </LinearLayout>
 
 </app.lawnchair.overview.LawnchairOverviewActionsView>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -559,4 +559,8 @@
     <string name="x_and_y">%s &amp; %s</string>
 
     <string name="system_settings">System Settings</string>
+    <string name="action_unlock">Unlock</string>
+    <string name="action_lock">Lock</string>
+    <string name="recents_lock_unlock">Lock/Unlock</string>
+    <string name="recents_lock_unlock_description">Prevent selected app from clearing when using "Clear All"</string>
 </resources>

--- a/lawnchair/src/app/lawnchair/overview/LawnchairOverviewActionsView.kt
+++ b/lawnchair/src/app/lawnchair/overview/LawnchairOverviewActionsView.kt
@@ -6,12 +6,20 @@ import android.view.View
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.Space
+import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import app.lawnchair.preferences.PreferenceManager
+import app.lawnchair.util.RecentHelper
+import app.lawnchair.util.isDefaultLauncher
 import app.lawnchair.util.isOnePlusStock
+import com.android.launcher3.Launcher
+import com.android.launcher3.LauncherState
 import com.android.launcher3.R
+import com.android.launcher3.statemanager.StateManager
 import com.android.quickstep.views.OverviewActionsView
+import com.android.quickstep.views.RecentsView
+import com.android.systemui.shared.recents.model.Task
 
 class LawnchairOverviewActionsView @JvmOverloads constructor(
     context: Context,
@@ -26,6 +34,23 @@ class LawnchairOverviewActionsView @JvmOverloads constructor(
     private lateinit var shareAction: Button
     private lateinit var lensAction: Button
     private lateinit var clearAllAction: Button
+    private lateinit var lockedAction: Button
+    val launcher: Launcher? = if (context.isDefaultLauncher()) Launcher.getLauncher(context) else null
+
+    private val lockedTaskStateLister = object : StateManager.StateListener<LauncherState> {
+        override fun onStateTransitionStart(toState: LauncherState) {}
+
+        override fun onStateTransitionComplete(finalState: LauncherState) {
+            // TODO
+            if (finalState.overviewUi && context.isDefaultLauncher() && launcher != null) {
+                val rv: RecentsView<Launcher, *> = launcher.getOverviewPanel()
+                rv.addOnScrollChangedListener {
+                    val task = rv.getCurrentPageTaskView()?.task
+                    task?.let { updateLockedActionState(it) }
+                }
+            }
+        }
+    }
 
     override fun onFinishInflate() {
         super.onFinishInflate()
@@ -35,14 +60,26 @@ class LawnchairOverviewActionsView @JvmOverloads constructor(
         shareAction = ViewCompat.requireViewById(this, R.id.action_share)
         lensAction = ViewCompat.requireViewById(this, R.id.action_lens)
         screenshotAction = ViewCompat.requireViewById(this, R.id.action_screenshot)
+        lockedAction = ViewCompat.requireViewById(this, R.id.action_locked)
 
         shareAction.setOnClickListener { mCallbacks?.onShare() }
         lensAction.setOnClickListener { mCallbacks?.onLens() }
+        if (context.isDefaultLauncher() && launcher != null) {
+            lockedAction.setOnClickListener {
+                val rv: RecentsView<Launcher, *> = launcher.getOverviewPanel()
+                val task = rv.getCurrentPageTaskView()?.task
+                if (task != null) {
+                    mCallbacks?.onLocked(context, task)
+                    updateLockedActionState(task)
+                }
+            }
+        }
 
         prefs.recentsActionClearAll.subscribeChanges(this, ::updateVisibilities)
         prefs.recentsActionLens.subscribeChanges(this, ::updateVisibilities)
         prefs.recentsActionScreenshot.subscribeChanges(this, ::updateVisibilities)
         prefs.recentsActionShare.subscribeChanges(this, ::updateVisibilities)
+        prefs.recentsActionLocked.subscribeChanges(this, ::updateVisibilities)
 
         updateVisibilities()
     }
@@ -55,15 +92,14 @@ class LawnchairOverviewActionsView @JvmOverloads constructor(
         if (prefs.recentsActionShare.get()) {
             buttons.add(shareAction)
         }
-        if (prefs.recentsActionLens.get()) {
-            val lensIntent = context.packageManager.getLaunchIntentForPackage("com.google.ar.lens")
-            val lensAvailable = lensIntent != null
-            if (lensAvailable) {
-                buttons.add(lensAction)
-            }
+        if (prefs.recentsActionLens.get() && isLensAvailable()) {
+            buttons.add(lensAction)
         }
         if (prefs.recentsActionClearAll.get()) {
             buttons.add(clearAllAction)
+        }
+        if (prefs.recentsActionLocked.get()) {
+            buttons.add(lockedAction)
         }
         container.removeAllViews()
         container.addView(createSpace())
@@ -71,6 +107,23 @@ class LawnchairOverviewActionsView @JvmOverloads constructor(
             view.isVisible = true
             container.addView(view)
             container.addView(createSpace())
+        }
+    }
+
+    private fun isLensAvailable(): Boolean {
+        val lensIntent = context.packageManager.getLaunchIntentForPackage("com.google.ar.lens")
+        return lensIntent != null
+    }
+
+    private fun updateLockedActionState(task: Task) {
+        lockedAction.post {
+            val isLocked = RecentHelper.isAppLocked(task.key.packageName, context)
+            val drawableResId = if (isLocked) R.drawable.ic_unlocked_recents else R.drawable.ic_locked_recents
+            val textResId = if (isLocked) R.string.action_unlock else R.string.action_lock
+
+            val drawable = ContextCompat.getDrawable(context, drawableResId)
+            lockedAction.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
+            lockedAction.setText(textResId)
         }
     }
 
@@ -82,5 +135,19 @@ class LawnchairOverviewActionsView @JvmOverloads constructor(
 
     override fun setClearAllClickListener(clearAllClickListener: OnClickListener?) {
         clearAllAction.setOnClickListener(clearAllClickListener)
+    }
+
+    override fun removeOnAttachStateChangeListener(listener: OnAttachStateChangeListener?) {
+        super.removeOnAttachStateChangeListener(listener)
+        if (context.isDefaultLauncher() && launcher != null && prefs.recentsActionLocked.get()) {
+            launcher.stateManager?.removeStateListener(lockedTaskStateLister)
+        }
+    }
+
+    override fun addOnAttachStateChangeListener(listener: OnAttachStateChangeListener?) {
+        super.addOnAttachStateChangeListener(listener)
+        if (context.isDefaultLauncher() && launcher != null && prefs.recentsActionLocked.get()) {
+            launcher.stateManager?.addStateListener(lockedTaskStateLister)
+        }
     }
 }

--- a/lawnchair/src/app/lawnchair/overview/LawnchairOverviewActionsView.kt
+++ b/lawnchair/src/app/lawnchair/overview/LawnchairOverviewActionsView.kt
@@ -96,11 +96,11 @@ class LawnchairOverviewActionsView @JvmOverloads constructor(
         if (prefs.recentsActionLens.get() && isLensAvailable()) {
             buttons.add(lensAction)
         }
-        if (prefs.recentsActionClearAll.get()) {
-            buttons.add(clearAllAction)
-        }
         if (prefs.recentsActionLocked.get()) {
             buttons.add(lockedAction)
+        }
+        if (prefs.recentsActionClearAll.get()) {
+            buttons.add(clearAllAction)
         }
         container.removeAllViews()
         container.addView(createSpace())

--- a/lawnchair/src/app/lawnchair/overview/TaskOverlayFactoryImpl.kt
+++ b/lawnchair/src/app/lawnchair/overview/TaskOverlayFactoryImpl.kt
@@ -3,6 +3,8 @@ package app.lawnchair.overview
 import android.content.Context
 import android.graphics.Matrix
 import androidx.annotation.Keep
+import app.lawnchair.util.RecentHelper
+import app.lawnchair.util.TaskUtilLockState
 import com.android.quickstep.TaskOverlayFactory
 import com.android.quickstep.views.OverviewActionsView
 import com.android.quickstep.views.TaskThumbnailView
@@ -60,11 +62,21 @@ class TaskOverlayFactoryImpl(@Suppress("UNUSED_PARAMETER") context: Context) : T
                     showBlockedByPolicyMessage()
                 }
             }
+            override fun onLocked(context: Context, task: Task) {
+                val isLocked = !RecentHelper.isAppLocked(task.key.packageName, context)
+                TaskUtilLockState.setTaskLockState(
+                    context,
+                    task.key.component,
+                    isLocked,
+                    task.key,
+                )
+            }
         }
     }
 
     sealed interface OverlayUICallbacks : TaskOverlayFactory.OverlayUICallbacks {
         fun onShare()
         fun onLens()
+        fun onLocked(context: Context, task: Task)
     }
 }

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
@@ -96,6 +96,7 @@ class PreferenceManager private constructor(private val context: Context) : Base
     val recentsActionShare = BoolPref("pref_recentsActionShare", isOnePlusStock)
     val recentsActionLens = BoolPref("pref_recentsActionLens", true)
     val recentsActionClearAll = BoolPref("pref_clearAllAsAction", false)
+    val recentsActionLocked = BoolPref("pref_lockedAsAction", false)
     val recentsTranslucentBackground = BoolPref("pref_recentsTranslucentBackground", false, recreate)
 
     init {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/ExperimentalFeaturesPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/ExperimentalFeaturesPreferences.kt
@@ -51,6 +51,11 @@ fun ExperimentalFeaturesPreferences() {
                 label = stringResource(id = R.string.perform_wide_search_title),
                 description = stringResource(id = R.string.perform_wide_search_description),
             )
+            SwitchPreference(
+                adapter = prefs.recentsActionLocked.getAdapter(),
+                label = stringResource(id = R.string.recents_lock_unlock),
+                description = stringResource(id = R.string.recents_lock_unlock_description),
+            )
         }
     }
 }

--- a/lawnchair/src/app/lawnchair/util/LawnchairLockedStateController.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairLockedStateController.kt
@@ -1,0 +1,221 @@
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.UserHandle
+import android.provider.Settings
+import android.util.Log
+import com.android.systemui.shared.system.ActivityManagerWrapper
+
+@SuppressLint("StaticFieldLeak")
+object LawnchairLockedStateController {
+
+    private const val TAG = "LawnchairLockedStateController"
+    private const val RECENT_TASK_LOCKED_LIST = "com_android_systemui_recent_task_lockd_list"
+    private const val RECENT_TASK_LOCKED_LIST_BK = "com_android_systemui_recent_task_locked_bk"
+    private const val TASK_LOCK_LIST_KEY = "task_lock_list"
+    const val TASK_LOCK_LIST_KEY_WITH_USERID = "task_lock_list_with_userid"
+    const val TASK_LOCK_STATE = "tasklockstate"
+
+    private var isReloaded = false
+    private var reloadCount = 0
+
+    private lateinit var applicationContext: Context
+    private val backgroundThread: HandlerThread by lazy {
+        HandlerThread("Recents-LawnchairLockedStateController", 10)
+    }
+    private val backgroundThreadHandler: Handler by lazy {
+        Handler(backgroundThread.looper)
+    }
+    private var lockedListWithUserId: MutableSet<String> = HashSet()
+    private var lockedPackageNameListWithUserId: MutableList<String> = ArrayList()
+    private val sharedPreferences: SharedPreferences by lazy {
+        applicationContext.getSharedPreferences(TASK_LOCK_STATE, Context.MODE_PRIVATE)
+    }
+
+    fun initialize(context: Context): LawnchairLockedStateController {
+        if (!this::applicationContext.isInitialized) {
+            this.applicationContext = context
+            backgroundThread.start()
+            initializePackageNameList(false)
+        }
+        return this
+    }
+
+    private fun initializePackageNameList(forceInitialization: Boolean) {
+        if (isReloaded && forceInitialization) return
+
+        val packageName = applicationContext.packageName
+        if (packageName.isNullOrEmpty() || !packageName.contains("launcher")) return
+
+        lockedListWithUserId =
+            sharedPreferences.getStringSet(TASK_LOCK_LIST_KEY_WITH_USERID, emptySet()) ?: HashSet()
+        lockedPackageNameListWithUserId = ArrayList()
+
+        if (lockedListWithUserId.isEmpty() && getLockedListFromProvider(
+                ActivityManagerWrapper.getInstance().currentUserId,
+            )
+        ) {
+            buildPackageNameList()
+        } else {
+            buildPackageNameList()
+            isReloaded = true
+        }
+
+        writeToProvider()
+        if (++reloadCount > 5) isReloaded = true
+    }
+
+    private fun buildPackageNameList() {
+        lockedListWithUserId.forEach { str ->
+            val split = str.split("/")
+            val substring = str.substring(str.lastIndexOf("#") + 1)
+            appendUserWithoutBrace(split[0], substring.substring(0, substring.length - 1)).let {
+                lockedPackageNameListWithUserId.add(
+                    it,
+                )
+            }
+        }
+    }
+
+    fun setTaskLockState(taskIdentifier: String, lockState: Boolean, userId: Int) {
+        val userIdStr = userId.toString()
+        val appendUserWithBrace = appendUserWithBrace(taskIdentifier, userIdStr)
+        val packageName = taskIdentifier.split("/")[0]
+        val packageNameWithUser = appendUserWithoutBrace(packageName, userIdStr)
+
+        if (lockState) {
+            appendUserWithBrace.let { lockedListWithUserId.add(it) }
+            lockedPackageNameListWithUserId.add(packageNameWithUser)
+        } else {
+            lockedListWithUserId.remove(appendUserWithBrace)
+            lockedPackageNameListWithUserId.remove(packageNameWithUser)
+        }
+
+        sharedPreferences.edit().apply {
+            clear()
+            putStringSet(TASK_LOCK_LIST_KEY_WITH_USERID, lockedListWithUserId)
+            apply()
+        }
+
+        writeToProvider()
+
+        if (!isReloaded) {
+            try {
+                val recentTaskLockedListBk =
+                    Settings.System.getStringForUser(
+                        applicationContext.contentResolver,
+                        RECENT_TASK_LOCKED_LIST_BK,
+                        ActivityManagerWrapper.getInstance().currentUserId,
+                    )
+                if (recentTaskLockedListBk == null) {
+                    Settings.System.putStringForUser(
+                        applicationContext.contentResolver,
+                        RECENT_TASK_LOCKED_LIST_BK,
+                        "done",
+                        ActivityManagerWrapper.getInstance().currentUserId,
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "setTaskLockState error: ", e)
+            }
+        }
+    }
+
+    fun getTaskLockState(taskIdentifier: String, userId: Int): Boolean {
+        return lockedListWithUserId.contains(appendUserWithBrace(taskIdentifier, userId.toString()))
+    }
+
+    // TODO Implement this, when the app is uninstalled
+    fun removeTaskLockState(taskIdentifier: String, userId: Int) {
+        if (userId != -1) {
+            backgroundThreadHandler.post {
+                val user = UserHandle.getUserId(userId)
+                val userString = "{$taskIdentifier/"
+                Log.d(TAG, "uninstall Lock task , $taskIdentifier, $user")
+                val arrayList = ArrayList(lockedListWithUserId)
+                val size = arrayList.size
+                for (i in 0 until size) {
+                    val userTask = arrayList[i]
+                    if (userTask.startsWith(userString) && userTask.endsWith("$user}")) {
+                        setTaskLockState(removeUserWithBrace(userTask), false, user)
+                    }
+                }
+            }
+        }
+    }
+
+    fun isTaskLocked(taskIdentifier: String): Boolean {
+        return lockedPackageNameListWithUserId.contains(taskIdentifier)
+    }
+
+    private fun appendUserWithoutBrace(input: String, userId: String): String {
+        return input.replace("{", "") + "#$userId"
+    }
+
+    private fun appendUserWithBrace(input: String, userId: String): String {
+        return input.replace("}", "") + "#$userId}"
+    }
+
+    private fun removeUserWithBrace(input: String): String {
+        return input.substring(0, input.lastIndexOf("#")) + "}"
+    }
+
+    private fun writeToProvider() {
+        val sb = StringBuilder()
+        lockedListWithUserId.forEach { taskIdentifier ->
+            sb.append(taskIdentifier)
+        }
+        writeLockedListToProvider(
+            sb.toString(),
+            ActivityManagerWrapper.getInstance().currentUserId,
+        )
+    }
+
+    private fun getLockedListFromProvider(userId: Int): Boolean {
+        try {
+            val str = Settings.System.getStringForUser(
+                applicationContext.contentResolver,
+                RECENT_TASK_LOCKED_LIST_BK,
+                userId,
+            )
+            if ("done" == str) {
+                isReloaded = true
+                return false
+            }
+            val split = str.split("}")
+            lockedListWithUserId.addAll(split)
+            sharedPreferences.edit().apply {
+                clear()
+                putStringSet(TASK_LOCK_LIST_KEY_WITH_USERID, lockedListWithUserId)
+                apply()
+            }
+            Settings.System.putStringForUser(
+                applicationContext.contentResolver,
+                RECENT_TASK_LOCKED_LIST_BK,
+                "done",
+                userId,
+            )
+            return true
+        } catch (e: Exception) {
+            Log.e(TAG, "getLockedListFromProvider error: ", e)
+            return false
+        }
+    }
+
+    private fun writeLockedListToProvider(str: String, userId: Int) {
+        backgroundThreadHandler.post {
+            try {
+                Settings.System.putStringForUser(
+                    applicationContext.contentResolver,
+                    RECENT_TASK_LOCKED_LIST,
+                    str,
+                    userId,
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "writeLockedListToProvider error: ", e)
+            }
+        }
+    }
+}

--- a/lawnchair/src/app/lawnchair/util/RecentHelper.kt
+++ b/lawnchair/src/app/lawnchair/util/RecentHelper.kt
@@ -1,0 +1,70 @@
+package app.lawnchair.util
+
+import android.app.ActivityManager
+import android.app.ActivityTaskManager
+import android.content.Context
+import android.os.Process
+import android.os.UserHandle
+import com.android.launcher3.BuildConfig
+import com.android.launcher3.Launcher
+import com.android.quickstep.views.RecentsView
+import com.android.systemui.shared.recents.model.Task
+import com.android.systemui.shared.system.ActivityManagerWrapper
+
+object RecentHelper {
+
+    fun clearAllTaskStacks(context: Context) {
+        try {
+            val launcher = Launcher.getLauncher(context)
+            val recentsView = launcher.getOverviewPanel<RecentsView<Launcher, *>>()
+            val taskViewCount = recentsView.getTaskViewCount()
+            val currentUserId = Process.myUserHandle().identifier
+            for (i in 0..taskViewCount) {
+                try {
+                    val rawTasks = ActivityTaskManager.getInstance()
+                        .getRecentTasks(i, ActivityManager.RECENT_IGNORE_UNAVAILABLE, currentUserId)
+                    for (recentTaskInfo in rawTasks) {
+                        var packageName = recentTaskInfo.baseIntent.component?.packageName
+                        val taskKey = Task.TaskKey(recentTaskInfo)
+                        val taskId = taskKey.id
+                        packageName = packageName?.replace("unknown", "")
+                        if (!packageName.isNullOrEmpty()) {
+                            packageName += "#" + UserHandle.getUserId(taskId)
+                            val taskLockState = taskKey.baseIntent.component?.let {
+                                TaskUtilLockState.getTaskLockState(
+                                    context,
+                                    it,
+                                    taskKey,
+                                )
+                            }
+                            if (!isAppLocked(packageName, context) &&
+                                !packageName.contains(BuildConfig.APPLICATION_ID) &&
+                                !taskLockState!!
+                            ) {
+                                ActivityManagerWrapper.getInstance().removeTask(taskId)
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
+        } catch (exception: Exception) {
+            ActivityManagerWrapper.getInstance().removeAllRecentTasks()
+        }
+    }
+
+    fun isAppLocked(packageName: String, context: Context): Boolean {
+        val pref = context.getSharedPreferences(
+            LawnchairLockedStateController.TASK_LOCK_STATE,
+            Context.MODE_PRIVATE,
+        )
+
+        val lockedApps = pref.getStringSet(
+            LawnchairLockedStateController.TASK_LOCK_LIST_KEY_WITH_USERID,
+            emptySet(),
+        )
+
+        return lockedApps?.any { it.contains(packageName) } ?: false
+    }
+}

--- a/lawnchair/src/app/lawnchair/util/TaskUtilLockState.kt
+++ b/lawnchair/src/app/lawnchair/util/TaskUtilLockState.kt
@@ -1,0 +1,75 @@
+package app.lawnchair.util
+
+import LawnchairLockedStateController
+import android.content.ComponentName
+import android.content.Context
+import android.os.Bundle
+import android.util.Log
+import com.android.systemui.shared.recents.model.Task
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+object TaskUtilLockState {
+    private val mLockedApps: MutableList<String> = ArrayList()
+    private val mIoExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+
+    private const val TAG = "TaskUtilLockState"
+    private const val SEPARATOR = "#"
+    private const val RECENT_LOCK_LIST = "recent_lock_list"
+
+    fun setTaskLockState(context: Context, componentName: ComponentName, isState: Boolean, taskKey: Task.TaskKey) {
+        LawnchairLockedStateController.initialize(context).setTaskLockState(componentName.toShortString(), isState, taskKey.userId)
+        val formatLockedAppStr = toFormatLockedAppStr(componentName.packageName, taskKey.userId)
+        if (isState) {
+            addLockedApp(formatLockedAppStr)
+        } else {
+            removeLockedApp(formatLockedAppStr)
+        }
+    }
+
+    private fun toFormatLockedAppStr(packageName: String, userId: Int): String {
+        return "$packageName$SEPARATOR$userId"
+    }
+
+    private fun saveLockedApps(lockedApps: List<String>?) {
+        lockedApps?.let {
+            mIoExecutor.execute { saveListToFileSync(it) }
+        }
+    }
+
+    private fun saveListToFileSync(lockedApps: List<String>) {
+        val bundle = Bundle()
+        bundle.putStringArrayList(RECENT_LOCK_LIST, ArrayList(lockedApps))
+    }
+
+    private fun addLockedApp(appStr: String) {
+        if (!mLockedApps.contains(appStr)) {
+            Log.d(TAG, "addLockedApp: $appStr")
+            mLockedApps.add(appStr)
+            saveLockedApps(mLockedApps)
+        }
+    }
+
+    private fun removeLockedApp(appStr: String) {
+        if (mLockedApps.contains(appStr)) {
+            Log.d(TAG, "removeLockedApp: $appStr")
+            mLockedApps.remove(appStr)
+            saveLockedApps(mLockedApps)
+        }
+    }
+
+    fun getTaskLockState(context: Context, componentName: ComponentName, taskKey: Task.TaskKey): Boolean {
+        return updateSpecifiedTaskLockState(context, componentName, taskKey)
+    }
+
+    private fun updateSpecifiedTaskLockState(context: Context, componentName: ComponentName, taskKey: Task.TaskKey): Boolean {
+        val taskLockState = LawnchairLockedStateController.initialize(context)
+            .getTaskLockState(componentName.toShortString(), taskKey.userId)
+        Log.d(TAG, "updateSpecifiedTaskLockState: Checking if the task is locked: $taskLockState")
+        if (taskLockState) {
+            setTaskLockState(context, taskKey.baseIntent.component, taskLockState, taskKey)
+            Log.i(TAG, "updateSpecifiedTaskLockState: Task is locked, clearing the lock state.")
+        }
+        return taskLockState
+    }
+}

--- a/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/TaskViewTouchController.java
+++ b/quickstep/src/com/android/launcher3/uioverrides/touchcontrollers/TaskViewTouchController.java
@@ -47,6 +47,8 @@ import com.android.quickstep.util.VibrationConstants;
 import com.android.quickstep.views.RecentsView;
 import com.android.quickstep.views.TaskView;
 
+import app.lawnchair.util.RecentHelper;
+
 /**
  * Touch controller for handling task view card swipes
  */
@@ -346,7 +348,7 @@ public abstract class TaskViewTouchController<T extends BaseDraggingActivity>
             fling = false;
         }
         PagedOrientationHandler orientationHandler = mRecentsView.getPagedOrientationHandler();
-        boolean goingUp = orientationHandler.isGoingUp(velocity, mIsRtl);
+        boolean goingUp = orientationHandler.isGoingUp(velocity, mIsRtl) && !RecentHelper.INSTANCE.isAppLocked(mTaskBeingDragged.getTask().key.getPackageName(), mActivity.getBaseContext());
         float progress = mCurrentAnimation.getProgressFraction();
         float interpolatedProgress = mCurrentAnimation.getInterpolatedProgress();
         if (fling) {

--- a/quickstep/src/com/android/quickstep/views/RecentsView.java
+++ b/quickstep/src/com/android/quickstep/views/RecentsView.java
@@ -224,6 +224,7 @@ import app.lawnchair.LawnchairApp;
 import app.lawnchair.compat.LawnchairQuickstepCompat;
 import app.lawnchair.theme.color.ColorTokens;
 import app.lawnchair.util.OverScrollerCompat;
+import app.lawnchair.util.RecentHelper;
 
 /**
  * A list of recent tasks.
@@ -4229,8 +4230,7 @@ public abstract class RecentsView<ACTIVITY_TYPE extends StatefulActivity<STATE_T
             if (isSuccess) {
                 // Remove all the task views now
                 finishRecentsAnimation(true /* toRecents */, false /* shouldPip */, () -> {
-                    UI_HELPER_EXECUTOR.getHandler().post(
-                            ActivityManagerWrapper.getInstance()::removeAllRecentTasks);
+                    RecentHelper.INSTANCE.clearAllTaskStacks(mContext);
                     removeTasksViewsAndClearAllButton();
                     startHome();
                 });


### PR DESCRIPTION


## Description

In situations where users frequently run the app in the background, and open multiple apps, there may be instances where a specific app should not be cleared when performing a 'Clear All' or 'Dismiss' action. This new feature ensures that a selected running task or app remains in the Recent View and will not be removed.

## Demo
https://github-production-user-asset-6210df.s3.amazonaws.com/36076410/282691448-00cf1295-4ce9-4162-ad94-4ffe8737cd98.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240209%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240209T031543Z&X-Amz-Expires=300&X-Amz-Signature=b9e46302859e36225890cfa6a65d614df55a12cd5b39c17770303c40831e3704&X-Amz-SignedHeaders=host&actor_id=36076410&key_id=0&repo_id=83799439

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
