### PR TITLE
Fix compiler warning regarding string substitution

### DIFF
--- a/lawnchair/res/values-af-rZA/strings.xml
+++ b/lawnchair/res/values-af-rZA/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-am-rET/strings.xml
+++ b/lawnchair/res/values-am-rET/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-ar-rSA/strings.xml
+++ b/lawnchair/res/values-ar-rSA/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">لقفل هاتفك عند تنفيذ إيماءة، يتطلب Lawnchair الوصول إلى إمكانية الوصول.\n\nLawnchair لا يراقب أي إجراء للمستخدم، رغم أن الصلاحية للقيام بذلك مطلوبة لجميع خدمات إمكانية الوصول. يقوم Lawnchair بالتخلص من أي حدث يتم إرساله بواسطة النظام.\n\nلقفل هاتفك، يستخدم Lawnchair خدمة إمكانية الوصول لتنفيذ الإجراء العالمي.</string>
     <string name="x_by_y">18. %1$d x %2$d</string>
-    <string name="x_and_y">19. %s &amp; %s</string>
+    <string name="x_and_y">19. %1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-az-rAZ/strings.xml
+++ b/lawnchair/res/values-az-rAZ/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-b+sr+Latn/strings.xml
+++ b/lawnchair/res/values-b+sr+Latn/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Da biste zaključali uređaj pokretom potrebno je da dodelite Lawnchairu pristup usluzi pristupačnosti.\n\nLawnchair ne nadgleda korisničke radnje, ali je privilegija za to potrebna svim uslugama pristupačnosti. Lawnchair odbacuje sve događaje koje pošalje sistem.\n\nKako bi zaključao uređaj, Lawnchair koristi uslugu pristupačnosti performGlobalAction.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s i %s</string>
+    <string name="x_and_y">%1$s i %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-bn-rBD/strings.xml
+++ b/lawnchair/res/values-bn-rBD/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">জেসচারের মাধ্যমে ফোন লক করার জন্য Lawnchair এর এক্সেসিবিলিটি এক্সেস প্রয়োজন।\n\nLawnchair ব্যবহারকারীদের কর্মকান্ডে কোন নজরদারি করে না, যদিও এক্সেসিবিলিটি সার্ভিসের জন্য এই ক্ষমতা প্রয়োজন। সিস্টেম কর্তৃক পাঠানো যেকোন কিছু Lawnchair সংরক্ষণ করবে না।\n\nLawnchair ফোন লক করার জন্য performGlobalAction এক্সেসিবিলিটি সার্ভিস ব্যবহার করে।</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-bs-rBA/strings.xml
+++ b/lawnchair/res/values-bs-rBA/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-ca-rES/strings.xml
+++ b/lawnchair/res/values-ca-rES/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-cs-rCZ/strings.xml
+++ b/lawnchair/res/values-cs-rCZ/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">K uzamčení telefonu při provádění gesta vyžaduje Lawnchair přístup k usnadnění.\n\nLawnchair nesleduje žádnou akci uživatele, ačkoli oprávnění k tomu je vyžadováno pro všechny služby usnadnění. Lawnchair zahodí jakoukoli událost odeslanou systémem.\n\nAby byl váš telefon uzamčen, používá Lawnchair službu usnadnění performGlobalAction.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-da-rDK/strings.xml
+++ b/lawnchair/res/values-da-rDK/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-de-rDE/strings.xml
+++ b/lawnchair/res/values-de-rDE/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Um Dein Gerät mit einer Geste zu sperren, benötigt Lawnchair Bedienungshilfen-Zugriff.\n\nLawnchair beobachtet keine Nutzeraktionen, auch wenn die Bedienungshilfen dies ermöglichen würden. Lawnchair verwirft alle vom System gesendeten Ereignisse.\n\nUm Dein Gerät zu sperren, verwendet Lawnchair den performGlobalAction-Dienst.</string>
     <string name="x_by_y">%1$d × %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-el-rGR/strings.xml
