### PR TITLE
Fix Iceraven and Mull QSB provider website links

### DIFF
--- a/lawnchair/src/app/lawnchair/qsb/providers/Iceraven.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Iceraven.kt
@@ -13,7 +13,7 @@ data object Iceraven : QsbSearchProvider(
     packageName = "io.github.forkmaintainers.iceraven",
     action = "org.mozilla.fenix.OPEN_TAB",
     className = "org.mozilla.fenix.IntentReceiverActivity",
-    website = "github.com/fork-maintainers/iceraven-browser/releases/latest",
+    website = "https://github.com/fork-maintainers/iceraven-browser/releases/latest",
     type = QsbSearchProviderType.APP,
     supportVoiceIntent = true,
 ) {

--- a/lawnchair/src/app/lawnchair/qsb/providers/Mull.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Mull.kt
@@ -13,7 +13,7 @@ data object Mull : QsbSearchProvider(
     packageName = "us.spotco.fennec_dos",
     action = "org.mozilla.fenix.OPEN_TAB",
     className = "org.mozilla.fenix.IntentReceiverActivity",
-    website = "gitlab.com/divested-mobile/mull-fenix",
+    website = "https://gitlab.com/divested-mobile/mull-fenix",
     type = QsbSearchProviderType.APP,
     supportVoiceIntent = true,
 ) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
Changed Iceraven and Mull QSB provider website links to start with "https://".
All other QSB provider website links (without exception) start with "https://".

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Additional info

I realize that this will not fix an issue that was raised in the Telegram channel recently whereby the Iceraven and Mull download links in the UI take the user to a Google Play Store "Item not found." page but this is a small problem that ought to be fixed regardless.