### PR TITLE
Update Quickstep constraint to 35

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ final def versionDisplayName = "${version}.${isReleaseBuild ? releaseName : devR
 final def majorVersion = versionDisplayName.split("\\.")[0]
 
 final def quickstepMinSdk = "29"
-final def quickstepMaxSdk = "34"
+final def quickstepMaxSdk = "35"
 
 android {
     namespace "com.android.launcher3"


### PR DESCRIPTION
## Description

I don't have A15 to do initial assessment, for now I'll update the constraint to 35 for LC15 in case someone wants to try initial testing so that bugs can be iron out.

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

Fixes https://t.me/lccommunity/793192?single

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

✅ General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