+++ b/lawnchair/res/values-el-rGR/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Για να κλειδώσετε το τηλέφωνό σας όταν εκτελείτε μια χειρονομία, το εκκινητής Lawnchair απαιτεί πρόσβαση στην προσβασιμότητα.\n\nΟ Lawnchair δεν παρακολουθεί καμία ενέργεια χρήστη, αν και το προνόμιο να το κάνει αυτό απαιτείται για όλες τις υπηρεσίες προσβασιμότητας. Ο Lawnchair απορρίπτει οποιοδήποτε συμβάν αποστέλλεται από το σύστημα.\n\nΓια να κλειδώσετε το τηλέφωνό σας, ο εκκινητής Lawnchair χρησιμοποιεί την υπηρεσία προσβασιμότητας performGlobalAction.</string>
     <string name="x_by_y">%1$d × %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-en-rCA/strings.xml
+++ b/lawnchair/res/values-en-rCA/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-es-rES/strings.xml
+++ b/lawnchair/res/values-es-rES/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Para bloquear su teléfono al realizar un gesto, Lawnchair requiere acceso de accesibilidad.\n\nLawnchair no observará ninguna acción del usuario, aunque se requiere el privilegio de hacerlo para todos los servicios de accesibilidad. Lawnchair descarta cualquier evento enviado por el sistema.\n\nPara bloquear su teléfono, Lawnchair utiliza el servicio de accesibilidad performGlobalAction.</string>
     <string name="x_by_y"></string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-et-rEE/strings.xml
+++ b/lawnchair/res/values-et-rEE/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-fi-rFI/strings.xml
+++ b/lawnchair/res/values-fi-rFI/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-fil-rPH/strings.xml
+++ b/lawnchair/res/values-fil-rPH/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-fr-rFR/strings.xml
+++ b/lawnchair/res/values-fr-rFR/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Pour pouvoir verrouiller votre téléphone en un seul geste, Lawnchair a besoin des droits d\'accessibilité.\n\nLawnchair n\'observe aucune action utilisateur, mais ce privilège est accordé à tous les services d\'accessibilité. Lawnchair rejette tout événement envoyé par le système.\n\nAfin de verrouiller votre téléphone, Lawnchair utilise le service d\'accessibilité performGlobalAction.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s et %s</string>
+    <string name="x_and_y">%1$s et %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-gl-rES/strings.xml
+++ b/lawnchair/res/values-gl-rES/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-hi-rIN/strings.xml
+++ b/lawnchair/res/values-hi-rIN/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-hr-rHR/strings.xml
+++ b/lawnchair/res/values-hr-rHR/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-hu-rHU/strings.xml
+++ b/lawnchair/res/values-hu-rHU/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">A kézmozdulattal való telefonlezáráshoz a Lawnchairnek akadálymentesítési engedélyre van szüksége\n\nA Lawnchair nem figyel semmilyen felhasználói műveletet, az ehhez szükséges jogosultság minden akadálymentesítési szolgáltatáshoz szükséges. A Lawnchair figyelmen kívül hagyja az összes, rendszer által küldött eseményt.\n\nA telefon zárolásához a Lawnchair a „performGlobalAction” akadálymentesítési szolgáltatást használja.</string>
     <string name="x_by_y">%1$d × %2$d</string>
-    <string name="x_and_y">%s és %s</string>
+    <string name="x_and_y">%1$s és %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-in-rID/strings.xml
+++ b/lawnchair/res/values-in-rID/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Untuk mengunci ponsel Anda saat melakukan gerakan, Lawnchair memerlukan akses aksesibilitas.\n\nLawnchair tidak mengawasi tindakan pengguna apa pun, meskipun hak istimewa untuk melakukannya diperlukan untuk semua layanan aksesibilitas. Lawnchair membuang acara apa pun yang dikirim oleh sistem.\n\nUntuk mengunci ponsel Anda, Lawnchair menggunakan layanan aksesibilitas performGlobalAction.</string>
     <string name="x_by_y">%1$d × %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-it-rIT/strings.xml
