### PR TITLE
fix custom app icon screen not showing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -382,7 +382,7 @@ dependencies {
     implementation 'androidx.compose.material3:material3-window-size-class'
     implementation "androidx.activity:activity-compose:1.9.2"
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6"
-    implementation "androidx.navigation:navigation-compose:2.8.2"
+    implementation "androidx.navigation:navigation-compose:2.8.0"
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
     implementation "androidx.palette:palette-ktx:1.0.0"
     implementation "androidx.slice:slice-core:1.1.0-alpha02"


### PR DESCRIPTION
the navigation dependency version 2.8.1 breaks the current behavior defined here https://github.com/LawnchairLauncher/lawnchair/blob/d0d19849bb5af42f203b244831f338638a43f5ad/lawnchair/src/app/lawnchair/override/CustomizeDialog.kt#L131-L134 see: https://developer.android.com/jetpack/androidx/releases/navigation?hl=en#:~:text=A%20NavDestination%20can,potentially%20protected%20destination  . So this commit is an temporary fix for this while an definitive solution is not made

## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->


Fixes #4875<!-- optional -->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
