### PR TITLE
Made show scrollbar setting stick after opening search

### DIFF
--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -178,6 +178,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
      * state.
      */
     private boolean mIsSearching;
+    boolean showFastScroller;
     private boolean mRebindAdaptersAfterSearchAnimation;
     private int mNavBarScrimHeight = 0;
     public SearchRecyclerView mSearchRecyclerView;
@@ -259,7 +260,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
      * onFinishInflate -> onPostCreate
      */
     protected void initContent() {
-        boolean showFastScroller = PreferenceExtensionsKt.firstBlocking(pref2.getShowScrollbar());
+        showFastScroller = PreferenceExtensionsKt.firstBlocking(pref2.getShowScrollbar());
         
         mMainAdapterProvider = mSearchUiDelegate.createMainAdapterProvider();
 
@@ -409,6 +410,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
         } else if (mAllAppsTransitionController != null) {
             // If exiting search, revert predictive back scale on all apps
             mAllAppsTransitionController.animateAllAppsToNoScale();
+            //mFastScroller.setVisibility(showFastScroller ? VISIBLE : INVISIBLE);
         }
         mSearchTransitionController.animateToSearchState(goingToSearch, durationMs,
                 /* onEndRunnable = */ () -> {

--- a/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
+++ b/src/com/android/launcher3/allapps/ActivityAllAppsContainerView.java
@@ -410,7 +410,7 @@ public class ActivityAllAppsContainerView<T extends Context & ActivityContext>
         } else if (mAllAppsTransitionController != null) {
             // If exiting search, revert predictive back scale on all apps
             mAllAppsTransitionController.animateAllAppsToNoScale();
-            //mFastScroller.setVisibility(showFastScroller ? VISIBLE : INVISIBLE);
+            mFastScroller.setVisibility(showFastScroller ? VISIBLE : INVISIBLE);
         }
         mSearchTransitionController.animateToSearchState(goingToSearch, durationMs,
                 /* onEndRunnable = */ () -> {


### PR DESCRIPTION
## Description

The scrollbar setting should now stick even after opening the search

Fixes #4715

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
