### PR TITLE
Fix typo in Catalan translation

### DIFF
--- a/lawnchair/res/values-ca-rES/strings.xml
+++ b/lawnchair/res/values-ca-rES/strings.xml
@@ -254,7 +254,7 @@
 
     -->
     <!-- Date formats -->
-    <string name="smartspace_calendar_gregorian">Georgià</string>
+    <string name="smartspace_calendar_gregorian">Gregorià</string>
     <string name="smartspace_calendar_persian">Persa</string>
     <string name="generic_smartspace_concatenated_desc">%1$s, %2$s</string>
     <!-- Battery labels -->


### PR DESCRIPTION
Reading the calendar options and not finding the Gregorian calendar was... Unexpected.

Fortunately it was just lost in translation

## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->


Fixes #(issue) <!-- optional -->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
