### PR TITLE
Correct versionCode semantic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,9 @@ final def quickstepMaxSdk = "34"
 android {
     namespace "com.android.launcher3"
     defaultConfig {
-        versionCode 15
+        // Lawnchair Launcher 14.0 Beta 2
+        // Android 14, Minor 0, Lawnchair Stage 2 (Beta), Update No 2
+        versionCode 14_00_02_02
         versionName "${versionDisplayName}"
         buildConfigField "String", "VERSION_DISPLAY_NAME", "\"${versionDisplayName}\""
         buildConfigField "String", "MAJOR_VERSION", "\"${majorVersion}\""


### PR DESCRIPTION
## Description

On Lawnchair Launcher 12.1 Alpha 4, we use 12_01_00_05 (`12010005`), However on Lawnchair Launcher 14 Beta 2 we reverted to just 14 (right now it's actually 15 but let's assume it was correct) thus making the upgrade from 12.1 Alpha 4 to 14 Beta 2 impossible.

Right now I have no idea which format are we using because LC 12.1 A4 uses `12010005` (what does the 5 stand for?) so I just created one.

Lawnchair Launcher 14 Beta 2 - 14_00_02_02 (14000202)

##### The graphic does not show Field 2 (Android Minor)

![image](https://github.com/LawnchairLauncher/lawnchair/assets/93124920/603d6c8b-af2e-41e2-bf5b-fb70a1cdca4b)

### Semantic (from my point of view)

| Name | Field 1 (Android Major) | Field 2 (Android Minor)  | Field 3 (Development Status) | Field 4 (Development version) |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Lawnchair Launcher 14 Release 1 | 14 | 00 | 04 | 01 |
| Lawnchair Launcher 14 Release Candidates 4 | 14 | 00 | 03 | 04 |
| Lawnchair Launcher 14 Beta 2 | 14 | 00 | 02 | 02 |
| Lawnchair Launcher 14 Alpha 2 | 14 | 00 | 01 | 02 |
| Lawnchair Launcher 15.2 Beta 1 | 15 | 02 | 02 | 01 |

### Fixes

Fixes Issues (populated as of May 4th 2024)
* #4341
* #4189

Fixes IzzyOnDroid Publishing
*  https://github.com/LawnchairLauncher/lawnchair/discussions/4325#discussioncomment-9252130

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
✅ Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)

<summary>
Fields for GitHub parser
<details>
Fixes #4189

Fixes #4341

Fixes https://github.com/LawnchairLauncher/lawnchair/discussions/4325
</details>
</summary>