+++ b/lawnchair/res/values-it-rIT/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Per bloccare il telefono quando si esegue un gesto, Lawnchair richiede l\'accesso all\'accessibilità.\n\nLawnchair non osserva alcuna azione dell\'utente, anche se il privilegio di farlo è richiesto per tutti i servizi di accessibilità. Lawnchair scarta qualsiasi evento inviato dal sistema.\n\nPer bloccare il telefono, Lawnchair utilizza il servizio di accessibilità performGlobalAction.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-ja-rJP/strings.xml
+++ b/lawnchair/res/values-ja-rJP/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d × %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-ka-rGE/strings.xml
+++ b/lawnchair/res/values-ka-rGE/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">თქვენი ტელეფონის დაბლოკვის ჟესტისთვის, Lawnchair საჭიროებს Accessibility წვდომას.\n\nLawnchair არ უთვალთვალებს მომხმარებლის ნებისმიერ მოქმედებას, თუმცა ამის პრივილეგია საჭიროა ყველა ხელმისაწვდომი სერვისისთვის. Lawnchair უგულებელყოფს სისტემის მიერ გაგზავნილ ნებისმიერ მოვლენას.\n\nთქვენი ტელეფონის დაბლოკვის მიზნით, Lawnchair იყენებს performGlobalAction Accessibility სერვისს.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-kmr-rTR/strings.xml
+++ b/lawnchair/res/values-kmr-rTR/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-ko-rKR/strings.xml
+++ b/lawnchair/res/values-ko-rKR/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">제스처를 수행할 때 휴대폰을 잠그려면 접근성 액세스 권한이 필요합니다.\n\nLawnchair는 모든 접근성 서비스를 위해 필요한 권한이지만 사용자 동작을 감시하지 않습니다. Lawnchair는 시스템에서 보낸 모든 이벤트를 삭제합니다.\n\nLawnchair는 휴대전화를 잠그기 위해 performGlobalAction 접근성 서비스를 사용합니다.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-lt-rLT/strings.xml
+++ b/lawnchair/res/values-lt-rLT/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Norint užrakinti telefoną gestu, \"Lawnchair\" reikia suteikti leidimą prieinamumo nustatymams.\n\n\"Lawnchair\" nestebi jūsų veiksmų, tačiau toks leidimas reikalingas visoms prieinamumo paslaugoms. \"Lawnchair\" atmeta bet kokį sistemos siunčiamą įvykį.\n\nTelefono užrakinimui \"Lawnchair\" naudoja prieinamumo paslaugą \"performGlobalAction\".</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-ml-rIN/strings.xml
+++ b/lawnchair/res/values-ml-rIN/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-mr-rIN/strings.xml
+++ b/lawnchair/res/values-mr-rIN/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-nl-rNL/strings.xml
+++ b/lawnchair/res/values-nl-rNL/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Om je telefoon te vergrendelen bij het uitvoeren van een gebaar, heeft Lawnchair toegang tot toegankelijkheid nodig.\n\nLawnchair kijkt niet naar gebruikersacties, hoewel het voorrecht om dit te doen vereist is voor alle toegankelijkheidsdiensten. Lawnchair negeert elke gebeurtenis die door het systeem wordt gemeld.\n\nOm je telefoon te vergrendelen, gebruikt Lawnchair de performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-no-rNO/strings.xml
+++ b/lawnchair/res/values-no-rNO/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-pl-rPL/strings.xml
+++ b/lawnchair/res/values-pl-rPL/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Aby zablokować telefon podczas wykonywania gestu, Lawnchair wymaga dostępu do aplikacji.\n\nLawnchair nie obserwuje żadnych działań użytkownika, chociaż uprawnienie do tego jest wymagane dla wszystkich usług dostępności. Lawnchair odrzuca każde zdarzenie wysłane przez system.\n\nAby zablokować telefon, Lawnchair korzysta z usługi ułatwienia dostępu performGlobalAction.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s i %s</string>
+    <string name="x_and_y">%1$s i %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-pt-rBR/strings.xml
+++ b/lawnchair/res/values-pt-rBR/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Para bloquear seu celular ao executar um gesto, O Lawnchair precisa do acesso à acessibilidade.\n\nO Lawnchair não observa qualquer ação do usuário, porém esta permissão é necessária para todos os serviços de acessibilidade. O Lawnchair descarta qualquer evento enviado pelo sistema.\n\nPara bloquear seu dispositivo, o Lawnchair usa o serviço de acessibilidade \"performGlobalAction\".</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-pt-rPT/strings.xml
+++ b/lawnchair/res/values-pt-rPT/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-ro-rRO/strings.xml
+++ b/lawnchair/res/values-ro-rRO/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-ru-rRU/strings.xml
+++ b/lawnchair/res/values-ru-rRU/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Чтобы заблокировать телефон с помощью жеста, Lawnchair требуется доступ к специальным возможностям.\n\nLawnchair не отслеживает никакие действия пользователя, хотя это требуется для всех служб специальных возможностей. Lawnchair отбрасывает любые события, отправленные системой.\n\nЧтобы заблокировать ваш телефон, Lawnchair использует службу специальных возможностей PerformGlobalAction.</string>
     <string name="x_by_y">%1$d × %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-sk-rSK/strings.xml
