### PR TITLE
Improve Live Information (Announcements)

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -111,7 +111,7 @@ private fun AnnouncementItem(
         AnnouncementItemContent(
             text = announcement.text,
             url = announcement.url,
-            icon = announcement.iconImageVector,
+            icon = announcement.getIcon(),
             onClose = onClose,
         )
     }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -92,6 +93,7 @@ private fun AnnouncementItem(
         AnnouncementItemContent(
             text = announcement.text,
             url = announcement.url,
+            icon = announcement.iconImageVector,
             onClose = onClose,
         )
     }
@@ -101,6 +103,7 @@ private fun AnnouncementItem(
 private fun AnnouncementItemContent(
     text: String,
     url: String?,
+    icon: ImageVector,
     modifier: Modifier = Modifier,
     onClose: () -> Unit,
 ) {
@@ -149,7 +152,11 @@ private fun AnnouncementItemContent(
             shape = MaterialTheme.shapes.large,
             color = MaterialTheme.colorScheme.surfaceVariant,
         ) {
-            AnnouncementPreferenceItemContent(text = text, url = url)
+            AnnouncementPreferenceItemContent(
+                text = text,
+                url = url,
+                icon = icon,
+            )
         }
     }
 }
@@ -165,6 +172,7 @@ private fun calculateAlpha(progress: Float): Float {
 private fun AnnouncementPreferenceItemContent(
     text: String,
     url: String?,
+    icon: ImageVector,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -193,7 +201,7 @@ private fun AnnouncementPreferenceItemContent(
         },
         startWidget = {
             Icon(
-                imageVector = Icons.Rounded.NewReleases,
+                imageVector = icon,
                 tint = MaterialTheme.colorScheme.primary,
                 contentDescription = null,
             )
@@ -223,6 +231,7 @@ private fun InfoPreferenceWithoutLinkPreview() {
     AnnouncementPreferenceItemContent(
         text = "Very important announcement ",
         url = "",
+        icon = Icons.Rounded.NewReleases,
     )
 }
 
@@ -232,5 +241,6 @@ private fun InfoPreferenceWithLinkPreview() {
     AnnouncementPreferenceItemContent(
         text = "Very important announcement with a very important link",
         url = "https://lawnchair.app/",
+        icon = Icons.Rounded.NewReleases,
     )
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -81,12 +81,14 @@ fun AnnouncementPreference(
         modifier = modifier,
     ) {
         announcements.forEachIndexed { index, announcement ->
-            var show by rememberSaveable { mutableStateOf(true) }
-            AnnouncementItem(show, announcement) {
+            var notDismissed by rememberSaveable { mutableStateOf(true) }
+            val visible = announcement.shouldBeVisible && notDismissed
+
+            AnnouncementItem(visible, announcement) {
                 onDismiss(announcement)
-                show = false
+                notDismissed = false
             }
-            if (index != announcements.lastIndex && show) {
+            if (index != announcements.lastIndex && visible) {
                 Spacer(modifier = Modifier.height(16.dp))
             }
         }
@@ -95,14 +97,14 @@ fun AnnouncementPreference(
 
 @Composable
 private fun AnnouncementItem(
-    show: Boolean,
+    visible: Boolean,
     announcement: Announcement,
     modifier: Modifier = Modifier,
     onClose: () -> Unit,
 ) {
     ExpandAndShrink(
         modifier = modifier,
-        visible = show && announcement.shouldBeVisible,
+        visible = visible,
     ) {
         AnnouncementItemContent(
             text = announcement.text,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -81,12 +81,12 @@ fun AnnouncementPreference(
         modifier = modifier,
     ) {
         announcements.forEachIndexed { index, announcement ->
-            var notDismissed by rememberSaveable { mutableStateOf(true) }
-            val visible = announcement.shouldBeVisible && notDismissed
+            var dismissed by remember { mutableStateOf(false) }
+            val visible = announcement.shouldBeVisible && !dismissed
 
             AnnouncementItem(visible, announcement) {
                 onDismiss(announcement)
-                notDismissed = false
+                dismissed = true
             }
             if (index != announcements.lastIndex && visible) {
                 Spacer(modifier = Modifier.height(16.dp))

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -44,15 +44,11 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
 import app.lawnchair.ui.preferences.data.liveinfo.liveInformationManager
 import app.lawnchair.ui.preferences.data.liveinfo.model.Announcement
 import app.lawnchair.ui.util.addIf
-import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
-import kotlin.coroutines.CoroutineContext
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 @Composable
 fun AnnouncementPreference() {

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -45,9 +45,6 @@ import app.lawnchair.ui.preferences.data.liveinfo.liveInformationManager
 import app.lawnchair.ui.preferences.data.liveinfo.model.Announcement
 import app.lawnchair.ui.util.addIf
 import com.android.launcher3.R
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 @Composable
@@ -62,7 +59,7 @@ fun AnnouncementPreference() {
 
     if (enabled && showAnnouncements) {
         AnnouncementPreference(
-            announcements = liveInformation.announcements.filter { it.id !in dismissedAnnouncementIds }.toImmutableList(),
+            announcements = liveInformation.announcements.filter { it.id !in dismissedAnnouncementIds },
             onDismiss = { announcement ->
                 val dismissed = dismissedAnnouncementIds.toMutableSet().apply { add(announcement.id) }
                 coroutineScope.launch { liveInformationManager.dismissedAnnouncementIds.set(dismissed) }
@@ -73,7 +70,7 @@ fun AnnouncementPreference() {
 
 @Composable
 fun AnnouncementPreference(
-    announcements: ImmutableList<Announcement>,
+    announcements: List<Announcement>,
     onDismiss: (Announcement) -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -57,9 +58,11 @@ fun AnnouncementPreference() {
     val dismissedAnnouncementIds by liveInformationManager.dismissedAnnouncementIds.asState()
     val liveInformation by liveInformationManager.liveInformation.asState()
 
+    val announcements = remember { liveInformation.announcements.filter { it.id !in dismissedAnnouncementIds } }
+
     if (enabled && showAnnouncements) {
         AnnouncementPreference(
-            announcements = liveInformation.announcements.filter { it.id !in dismissedAnnouncementIds },
+            announcements = announcements,
             onDismiss = { announcement ->
                 val dismissed = dismissedAnnouncementIds.toMutableSet().apply { add(announcement.id) }
                 coroutineScope.launch { liveInformationManager.dismissedAnnouncementIds.set(dismissed) }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -87,9 +87,7 @@ private fun AnnouncementItem(
 ) {
     ExpandAndShrink(
         modifier = modifier,
-        visible = show && announcement.active &&
-            announcement.text.isNotBlank() &&
-            (!announcement.test || BuildConfig.DEBUG),
+        visible = show && announcement.shouldBeVisible,
     ) {
         AnnouncementItemContent(
             text = announcement.text,

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -45,14 +46,19 @@ import app.lawnchair.ui.preferences.data.liveinfo.model.Announcement
 import app.lawnchair.ui.util.addIf
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
+import kotlin.coroutines.CoroutineContext
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 @Composable
 fun AnnouncementPreference() {
     val liveInformationManager = liveInformationManager()
 
+    val coroutineScope = rememberCoroutineScope()
     val enabled by liveInformationManager.enabled.asState()
     val showAnnouncements by liveInformationManager.showAnnouncements.asState()
     val dismissedAnnouncementIds by liveInformationManager.dismissedAnnouncementIds.asState()
@@ -63,7 +69,7 @@ fun AnnouncementPreference() {
             announcements = liveInformation.announcements.filter { it.id !in dismissedAnnouncementIds }.toImmutableList(),
             onDismiss = { announcement ->
                 val dismissed = dismissedAnnouncementIds.toMutableSet().apply { add(announcement.id) }
-                runBlocking { liveInformationManager.dismissedAnnouncementIds.set(dismissed) }
+                coroutineScope.launch { liveInformationManager.dismissedAnnouncementIds.set(dismissed) }
             },
         )
     }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -80,7 +81,7 @@ fun AnnouncementPreference(
         modifier = modifier,
     ) {
         announcements.forEachIndexed { index, announcement ->
-            var dismissed by remember { mutableStateOf(false) }
+            var dismissed by rememberSaveable { mutableStateOf(false) }
             val visible = announcement.shouldBeVisible && !dismissed
 
             AnnouncementItem(visible, announcement) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationManager.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationManager.kt
@@ -10,6 +10,7 @@ import app.lawnchair.ui.preferences.data.liveinfo.model.LiveInformation
 import com.android.launcher3.R
 import com.android.launcher3.util.MainThreadInitializedObject
 import com.patrykmichalik.opto.core.PreferenceManager
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 class LiveInformationManager private constructor(context: Context) : PreferenceManager {
@@ -41,11 +42,28 @@ class LiveInformationManager private constructor(context: Context) : PreferenceM
     val liveInformation = preference(
         key = stringPreferencesKey(name = "live_information"),
         defaultValue = LiveInformation.default,
+        parse = { string ->
+            val withUnknownKeys = Json { ignoreUnknownKeys = true }
+            withUnknownKeys.decodeFromString<LiveInformation>(string)
+        },
+        save = { liveInformation ->
+            Json.encodeToString(
+                LiveInformation.serializer(),
+                liveInformation,
+            )
+        },
+    )
+
+    val dismissedAnnouncementIds = preference(
+        key = stringPreferencesKey(name = "dismissed_announcement_ids"),
+        defaultValue = emptySet(),
         parse = {
             val withUnknownKeys = Json { ignoreUnknownKeys = true }
-            withUnknownKeys.decodeFromString<LiveInformation>(it)
+            withUnknownKeys.decodeFromString<Set<Pair<String, String?>>>(it)
         },
-        save = { Json.encodeToString(LiveInformation.serializer(), it) },
+        save = {
+            Json.encodeToString(it)
+        },
     )
 }
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationManager.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationManager.kt
@@ -41,7 +41,10 @@ class LiveInformationManager private constructor(context: Context) : PreferenceM
     val liveInformation = preference(
         key = stringPreferencesKey(name = "live_information"),
         defaultValue = LiveInformation.default,
-        parse = { Json.decodeFromString<LiveInformation>(it) },
+        parse = {
+            val withUnknownKeys = Json { ignoreUnknownKeys = true }
+            withUnknownKeys.decodeFromString<LiveInformation>(it)
+        },
         save = { Json.encodeToString(LiveInformation.serializer(), it) },
     )
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationManager.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/LiveInformationManager.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import app.lawnchair.ui.preferences.data.liveinfo.model.AnnouncementId
 import app.lawnchair.ui.preferences.data.liveinfo.model.LiveInformation
 import com.android.launcher3.R
 import com.android.launcher3.util.MainThreadInitializedObject
@@ -59,7 +60,7 @@ class LiveInformationManager private constructor(context: Context) : PreferenceM
         defaultValue = emptySet(),
         parse = {
             val withUnknownKeys = Json { ignoreUnknownKeys = true }
-            withUnknownKeys.decodeFromString<Set<Pair<String, String?>>>(it)
+            withUnknownKeys.decodeFromString<Set<AnnouncementId>>(it)
         },
         save = {
             Json.encodeToString(it)

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
@@ -23,9 +23,9 @@ import kotlinx.serialization.Serializable
 data class Announcement(
     val text: String,
     val url: String? = null,
-    val active: Boolean = true,
-    val test: Boolean = false,
-    val channel: String? = null,
+    private val active: Boolean = true,
+    private val test: Boolean = false,
+    private val channel: String? = null,
     private val icon: String? = null,
 ) {
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
@@ -25,30 +25,29 @@ data class Announcement(
     val url: String? = null,
     val active: Boolean = true,
     val test: Boolean = false,
-    val icon: String? = null,
     val channel: String? = null,
+    private val icon: String? = null,
 ) {
 
     val id: AnnouncementId get() = text to url
 
-    val iconImageVector
-        get() = when (icon) {
-            "bug-report" -> Icons.Rounded.BugReport
-            "check-circle" -> Icons.Rounded.CheckCircle
-            "error" -> Icons.Rounded.Error
-            "favorite" -> Icons.Rounded.Favorite
-            "feedback" -> Icons.Rounded.Feedback
-            "forum" -> Icons.Rounded.Forum
-            "hub" -> Icons.Rounded.Hub
-            "loyalty" -> Icons.Rounded.Loyalty
-            "priority-high" -> Icons.Rounded.PriorityHigh
-            "privacy-tip" -> Icons.Rounded.PrivacyTip
-            "sos" -> Icons.Rounded.Sos
-            "star" -> Icons.Rounded.Star
-            "support" -> Icons.Rounded.Support
-            "warning" -> Icons.Rounded.Warning
-            else -> Icons.Rounded.NewReleases
-        }
+    fun getIcon() = when (icon) {
+        "bug-report" -> Icons.Rounded.BugReport
+        "check-circle" -> Icons.Rounded.CheckCircle
+        "error" -> Icons.Rounded.Error
+        "favorite" -> Icons.Rounded.Favorite
+        "feedback" -> Icons.Rounded.Feedback
+        "forum" -> Icons.Rounded.Forum
+        "hub" -> Icons.Rounded.Hub
+        "loyalty" -> Icons.Rounded.Loyalty
+        "priority-high" -> Icons.Rounded.PriorityHigh
+        "privacy-tip" -> Icons.Rounded.PrivacyTip
+        "sos" -> Icons.Rounded.Sos
+        "star" -> Icons.Rounded.Star
+        "support" -> Icons.Rounded.Support
+        "warning" -> Icons.Rounded.Warning
+        else -> Icons.Rounded.NewReleases
+    }
 
     val shouldBeVisible
         get(): Boolean {

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
@@ -1,5 +1,7 @@
 package app.lawnchair.ui.preferences.data.liveinfo.model
 
+import com.android.launcher3.BuildConfig
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -8,4 +10,15 @@ data class Announcement(
     val url: String? = null,
     val active: Boolean = true,
     val test: Boolean = false,
-)
+    @SerialName("flavor-channel") val flavorChannel: String? = null,
+) {
+
+    val shouldBeVisible
+        get(): Boolean {
+            if (active.not()) return false
+            if (text.isBlank()) return false
+            if (test && BuildConfig.DEBUG.not()) return false
+            if (flavorChannel != null && flavorChannel != BuildConfig.FLAVOR_channel) return false
+            return true
+        }
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
@@ -1,5 +1,21 @@
 package app.lawnchair.ui.preferences.data.liveinfo.model
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.BugReport
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Error
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.Feedback
+import androidx.compose.material.icons.rounded.Forum
+import androidx.compose.material.icons.rounded.Hub
+import androidx.compose.material.icons.rounded.Loyalty
+import androidx.compose.material.icons.rounded.NewReleases
+import androidx.compose.material.icons.rounded.PriorityHigh
+import androidx.compose.material.icons.rounded.PrivacyTip
+import androidx.compose.material.icons.rounded.Sos
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material.icons.rounded.Support
+import androidx.compose.material.icons.rounded.Warning
 import com.android.launcher3.BuildConfig
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -10,8 +26,27 @@ data class Announcement(
     val url: String? = null,
     val active: Boolean = true,
     val test: Boolean = false,
+    val icon: String? = null,
     @SerialName("flavor-channel") val flavorChannel: String? = null,
 ) {
+
+    val iconImageVector get() = when (icon) {
+        "bug-report" -> Icons.Rounded.BugReport
+        "check-circle" -> Icons.Rounded.CheckCircle
+        "error" -> Icons.Rounded.Error
+        "favorite" -> Icons.Rounded.Favorite
+        "feedback" -> Icons.Rounded.Feedback
+        "forum" -> Icons.Rounded.Forum
+        "hub" -> Icons.Rounded.Hub
+        "loyalty" -> Icons.Rounded.Loyalty
+        "priority-high" -> Icons.Rounded.PriorityHigh
+        "privacy-tip" -> Icons.Rounded.PrivacyTip
+        "sos" -> Icons.Rounded.Sos
+        "star" -> Icons.Rounded.Star
+        "support" -> Icons.Rounded.Support
+        "warning" -> Icons.Rounded.Warning
+        else -> Icons.Rounded.NewReleases
+    }
 
     val shouldBeVisible
         get(): Boolean {

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
@@ -29,7 +29,7 @@ data class Announcement(
     val channel: String? = null,
 ) {
 
-    val id get() = text to url
+    val id: AnnouncementId get() = text to url
 
     val iconImageVector
         get() = when (icon) {

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/Announcement.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.rounded.Star
 import androidx.compose.material.icons.rounded.Support
 import androidx.compose.material.icons.rounded.Warning
 import com.android.launcher3.BuildConfig
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -27,33 +26,36 @@ data class Announcement(
     val active: Boolean = true,
     val test: Boolean = false,
     val icon: String? = null,
-    @SerialName("flavor-channel") val flavorChannel: String? = null,
+    val channel: String? = null,
 ) {
 
-    val iconImageVector get() = when (icon) {
-        "bug-report" -> Icons.Rounded.BugReport
-        "check-circle" -> Icons.Rounded.CheckCircle
-        "error" -> Icons.Rounded.Error
-        "favorite" -> Icons.Rounded.Favorite
-        "feedback" -> Icons.Rounded.Feedback
-        "forum" -> Icons.Rounded.Forum
-        "hub" -> Icons.Rounded.Hub
-        "loyalty" -> Icons.Rounded.Loyalty
-        "priority-high" -> Icons.Rounded.PriorityHigh
-        "privacy-tip" -> Icons.Rounded.PrivacyTip
-        "sos" -> Icons.Rounded.Sos
-        "star" -> Icons.Rounded.Star
-        "support" -> Icons.Rounded.Support
-        "warning" -> Icons.Rounded.Warning
-        else -> Icons.Rounded.NewReleases
-    }
+    val id get() = text to url
+
+    val iconImageVector
+        get() = when (icon) {
+            "bug-report" -> Icons.Rounded.BugReport
+            "check-circle" -> Icons.Rounded.CheckCircle
+            "error" -> Icons.Rounded.Error
+            "favorite" -> Icons.Rounded.Favorite
+            "feedback" -> Icons.Rounded.Feedback
+            "forum" -> Icons.Rounded.Forum
+            "hub" -> Icons.Rounded.Hub
+            "loyalty" -> Icons.Rounded.Loyalty
+            "priority-high" -> Icons.Rounded.PriorityHigh
+            "privacy-tip" -> Icons.Rounded.PrivacyTip
+            "sos" -> Icons.Rounded.Sos
+            "star" -> Icons.Rounded.Star
+            "support" -> Icons.Rounded.Support
+            "warning" -> Icons.Rounded.Warning
+            else -> Icons.Rounded.NewReleases
+        }
 
     val shouldBeVisible
         get(): Boolean {
             if (active.not()) return false
             if (text.isBlank()) return false
             if (test && BuildConfig.DEBUG.not()) return false
-            if (flavorChannel != null && flavorChannel != BuildConfig.FLAVOR_channel) return false
+            if (channel != null && channel != BuildConfig.FLAVOR_channel) return false
             return true
         }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/AnnouncementId.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/AnnouncementId.kt
@@ -1,0 +1,3 @@
+package app.lawnchair.ui.preferences.data.liveinfo.model
+
+typealias AnnouncementId = Pair<String, String?>

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/LiveInformation.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/LiveInformation.kt
@@ -4,12 +4,13 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LiveInformation(
-    private val version: Int = 1,
+    private val version: Int = 2,
     val announcements: List<Announcement>,
 ) {
+
     companion object {
         val default = LiveInformation(
-            version = 1,
+            version = 2,
             announcements = emptyList(),
         )
     }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DebugMenuPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DebugMenuPreferences.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.datastore.preferences.core.Preferences
+import androidx.lifecycle.LifecycleCoroutineScope
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
@@ -18,9 +19,14 @@ import app.lawnchair.ui.preferences.components.controls.SwitchPreference
 import app.lawnchair.ui.preferences.components.controls.TextPreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
+import app.lawnchair.ui.preferences.data.liveinfo.liveInformationManager
+import app.lawnchair.ui.preferences.data.liveinfo.model.LiveInformation
 import com.android.launcher3.settings.SettingsActivity
 import com.android.launcher3.uioverrides.flags.DeveloperOptionsFragment
 import com.patrykmichalik.opto.domain.Preference
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 /**
  * A screen to house unfinished preferences and debug flags
@@ -31,6 +37,7 @@ fun DebugMenuPreferences(
 ) {
     val prefs = preferenceManager()
     val prefs2 = preferenceManager2()
+    val liveInfoManager = liveInformationManager()
     val flags = remember { prefs.debugFlags }
     val flags2 = remember { prefs2.debugFlags }
     val textFlags = remember { prefs2.textFlags }
@@ -59,6 +66,15 @@ fun DebugMenuPreferences(
                 ClickablePreference(
                     label = "Crash launcher",
                     onClick = { throw RuntimeException("User triggered crash") },
+                )
+                ClickablePreference(
+                    label = "Reset live information",
+                    onClick = {
+                        runBlocking {
+                            liveInfoManager.liveInformation.set(LiveInformation.default)
+                            liveInfoManager.dismissedAnnouncementIds.set(emptySet())
+                        }
+                    },
                 )
             }
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DebugMenuPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DebugMenuPreferences.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.datastore.preferences.core.Preferences
-import androidx.lifecycle.LifecycleCoroutineScope
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
@@ -24,8 +23,6 @@ import app.lawnchair.ui.preferences.data.liveinfo.model.LiveInformation
 import com.android.launcher3.settings.SettingsActivity
 import com.android.launcher3.uioverrides.flags.DeveloperOptionsFragment
 import com.patrykmichalik.opto.domain.Preference
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 /**


### PR DESCRIPTION
## Description

Multiple improvements for Announcements (Live Information) feature:
- The announcement dismissals are now persistent 
- The ability to set custom icon for each announcement
- The ability to set custom channel target for each announcement
- The unknown keys will now be ignored when decoding

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
