### PR TITLE
Get rid of AppCompatActivity when using Compose

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ allprojects {
         }
         dependencies {
             implementation 'androidx.core:core-ktx:1.13.1'
-            implementation 'androidx.appcompat:appcompat:1.7.0'
         }
     }
 

--- a/lawnchair/res/values-night/themes.xml
+++ b/lawnchair/res/values-night/themes.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Theme.Lawnchair" parent="Base.Theme.Lawnchair">
-        <item name="android:colorBackground">#ff121212</item>
-        <item name="android:windowLightStatusBar" >false</item>
-        <item name="android:windowLightNavigationBar" tools:ignore="NewApi">false</item>
-    </style>
-</resources>

--- a/lawnchair/res/values/themes.xml
+++ b/lawnchair/res/values/themes.xml
@@ -11,14 +11,14 @@
         <item name="android:colorBackground">@color/white_50</item>
     </style>
 
-    <style name="Base.Theme.MaterialThemeBuilder" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="Base.Theme.MaterialThemeBuilder" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:statusBarColor" tools:ignore="NewApi">?android:attr/colorBackground</item>
         <item name="android:windowLightStatusBar" tools:ignore="NewApi">true</item>
         <item name="android:navigationBarColor" tools:ignore="NewApi">?android:attr/colorBackground</item>
         <item name="android:windowLightNavigationBar" tools:ignore="NewApi">true</item>
     </style>
 
-    <style name="Theme.Transparent" parent="Theme.AppCompat.Light">
+    <style name="Theme.Transparent" parent="android:Theme.Material.Light">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowAnimationStyle">@null</item>
         <item name="android:windowBackground">@android:color/transparent</item>

--- a/lawnchair/src/app/lawnchair/BlankActivity.kt
+++ b/lawnchair/src/app/lawnchair/BlankActivity.kt
@@ -6,11 +6,11 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.ResultReceiver
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
@@ -28,7 +28,7 @@ import app.lawnchair.util.unsafeLazy
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 
-class BlankActivity : AppCompatActivity() {
+class BlankActivity : ComponentActivity() {
 
     private val resultReceiver by unsafeLazy { intent.getParcelableExtra<ResultReceiver>("callback")!! }
     private var resultSent = false
@@ -94,7 +94,7 @@ class BlankActivity : AppCompatActivity() {
                         resultReceiver.send(it.resultCode, it.data?.extras)
                         resultSent = true
                         finish()
-                    }.launch(intent.getParcelableExtra("intent"))
+                    }.launch(requireNotNull(intent.getParcelableExtra("intent")))
                 }
             }
             else -> {

--- a/lawnchair/src/app/lawnchair/smartspace/SmartspacePreferencesShortcut.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/SmartspacePreferencesShortcut.kt
@@ -1,11 +1,11 @@
 package app.lawnchair.smartspace
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.ComponentActivity
 import app.lawnchair.ui.preferences.PreferenceActivity
 import app.lawnchair.ui.preferences.navigation.Routes
 
-class SmartspacePreferencesShortcut : AppCompatActivity() {
+class SmartspacePreferencesShortcut : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/lawnchair/src/app/lawnchair/ui/preferences/PreferenceActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/PreferenceActivity.kt
@@ -19,16 +19,16 @@ package app.lawnchair.ui.preferences
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.core.net.toUri
 import app.lawnchair.ui.theme.EdgeToEdge
 import app.lawnchair.ui.theme.LawnchairTheme
 
-class PreferenceActivity : AppCompatActivity() {
+class PreferenceActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->



## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