+++ b/lawnchair/res/values-sk-rSK/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Na uzamknutie telefónu pri vykonávaní gesta vyžaduje aplikácia Lawnchair prístup k funkciám prístupnosti.\n\nLawnchair nesleduje žiadnu činnosť používateľa, hoci oprávnenie na to sa vyžaduje pre všetky služby prístupnosti. Služba Lawnchair zahodí akúkoľvek udalosť odoslanú systémom.\n\nNa uzamknutie telefónu používa služba sprístupnenia performGlobalAction.</string>
     <string name="x_by_y">%1$d × %2$d</string>
-    <string name="x_and_y">%s a %s</string>
+    <string name="x_and_y">%1$s a %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-sl-rSI/strings.xml
+++ b/lawnchair/res/values-sl-rSI/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-sq-rAL/strings.xml
+++ b/lawnchair/res/values-sq-rAL/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s&amp;%s</string>
+    <string name="x_and_y">%1$s&amp;%2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-sr/strings.xml
+++ b/lawnchair/res/values-sr/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Да бисте закључали уређај покретом потребно је да доделите Lawnchair-у приступ услузи приступачности.\n\nLawnchair не надгледа корисничке радње, али је привилегија за то потребна свим услугама приступачности. Lawnchair одбацује све догађаје које пошаље систем.\n\nКако би закључао уређај, Lawnchair користи услугу приступачности performGlobalAction.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s и %s</string>
+    <string name="x_and_y">%1$s и %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-sv-rSE/strings.xml
+++ b/lawnchair/res/values-sv-rSE/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">För att kunna låsa din telefon när en gest görs kräver Lawnchair tillgänglighetsåtkomst.\n\nLawnchair övervakar inte några användaraktiviteter, men behörigheten att göra detta krävs för alla tillgänglighetstjänster. Lawnchair förkastar alla händelser som skickas av systemet.\n\nFör att kunna låsa din telefon använder Lawnchair tillgänglighetstjänsten performGlobalAction.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-sw-rKE/strings.xml
+++ b/lawnchair/res/values-sw-rKE/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-sw/strings.xml
+++ b/lawnchair/res/values-sw/strings.xml
@@ -397,5 +397,5 @@
     <string name="backup_restore_error">Imeshindwa kuunda nakala.</string>
     <string name="invalid_backup_file">Faili ya kuhifadhi nakala si sahihi.</string>
     <string name="x_by_y">%1$d × %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
 </resources>

