### PR TITLE
Give nightly release and apk pretty names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
     permissions:
       contents: write
     env:
-      APK_NAME: Lawnchair.Debug.${{ github.ref_name }}.Nightly.${{ github.sha }}.(CI_#${{ github.run_number }}).apk
+      APK_NAME: Lawnchair.Debug.${{ github.ref_name }}.Nightly-${{ github.sha }}-(CI_#${{ github.run_number }}).apk
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,13 +125,16 @@ jobs:
     needs: build-debug-apk
     permissions:
       contents: write
+    env:
+      APK_NAME: Lawnchair.Debug.${{ github.ref_name }}.Nightly.${{ github.sha }}.(CI_#${{ github.run_number }}).apk
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
-      # Rename because the # symbol causes errors in GH release command.
       - name: Rename .apk file
-        run: mv ./Debug\ APK/lawnWithQuickstepGithub/debug/*.apk ./debug.apk
+        run: mv "./Debug APK/lawnWithQuickstepGithub/debug/"*.apk "./$APK_NAME"
       - name: Delete release if exist then create release
-        run: gh release view "nightly" && gh release delete "nightly" -y --cleanup-tag ; gh release create "nightly" "./debug.apk" -p --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "nightly" && gh release delete "nightly" -y --cleanup-tag
+          gh release create "nightly" "./$APK_NAME" -p -t "Lawnchair Nightly" --generate-notes


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

Wanted to tidy up the yml and look of the new nightly builds in the release section to match the other release naming.

For example the current nightly release `debug.apk` would instead be uploaded as:
`Lawnchair.Debug.14-dev.Nightly-7516813-(CI_#729).apk`

Which nicely indicates that this is still the app.lawnchair.debug package name, the build branch and Nightly for the version, then the commit hash and CI# of the corresponding tag to easily trace issues reported after it may have been replaced by the next nightly.

The Beta Release APK naming I've attempted to take these cues from, for reference:
`Lawnchair.14.0.0.Beta.2.apk`

The proper quotes in the commands should resolve the # issue mentioned in the removed comment.

The releases will be titled "Lawnchair Nightly" instead of the simple "nightly" from the tag, which also more matches the release titles of the new betas.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
