### PR TITLE
Restore AppCompat themes for some material components

### DIFF
--- a/lawnchair/res/values-night/themes.xml
+++ b/lawnchair/res/values-night/themes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.Lawnchair" parent="Base.Theme.Lawnchair">
+        <item name="android:colorBackground">#ff121212</item>
+        <item name="android:windowLightStatusBar" >false</item>
+        <item name="android:windowLightNavigationBar" tools:ignore="NewApi">false</item>
+    </style>
+</resources>

--- a/lawnchair/res/values/themes.xml
+++ b/lawnchair/res/values/themes.xml
@@ -11,14 +11,14 @@
         <item name="android:colorBackground">@color/white_50</item>
     </style>
 
-    <style name="Base.Theme.MaterialThemeBuilder" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Base.Theme.MaterialThemeBuilder" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:statusBarColor" tools:ignore="NewApi">?android:attr/colorBackground</item>
         <item name="android:windowLightStatusBar" tools:ignore="NewApi">true</item>
         <item name="android:navigationBarColor" tools:ignore="NewApi">?android:attr/colorBackground</item>
         <item name="android:windowLightNavigationBar" tools:ignore="NewApi">true</item>
     </style>
 
-    <style name="Theme.Transparent" parent="android:Theme.Material.Light">
+    <style name="Theme.Transparent" parent="Theme.AppCompat.Light">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowAnimationStyle">@null</item>
         <item name="android:windowBackground">@android:color/transparent</item>


### PR DESCRIPTION
## Description

We still rely on them for using material views.

- Closes #4807.
- Reverts part of #4554.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
