### PR TITLE
[Suggestion] Revert "Align widget padding to icons"

### DIFF
--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -1317,7 +1317,6 @@ public class DeviceProfile {
         } else {
             widgetPadding.setEmpty();
         }
-        widgetPadding.left = widgetPadding.right += widgetPadding.right + widgetPadding.left - Math.round(Math.max(0, minSpacing - cellLayoutBorderSpacePx.x));
     }
 
     /**

--- a/src/com/android/launcher3/qsb/QsbContainerView.java
+++ b/src/com/android/launcher3/qsb/QsbContainerView.java
@@ -149,7 +149,7 @@ public class QsbContainerView extends FrameLayout {
 
     @Override
     public void setPadding(int left, int top, int right, int bottom) {
-        super.setPadding(left, top, right, bottom);
+        super.setPadding(0, 0, 0, 0);
     }
 
     protected void setPaddingUnchecked(int left, int top, int right, int bottom) {


### PR DESCRIPTION
This reverts commit 93cb189b40b1152579adde26eb6ae88558f1d54e.

## Description

Following the introduction of this commit, the appearance of the widgets has been modified in terms of width, and they now occupy a much smaller portion of the screen.
As a result, some widgets have significantly lost readability, and there is now too much unused space around them.

Here is an example before the introduction of this commit:
![1](https://github.com/user-attachments/assets/9e9ea15d-8625-4dff-84fc-c6bff9ca8019)

And an example after the introduction of this commit:
![2](https://github.com/user-attachments/assets/b5f553df-8365-40be-9994-d8bb0311cdc2)

As you can see, the available space for the text inside the widgets is much more limited than before. This is particularly problematic for certain widgets like calendars or task lists.

I suggest reverting to the previous layout or allowing the margin to be configurable.


## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
