### PR TITLE
Use collectAsStateWithLifecycle to safely collect uiState

### DIFF
--- a/lawnchair/src/app/lawnchair/backup/ui/CreateBackupScreen.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/CreateBackupScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -37,6 +36,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.backup.LawnchairBackup
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.ui.preferences.LocalNavController
@@ -62,9 +62,9 @@ fun CreateBackupScreen(
     viewModel: CreateBackupViewModel,
     modifier: Modifier = Modifier,
 ) {
-    val contents by viewModel.backupContents.collectAsState()
-    val screenshot by viewModel.screenshot.collectAsState()
-    val screenshotDone by viewModel.screenshotDone.collectAsState()
+    val contents by viewModel.backupContents.collectAsStateWithLifecycle()
+    val screenshot by viewModel.screenshot.collectAsStateWithLifecycle()
+    val screenshotDone by viewModel.screenshotDone.collectAsStateWithLifecycle()
 
     val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
     val scrollState = rememberScrollState()

--- a/lawnchair/src/app/lawnchair/backup/ui/RestoreBackupScreen.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/RestoreBackupScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -37,6 +36,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
@@ -85,7 +85,7 @@ fun RestoreBackupScreen(
 ) {
     val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
     val scrollState = rememberScrollState()
-    val uiState = viewModel.uiState.collectAsState().value
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
 
     PreferenceLayout(
         label = stringResource(id = R.string.restore_backup),
@@ -120,7 +120,7 @@ fun ColumnScope.RestoreBackupOptions(
     viewModel: RestoreBackupViewModel = viewModel(),
 ) {
     val backupContents = backup.info.contents
-    val contents by viewModel.backupContents.collectAsState()
+    val contents by viewModel.backupContents.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     val scope = rememberCoroutineScope()

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceAdapter.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceAdapter.kt
@@ -20,12 +20,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.preferences2.IdpPreference
 import app.lawnchair.preferences2.asState
 import app.lawnchair.preferences2.firstBlocking
@@ -126,7 +126,7 @@ fun IdpPreference.getAdapter(): PreferenceAdapter<Int> {
     val context = LocalContext.current
     val idp = remember { InvariantDeviceProfile.INSTANCE.get(context) }
     val defaultGrid = idp.closestProfile
-    val state = get(defaultGrid).collectAsState(initial = firstBlocking(defaultGrid))
+    val state = get(defaultGrid).collectAsStateWithLifecycle(initialValue = firstBlocking(defaultGrid))
     return createStateAdapter(state = state, set = { set(it, defaultGrid) })
 }
 

--- a/lawnchair/src/app/lawnchair/preferences2/IdpPreference.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/IdpPreference.kt
@@ -1,10 +1,10 @@
 package app.lawnchair.preferences2
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.android.launcher3.InvariantDeviceProfile
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -46,4 +46,4 @@ fun IdpPreference.firstBlocking(gridOption: InvariantDeviceProfile.GridOption) =
 fun IdpPreference.state(
     gridOption: InvariantDeviceProfile.GridOption,
     initial: Int? = null,
-) = get(gridOption = gridOption).collectAsState(initial = initial)
+) = get(gridOption = gridOption).collectAsStateWithLifecycle(initialValue = initial)

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceUtils.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceUtils.kt
@@ -1,14 +1,14 @@
 package app.lawnchair.preferences2
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.util.subscribeBlocking
 import com.patrykmichalik.opto.core.firstBlocking
 import com.patrykmichalik.opto.domain.Preference
 import kotlinx.coroutines.CoroutineScope
 
 @Composable
-fun <C, S> Preference<C, S, *>.asState() = get().collectAsState(initial = firstBlocking())
+fun <C, S> Preference<C, S, *>.asState() = get().collectAsStateWithLifecycle(initialValue = firstBlocking())
 
 fun <C, S> Preference<C, S, *>.subscribeBlocking(
     scope: CoroutineScope,

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/acknowledgements/Acknowledgements.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/acknowledgements/Acknowledgements.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -37,6 +36,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.ui.ModalBottomSheetContent
 import app.lawnchair.ui.preferences.LocalPreferenceInteractor
 import app.lawnchair.ui.preferences.components.layout.LoadingScreen
@@ -50,7 +50,7 @@ import com.android.launcher3.R
 fun Acknowledgements(
     modifier: Modifier = Modifier,
 ) {
-    val ossLibraries by LocalPreferenceInteractor.current.ossLibraries.collectAsState()
+    val ossLibraries by LocalPreferenceInteractor.current.ossLibraries.collectAsStateWithLifecycle()
     LoadingScreen(
         obj = ossLibraries,
         modifier = modifier,

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/FontSelectionPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/FontSelectionPreference.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.font.FontCache
 import app.lawnchair.font.googlefonts.GoogleFontsListing
 import app.lawnchair.preferences.BasePreferenceManager
@@ -68,7 +68,7 @@ fun FontSelection(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val customFonts by remember { FontCache.INSTANCE.get(context).customFonts }.collectAsState(initial = emptyList())
+    val customFonts by remember { FontCache.INSTANCE.get(context).customFonts }.collectAsStateWithLifecycle(initialValue = emptyList())
     val items by produceState(initialValue = emptyList<FontCache.Family>()) {
         val list = mutableListOf<FontCache.Family>()
         list.add(FontCache.Family(FontCache.SystemFont("sans-serif")))

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GeneralPreferences.kt
@@ -17,12 +17,12 @@
 package app.lawnchair.ui.preferences.destinations
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.preferences2.asState
@@ -56,7 +56,7 @@ fun GeneralPreferences() {
     val context = LocalContext.current
     val prefs = preferenceManager()
     val prefs2 = preferenceManager2()
-    val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsState()
+    val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsStateWithLifecycle()
     val themedIconsAdapter = prefs.themedIcons.getAdapter()
     val drawerThemedIconsAdapter = prefs.drawerThemedIcons.getAdapter()
     val iconShapeAdapter = prefs2.iconShape.getAdapter()
@@ -164,7 +164,7 @@ fun GeneralPreferences() {
         }
 
         PreferenceGroup(heading = stringResource(id = R.string.notification_dots)) {
-            val enabled by remember { notificationDotsEnabled(context) }.collectAsState(initial = false)
+            val enabled by remember { notificationDotsEnabled(context) }.collectAsStateWithLifecycle(initialValue = false)
             val serviceEnabled = notificationServiceEnabled()
             NotificationDotsPreference(enabled = enabled, serviceEnabled = serviceEnabled)
             if (enabled && serviceEnabled) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
@@ -51,6 +50,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.preferences.PreferenceAdapter
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
@@ -224,8 +224,8 @@ fun IconPackGrid(
     isThemedIconPack: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsState()
-    val themedIconPacks by LocalPreferenceInteractor.current.themedIconPacks.collectAsState()
+    val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsStateWithLifecycle()
+    val themedIconPacks by LocalPreferenceInteractor.current.themedIconPacks.collectAsStateWithLifecycle()
     val lazyListState = rememberLazyListState()
     val padding = 12.dp
     var iconPacksLocal = iconPacks

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPickerPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPickerPreference.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,6 +33,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.icons.CustomIconPack
 import app.lawnchair.icons.IconPack
 import app.lawnchair.icons.IconPackProvider
@@ -137,7 +137,7 @@ fun IconPickerGrid(
         iconPack.getAllIcons()
             .catch { loadFailed = true }
     }
-    val categories by categoriesFlow.collectAsState(emptyList())
+    val categories by categoriesFlow.collectAsStateWithLifecycle(emptyList())
     val filteredCategories by remember(searchQuery) {
         derivedStateOf {
             categories.asSequence()

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SearchPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SearchPreferences.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -13,6 +12,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.not
@@ -180,7 +180,7 @@ private fun LocalSearchSettings(
     )
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         val lifecycleOwner = LocalLifecycleOwner.current
-        val state by lifecycleOwner.lifecycle.currentStateFlow.collectAsState()
+        val state by lifecycleOwner.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
         var isGranted by remember { mutableStateOf(filesAndStorageGranted(context)) }
         // TODO refactor permission handling of all files access
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/SelectIconPreference.kt
@@ -4,13 +4,13 @@ import android.app.Activity
 import android.content.Intent
 import android.content.pm.LauncherApps
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.core.graphics.drawable.toBitmap
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.data.iconoverride.IconOverrideRepository
 import app.lawnchair.icons.IconPickerItem
 import app.lawnchair.ui.preferences.LocalNavController
@@ -35,7 +35,7 @@ fun SelectIconPreference(componentKey: ComponentKey) {
         val activity = launcherApps.resolveActivity(intent, componentKey.user)
         activity.label.toString()
     }
-    val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsState()
+    val iconPacks by LocalPreferenceInteractor.current.iconPacks.collectAsStateWithLifecycle()
     val navController = LocalNavController.current
     val scope = rememberCoroutineScope()
 
@@ -50,7 +50,7 @@ fun SelectIconPreference(componentKey: ComponentKey) {
         }
     }
 
-    val overrideItem by repo.observeTarget(componentKey).collectAsState(initial = null)
+    val overrideItem by repo.observeTarget(componentKey).collectAsStateWithLifecycle(initialValue = null)
     val hasOverride = overrideItem != null
 
     PreferenceLayoutLazyColumn(label = label) {

--- a/lawnchair/src/app/lawnchair/util/FlowUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/FlowUtils.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -22,7 +22,7 @@ import kotlinx.coroutines.runBlocking
 fun <T> Flow<T>.firstBlocking() = runBlocking { first() }
 
 @Composable
-fun <T> Flow<T>.collectAsStateBlocking() = collectAsState(initial = firstBlocking())
+fun <T> Flow<T>.collectAsStateBlocking() = collectAsStateWithLifecycle(initialValue = firstBlocking())
 
 fun broadcastReceiverFlow(context: Context, filter: IntentFilter) = callbackFlow {
     val receiver = object : BroadcastReceiver() {


### PR DESCRIPTION
## Description

https://medium.com/androiddevelopers/consuming-flows-safely-in-jetpack-compose-cde014d0d5a3

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
