### PR TITLE
Promote smartspace provider selection to stable

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -59,7 +59,6 @@
     <string name="always_reload_icons_description">Avoid using cached icons from icon packs</string>
     <string name="transparent_background_icons">Transparent Themed Icons</string>
     <string name="transparent_background_icons_description">Use transparent background on themed icons</string>
-    <string name="smartspace_mode_selection">At a Glance Provider selection</string>
 
     <!-- GeneralPreferences -->
     <string name="home_screen_rotation_label">Home Screen Rotation</string>

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -457,11 +457,6 @@ class PreferenceManager2 private constructor(private val context: Context) : Pre
         onSet = { reloadHelper.recreate() },
     )
 
-    val smartspaceModeSelection = preference(
-        key = booleanPreferencesKey("smartspace_mode_selection"),
-        defaultValue = false,
-    )
-
     val smartspaceAagWidget = preference(
         key = booleanPreferencesKey("enable_smartspace_aag_widget"),
         defaultValue = true,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/ExperimentalFeaturesPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/ExperimentalFeaturesPreferences.kt
@@ -43,10 +43,6 @@ fun ExperimentalFeaturesPreferences() {
                 description = stringResource(id = R.string.always_reload_icons_description),
             )
             SwitchPreference(
-                adapter = prefs2.smartspaceModeSelection.getAdapter(),
-                label = stringResource(id = R.string.smartspace_mode_selection),
-            )
-            SwitchPreference(
                 adapter = prefs.performWideSearchExperimental.getAdapter(),
                 label = stringResource(id = R.string.perform_wide_search_title),
                 description = stringResource(id = R.string.perform_wide_search_description),

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SmartspacePreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SmartspacePreferences.kt
@@ -65,7 +65,6 @@ fun SmartspacePreferences(
     val smartspaceProvider = SmartspaceProvider.INSTANCE.get(LocalContext.current)
     val smartspaceAdapter = preferenceManager2.enableSmartspace.getAdapter()
     val smartspaceModeAdapter = preferenceManager2.smartspaceMode.getAdapter()
-    val smartspaceModeSelectionAdapter = preferenceManager2.smartspaceModeSelection.getAdapter()
     val selectedMode = smartspaceModeAdapter.state.value
     val modeIsLawnchair = selectedMode == LawnchairSmartspace
 
@@ -76,7 +75,7 @@ fun SmartspacePreferences(
                     adapter = smartspaceAdapter,
                     label = stringResource(id = R.string.smartspace_widget_toggle_label),
                 )
-                ExpandAndShrink(visible = smartspaceAdapter.state.value && smartspaceModeSelectionAdapter.state.value) {
+                ExpandAndShrink(visible = smartspaceAdapter.state.value) {
                     SmartspaceProviderPreference(
                         adapter = smartspaceModeAdapter,
                         endWidget = when (selectedMode) {


### PR DESCRIPTION
## Description

Promote a previously experimental feature to stable, At a Glance Provider Selection is a experimental feature because of #2820 where on widget configuration the launcher crashed (see https://github.com/LawnchairLauncher/lawnchair/pull/3049#issuecomment-1288537529), but now that #2820 has been fixed, we can promote this to stable *hopefully without any issue*.

## Type of change

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
