### PR TITLE
Fix calculator search precision and rounding errors

### DIFF
--- a/lawnchair/src/app/lawnchair/search/adapter/SearchTargetFactory.kt
+++ b/lawnchair/src/app/lawnchair/search/adapter/SearchTargetFactory.kt
@@ -37,6 +37,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.security.MessageDigest
 import java.util.Locale
+import java.util.UUID
 import okio.ByteString
 
 class SearchTargetFactory(
@@ -93,7 +94,8 @@ class SearchTargetFactory(
     ): SearchTargetCompat {
         val result = calculation.result
         val equation = calculation.equation
-        val id = "calculator:$result"
+        val uuid = UUID.randomUUID().toString()
+        val id = "calculator:$uuid"
         val action = SearchActionCompat.Builder(id, result)
             .setIcon(
                 Icon.createWithResource(context, R.drawable.calculator)

--- a/lawnchair/src/app/lawnchair/search/algorithms/data/Calculation.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/data/Calculation.kt
@@ -1,6 +1,8 @@
 package app.lawnchair.search.algorithms.data
 
 import app.lawnchair.search.algorithms.data.calculator.Expressions
+import java.math.BigDecimal
+import java.math.MathContext
 
 data class Calculation(
     val equation: String,
@@ -12,9 +14,17 @@ fun calculateEquationFromString(
     query: String,
 ): Calculation {
     return try {
-        val result = Expressions()
-            .eval(query)
-            .toString()
+        val evaluatedValue = Expressions().eval(query)
+        val roundedValue = evaluatedValue.round(MathContext.DECIMAL64)
+        val formattedValue = roundedValue.stripTrailingZeros()
+        val absoluteValue = formattedValue.abs()
+        val threshold = BigDecimal("9999999999999999")
+
+        val result = if (absoluteValue.compareTo(threshold) > 0) {
+            formattedValue.toString()
+        } else {
+            formattedValue.toPlainString()
+        }
 
         Calculation(
             equation = query,

--- a/lawnchair/src/app/lawnchair/search/algorithms/data/Calculation.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/data/Calculation.kt
@@ -20,7 +20,7 @@ fun calculateEquationFromString(
         val absoluteValue = formattedValue.abs()
         val threshold = BigDecimal("9999999999999999")
 
-        val result = if (absoluteValue.compareTo(threshold) > 0) {
+        val result = if (absoluteValue > threshold) {
             formattedValue.toString()
         } else {
             formattedValue.toPlainString()

--- a/lawnchair/src/app/lawnchair/search/algorithms/data/calculator/Expressions.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/data/calculator/Expressions.kt
@@ -18,8 +18,8 @@ class Expressions {
     private val evaluator = Evaluator()
 
     init {
-        define("pi", Math.PI)
-        define("e", Math.E)
+        define("pi", BigDecimal(Math.PI).setScale(33, RoundingMode.HALF_EVEN))
+        define("e", BigDecimal(Math.E).setScale(33, RoundingMode.HALF_EVEN))
 
         evaluator.addFunction("abs") { arguments ->
             if (arguments.size != 1) {

--- a/lawnchair/src/app/lawnchair/search/algorithms/data/calculator/internal/Evaluator.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/data/calculator/internal/Evaluator.kt
@@ -23,7 +23,7 @@ import java.util.Locale
 import kotlin.math.pow
 
 internal class Evaluator : ExprVisitor<BigDecimal> {
-    internal var mathContext: MathContext = MathContext.DECIMAL64
+    internal var mathContext: MathContext = MathContext.DECIMAL128
 
     private val variables: LinkedHashMap<String, BigDecimal> = linkedMapOf()
     private val functions: MutableMap<String, Function> = mutableMapOf()


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
Fixes calculator search result precision and rounding errors.

Previously:
- pi*0 = 0E-15
- pi*1.000 = 3.141592653589793000
- 2.0*6.0 = 6.00
- 1/3*3 = 0.9999999999999999

This PR fixes such issues, now resulting in:
- pi*0 = 0
- pi*1.000 = 3.141592653589793
- 2.0*6.0 = 6
- 1/3*3 = 1

Fixes #4756 <!-- optional -->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