--- a/lawnchair/res/values-ta-rIN/strings.xml
+++ b/lawnchair/res/values-ta-rIN/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">சைகையைச் செய்யும்போது உங்கள் தொலைபேசியைப் பூட்ட, Lawnchair க்கு அணுகல்தன்மை அணுகல் தேவைப்படுகிறது.\n\nலான்ச்சர் எந்தவொரு பயனர் செயலையும் பார்ப்பதில்லை, இருப்பினும் அனைத்து அணுகல் சேவைகளுக்கும் அவ்வாறு செய்வதற்கான சிறப்புரிமை தேவைப்படுகிறது. கணினியால் அனுப்பப்பட்ட எந்த நிகழ்வையும் லான்ச்சர் நிராகரிக்கிறது.\n\nஉங்கள் தொலைபேசியைப் பூட்டுவதற்கு, லான்ச்சர் performGlobalAction அணுகல் சேவையைப் பயன்படுத்துகிறது.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-te-rIN/strings.xml
+++ b/lawnchair/res/values-te-rIN/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-th-rTH/strings.xml
+++ b/lawnchair/res/values-th-rTH/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-tr-rTR/strings.xml
+++ b/lawnchair/res/values-tr-rTR/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Telefonunuzu kilitlemek için gesture kullanılırken, Lawnchair erişilebilirlik ayarlarınıza ihtiyaç duyar.\n\nLawnchair, erişilebilirlik servisleri izin verse bile kullanıcı hareketlerini izlemez. Lawnchair sistem tarafından gönderilen herhangi bir event\'i izlemez.\n\nLawnchair, telefonunuzu kilitlemek için performGlobalAction Accessibility servisini kullanır.</string>
     <string name="x_by_y">%1$dx%2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-uk-rUA/strings.xml
+++ b/lawnchair/res/values-uk-rUA/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Для блокування телефону під час виконання жесту, Lawnchair потрібен доступ до дозволу.\n\nLawnchair не відстежує будь-які дії користувача, хоча привілей для цього є необхідними для всіх спеціальних служб підтримки. Lawnchair кидає будь-яку подію, яку надіслала система.\n\nщоб заблокувати ваш телефон, Lawnchair використовує службу додаткових спеціальних можливостей GlobalAction.</string>
     <string name="x_by_y">%1$d × %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-ur-rIN/strings.xml
+++ b/lawnchair/res/values-ur-rIN/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-ur-rPK/strings.xml
+++ b/lawnchair/res/values-ur-rPK/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-uz-rUZ/strings.xml
+++ b/lawnchair/res/values-uz-rUZ/strings.xml
@@ -74,7 +74,7 @@
     <string name="accessibility_service_description">Imo-ishorani bajarayotganda telefoningizni qulflash uchun Lawnchair maxsus imkoniyatlarga kirishni talab qiladi.\n\nLawnchair hech qanday foydalanuvchi harakatini kuzatmaydi, lekin bu imtiyoz barcha maxsus imkoniyatlar xizmatlari uchun talab qilinadi.
 Lawnchair tizim tomonidan yuborilgan har qanday hodisani bekor qiladi.\n\nTelefoningizni qulflash uchun Lawnchair Global Action Accessibility xizmatidan foydalanadi.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-vi-rVN/strings.xml
+++ b/lawnchair/res/values-vi-rVN/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, Lawnchair uses the performGlobalAction Accessibility service.</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-zh-rCN/strings.xml
+++ b/lawnchair/res/values-zh-rCN/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">需要给予 Lawnchair 无障碍权限以使用手势锁屏。\n\nLawnchair 不会获取屏幕内容和用户操作，即使此权限允许这样做，Lawnchair 不接收任何输入。\n\nLawnchair 使用 performGlobalAction 服务来锁屏。</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values-zh-rTW/strings.xml
+++ b/lawnchair/res/values-zh-rTW/strings.xml
@@ -73,7 +73,7 @@
     <!-- A11y description -->
     <string name="accessibility_service_description">Lawnchair 需要無障礙設定存取權來啟用手勢鎖定螢幕。\n\n由於權限所需，系統可能提示您授予畫面權限，但請放心，Lawnchair 不會監看、存取您的畫面。\n\nLawnchair 使用 performGlobalAction 無障礙服務來鎖定您的裝置。</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -94,7 +94,7 @@
 
     <string name="n_percent" translatable="false">%1$d%%</string>
     <string name="x_by_y">%1$d x %2$d</string>
-    <string name="x_and_y">%s &amp; %s</string>
+    <string name="x_and_y">%1$s &amp; %2$s</string>
     <!--
 
     Preference Dashboard


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
Fix compiler warning regarding string substitution in _strings.xml_.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
