### PR TITLE
Fix floating point arithmetic error

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderPreference.kt
@@ -140,9 +140,9 @@ fun getSteps(valueRange: ClosedFloatingPointRange<Float>, step: Float): Int {
     if (step == 0f) return 0
     val start = valueRange.start.toBigDecimal()
     val end = valueRange.endInclusive.toBigDecimal()
-    val test = (end - start) / step.toBigDecimal()
-    val steps = test.toInt()
-    require(test.compareTo(steps.toBigDecimal()) == 0) {
+    val decimalSteps = (end - start) / step.toBigDecimal()
+    val steps = decimalSteps.toInt()
+    require(decimalSteps.compareTo(steps.toBigDecimal()) == 0) {
         "value range must be a multiple of step"
     }
     return steps - 1

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/controls/SliderPreference.kt
@@ -138,10 +138,11 @@ fun SliderPreference(
 
 fun getSteps(valueRange: ClosedFloatingPointRange<Float>, step: Float): Int {
     if (step == 0f) return 0
-    val start = valueRange.start
-    val end = valueRange.endInclusive
-    val steps = ((end - start) / step).toInt()
-    require(start + step * steps == end) {
+    val start = valueRange.start.toBigDecimal()
+    val end = valueRange.endInclusive.toBigDecimal()
+    val test = (end - start) / step.toBigDecimal()
+    val steps = test.toInt()
+    require(test.compareTo(steps.toBigDecimal()) == 0) {
         "value range must be a multiple of step"
     }
     return steps - 1


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
Fixes root cause of this crash: https://github.com/LawnchairLauncher/lawnchair/issues/4663#issuecomment-2308932350
Floating point arithmetic rounding causes error in comparison when checking a UI slider's range/steps.

Crash was avoided by changing lower range of slider to 0.3f but using a value of 0.2f causes the app to crash.
Changing a different slider's range value could potentially cause a similar crash in the future so fixing the root cause of the problem is necessary.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
