### PR TITLE
Fix translation string labels

### DIFF
--- a/lawnchair/res/values-en-rGB/strings.xml
+++ b/lawnchair/res/values-en-rGB/strings.xml
@@ -114,19 +114,6 @@
     <string name="drawer_search_description">Web suggestions, global search</string>
 
     <string name="folders_label">Folders</string>
-<<<<<<< Translation_String_Labels
-    <string name="folders_description">Row and Column Count</string>
-    <string name="app_drawer_columns">App Drawer Columns</string>
-    <string name="dock_icons">Dock Icons</string>
-    <string name="max_folder_columns">Max. Folder Columns</string>
-    <string name="max_folder_rows">Max. Folder Rows</string>
-    <string name="grid">Grid</string>
-    <string name="icons">Icons</string>
-    <string name="icon_sizes">Icon Size</string>
-    <string name="label_size">Label Size</string>
-    <string name="notification_dots">Notification Dots</string>
-    <string name="smartspace_preferences">Preferences</string>
-=======
     <string name="folders_description">Row and column count</string>
 
     <string name="gestures_label">Gestures</string>
@@ -135,7 +122,6 @@
     <string name="quickstep_label">Recents</string>
     <string name="quickstep_description">Clear All button, corner radius</string>
 
->>>>>>> 14-dev
     <string name="about_label">About</string>
 
     <string name="app_info_drop_target_label">App info</string>

--- a/lawnchair/res/values-en-rGB/strings.xml
+++ b/lawnchair/res/values-en-rGB/strings.xml
@@ -41,7 +41,7 @@
     <string name="max_folder_rows">Max. Folder Rows</string>
     <string name="grid">Grid</string>
     <string name="icons">Icons</string>
-    <string name="icon_size">Icon Size</string>
+    <string name="icon_sizes">Icon Size</string>
     <string name="label_size">Label Size</string>
     <string name="notification_dots">Notification Dots</string>
     <string name="smartspace_preferences">Preferences</string>

--- a/lawnchair/res/values-he/strings.xml
+++ b/lawnchair/res/values-he/strings.xml
@@ -39,7 +39,7 @@
     <string name="grid">רשת</string>
     <string name="rows">שורות</string>
     <string name="icons">סמלים</string>
-    <string name="icon_size">גודל סמל</string>
+    <string name="icon_sizes">גודל סמל</string>
     <string name="label_size">גודל טקסט</string>
     <string name="show_home_labels">הצגת תוויות</string>
     <string name="notification_dots">התראות</string>

--- a/lawnchair/res/values-id/strings.xml
+++ b/lawnchair/res/values-id/strings.xml
@@ -39,7 +39,7 @@
     <string name="grid">Kisi</string>
     <string name="rows">Baris</string>
     <string name="icons">Ikon</string>
-    <string name="icon_size">Ukuran Ikon</string>
+    <string name="icon_sizes">Ukuran Ikon</string>
     <string name="label_size">Ukuran Label</string>
     <string name="show_home_labels">Tampilkan Label</string>
     <string name="notification_dots">Bintik Notifikasi</string>

--- a/lawnchair/res/values-ku/strings.xml
+++ b/lawnchair/res/values-ku/strings.xml
@@ -39,7 +39,7 @@
     <string name="grid">Grid</string>
     <string name="rows">Rows</string>
     <string name="icons">Icons</string>
-    <string name="icon_size">Icon Size</string>
+    <string name="icon_sizes">Icon Size</string>
     <string name="label_size">Label Size</string>
     <string name="show_home_labels">Show Labels</string>
     <string name="notification_dots">Notification Dots</string>

--- a/lawnchair/res/values-sw/strings.xml
+++ b/lawnchair/res/values-sw/strings.xml
@@ -184,7 +184,7 @@
     <string name="show_status_bar">Onyesha Upau wa Hali</string>
     <string name="dark_status_bar_label">Upau wa Hali ya Giza</string>
     <string name="icons">Ikoni</string>
-    <string name="icon_size">Umbo la ikoni</string>
+    <string name="icon_sizes">Umbo la ikoni</string>
     <string name="show_home_labels">Onyesha Lebo</string>
     <string name="label_size">Ukubwa wa lebo</string>
     <string name="reset_custom_icons">Weka upya Ikoni Maalum</string>


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
The text for 'Icon size' (used in the Home Screen and App Drawer settings) is 'R.string.icon_sizes'.
However, in the 'strings.xml' file for certain languages, the corresponding lines are mislabelled as `<string name="icon_size">` (i.e. 'icon_size' rather than 'icon_sizes').

Languages affected:
- values-en-rGB
- values-he
- values-id
- values-ku
- values-sw

This PR fixes this.

Fixes #4726 <!-- optional -->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Additional info

Adding this pull request after noticing that 'strings.xml' files can be altered by PRs and not just via Crowdin. (Not sure that the actual defining labels could be altered via Crowdin anyway.)