### PR TITLE
Fix release build due to missing ui-tooling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -360,7 +360,7 @@ dependencies {
     implementation platform("androidx.compose:compose-bom:2024.01.00")
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.ui:ui-util"
-    debugImplementation "androidx.compose.ui:ui-tooling"
+    implementation "androidx.compose.ui:ui-tooling"
     implementation "androidx.compose.ui:ui-text-google-fonts"
     implementation "androidx.compose.foundation:foundation"
     implementation "androidx.compose.material:material-icons-extended"


### PR DESCRIPTION
## Description

I noticed that I couldn't build Lawnchair with the lawnWithQuickStepMarketRelease target due to the errors: `Unresolved reference: tooling` and `Unresolved reference: Preview` in `AnnouncementPreference.kt`, added by #3862. These are provided in `androidx.compose.ui:ui-tooling`, which is included only in debug builds with debugImplementation, even though it is also necessary for release builds.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
