### PR TITLE
Use safeDrawingPadding for ModalBottomSheetContent

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/AlertBottomSheetContent.kt
+++ b/lawnchair/src/app/lawnchair/ui/AlertBottomSheetContent.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
@@ -25,7 +26,8 @@ fun ModalBottomSheetContent(
 
     Column(
         modifier = modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .safeDrawingPadding(),
     ) {
         title?.let {
             Box(modifier = Modifier.padding(start = 16.dp, end = 16.dp)) {


### PR DESCRIPTION
## Description

Prevents bottom sheet content from being obscured by the navigation bar

Before
![image](https://github.com/LawnchairLauncher/lawnchair/assets/14132249/e7e423f2-83d8-439e-9cda-d457f5c5bdd3)

After
![image](https://github.com/LawnchairLauncher/lawnchair/assets/14132249/edf481b7-4c38-48ee-93ef-2634639dc96c)

## Type of change

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
