### PR TITLE
Fix recents not working on NothingOS 2.6

### DIFF
--- a/quickstep/src/com/android/launcher3/LauncherAnimationRunner.java
+++ b/quickstep/src/com/android/launcher3/LauncherAnimationRunner.java
@@ -31,6 +31,8 @@ import android.os.Handler;
 import android.os.RemoteException;
 import android.view.IRemoteAnimationFinishedCallback;
 import android.view.RemoteAnimationTarget;
+import android.view.SurfaceControl;
+import android.window.TransitionInfo;
 
 import androidx.annotation.BinderThread;
 import androidx.annotation.Nullable;
@@ -100,6 +102,22 @@ public class LauncherAnimationRunner extends RemoteAnimationRunnerCompat {
         } else {
             postAsyncCallback(mHandler, r);
         }
+    }
+
+    // Introduced in NothingOS 2.5.5, needed in 2.6
+    @BinderThread
+    public void onAnimationStartWithSurfaceTransaction(
+            int transit,
+            TransitionInfo transitionInfo,
+            SurfaceControl.Transaction transaction,
+            RemoteAnimationTarget[] appTargets,
+            RemoteAnimationTarget[] wallpaperTargets,
+            RemoteAnimationTarget[] nonAppTargets,
+            Runnable runnable) {
+        if (transaction != null) {
+            transaction.apply();
+        }
+        onAnimationStart(transit, appTargets, wallpaperTargets, nonAppTargets, runnable);
     }
 
     private RemoteAnimationFactory getFactory() {

--- a/quickstep/src/com/android/quickstep/RecentsAnimationCallbacks.java
+++ b/quickstep/src/com/android/quickstep/RecentsAnimationCallbacks.java
@@ -25,6 +25,8 @@ import static com.android.quickstep.util.ActiveGestureErrorDetector.GestureEvent
 import android.graphics.Rect;
 import android.util.ArraySet;
 import android.view.RemoteAnimationTarget;
+import android.view.SurfaceControl;
+import android.window.TransitionInfo;
 
 import androidx.annotation.BinderThread;
 import androidx.annotation.NonNull;
@@ -97,6 +99,18 @@ public class RecentsAnimationCallbacks implements
             Rect minimizedHomeBounds) {
         onAnimationStart(controller, appTargets, new RemoteAnimationTarget[0],
                 homeContentInsets, minimizedHomeBounds);
+    }
+
+    // Introduced in NothingOS 2.5.5, needed in 2.6
+    @BinderThread
+    public final void onAnimationStart(RecentsAnimationControllerCompat controller,
+            TransitionInfo transitionInfo, SurfaceControl.Transaction transaction,
+            RemoteAnimationTarget[] apps, RemoteAnimationTarget[] wallpapers,
+            Rect homeContentInsets, Rect minimizedHomeBounds) {
+        if (transaction != null) {
+            transaction.apply();
+        }
+        onAnimationStart(controller, apps, wallpapers, homeContentInsets, minimizedHomeBounds);
     }
 
     // Called only in R+ platform

--- a/quickstep/src/com/android/quickstep/SystemUiProxy.java
+++ b/quickstep/src/com/android/quickstep/SystemUiProxy.java
@@ -1489,8 +1489,9 @@ public class SystemUiProxy implements ISystemUiProxy {
                     RemoteAnimationTarget[] wallpapers,
                     Rect homeContentInsets,
                     Rect minimizedHomeBounds) {
-                listener.onAnimationStart(new RecentsAnimationControllerCompat(controller), apps,
-                        wallpapers, homeContentInsets, minimizedHomeBounds);
+                listener.onAnimationStart(new RecentsAnimationControllerCompat(controller),
+                        transitionInfo, transaction, apps, wallpapers,
+                        homeContentInsets, minimizedHomeBounds);
             }
 
             @Override

--- a/systemUIShared/src/com/android/systemui/shared/system/RecentsAnimationListener.java
+++ b/systemUIShared/src/com/android/systemui/shared/system/RecentsAnimationListener.java
@@ -18,6 +18,8 @@ package com.android.systemui.shared.system;
 
 import android.graphics.Rect;
 import android.view.RemoteAnimationTarget;
+import android.view.SurfaceControl;
+import android.window.TransitionInfo;
 
 import com.android.systemui.shared.recents.model.ThumbnailData;
 
@@ -28,6 +30,12 @@ public interface RecentsAnimationListener {
      * Called when the animation into Recents can start. This call is made on the binder thread.
      */
     void onAnimationStart(RecentsAnimationControllerCompat controller,
+            RemoteAnimationTarget[] apps, RemoteAnimationTarget[] wallpapers,
+            Rect homeContentInsets, Rect minimizedHomeBounds);
+
+    // Introduced in NothingOS 2.5.5, needed in 2.6
+    void onAnimationStart(RecentsAnimationControllerCompat controller,
+            TransitionInfo transitionInfo, SurfaceControl.Transaction transaction,
             RemoteAnimationTarget[] apps, RemoteAnimationTarget[] wallpapers,
             Rect homeContentInsets, Rect minimizedHomeBounds);
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

In NothingOS 2.6 with QuickStep activated, going to recents from an app via the bottom gesture is no longer working.

Pull #4417 implemented this incompletely, resulting in breakage in NothingOS 2.6.

Transaction needs to be applied so that the animation chain can continue.

No issues were filed for this specific bug thus far.

- Closes #4917
- Closes #4925
## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
