### PR TITLE
Allow Launcher3 to use grid/hotseat/icon size value

### DIFF
--- a/src/com/android/launcher3/InvariantDeviceProfile.java
+++ b/src/com/android/launcher3/InvariantDeviceProfile.java
@@ -255,10 +255,7 @@ public class InvariantDeviceProfile implements SafeCloseable {
          * This constructor should NOT have any monitors by design.
          */
         public InvariantDeviceProfile(Context context, String gridName) {
-                String newName = initGrid(context, gridName);
-                if (newName == null || !newName.equals(gridName)) {
-                        throw new IllegalArgumentException("Unknown grid name: " + gridName);
-                }
+                this(context, DeviceProfileOverrides.INSTANCE.get(context).getGridInfo(gridName));
         }
 
         public InvariantDeviceProfile(Context context, DeviceProfileOverrides.DBGridInfo dbGridInfo) {
@@ -364,7 +361,7 @@ public class InvariantDeviceProfile implements SafeCloseable {
         }
 
         public static String getCurrentGridName(Context context) {
-                return LauncherPrefs.get(context).get(GRID_NAME);
+                return DeviceProfileOverrides.INSTANCE.get(context).getCurrentGridName();
         }
 
         private String initGrid(Context context, String gridName) {

--- a/src/com/android/launcher3/InvariantDeviceProfile.java
+++ b/src/com/android/launcher3/InvariantDeviceProfile.java
@@ -400,10 +400,10 @@ public class InvariantDeviceProfile implements SafeCloseable {
                         .getOverrides(displayOption.grid);
                 DisplayMetrics metrics = context.getResources().getDisplayMetrics();
                 closestProfile = displayOption.grid;
-                numRows = closestProfile.numRows;
-                numColumns = closestProfile.numColumns;
+                numRows = dbGridInfo.getNumRows();
+                numColumns = dbGridInfo.getNumColumns();
                 numSearchContainerColumns = closestProfile.numSearchContainerColumns;
-                dbFile = closestProfile.dbFile;
+                dbFile = dbGridInfo.getDbFile();
                 defaultLayoutId = closestProfile.defaultLayoutId;
                 demoModeLayoutId = closestProfile.demoModeLayoutId;
 
@@ -434,11 +434,16 @@ public class InvariantDeviceProfile implements SafeCloseable {
                 inlineNavButtonsEndSpacing = closestProfile.inlineNavButtonsEndSpacing;
 
                 iconSize = displayOption.iconSizes;
+                allAppsIconSize = displayOption.allAppsIconSizes;
                 float maxIconSize = iconSize[0];
                 for (int i = 1; i < iconSize.length; i++) {
                         maxIconSize = Math.max(maxIconSize, iconSize[i]);
                 }
-                iconBitmapSize = ResourceUtils.pxFromDp(maxIconSize, metrics);
+                float maxAllAppsIconSize = allAppsIconSize[0];
+                for (int i = 1; i < allAppsIconSize.length; i++) {
+                    maxAllAppsIconSize = Math.max(maxAllAppsIconSize, allAppsIconSize[i]);
+                }
+                iconBitmapSize = ResourceUtils.pxFromDp(Math.max(maxIconSize, maxAllAppsIconSize), metrics);
                 fillResIconDpi = getLauncherIconDensity(iconBitmapSize);
 
                 iconTextSize = displayOption.textSizes;
@@ -449,9 +454,10 @@ public class InvariantDeviceProfile implements SafeCloseable {
 
                 horizontalMargin = displayOption.horizontalMargin;
 
-                numShownHotseatIcons = closestProfile.numHotseatIcons;
+                numShownHotseatIcons = deviceType == TYPE_MULTI_DISPLAY 
+                        ? closestProfile.numHotseatIcons : dbGridInfo.getNumHotseatColumns();
                 numDatabaseHotseatIcons = deviceType == TYPE_MULTI_DISPLAY
-                        ? closestProfile.numDatabaseHotseatIcons : closestProfile.numHotseatIcons;
+                        ? closestProfile.numDatabaseHotseatIcons : numShownHotseatIcons;
                 hotseatBarBottomSpace = displayOption.hotseatBarBottomSpace;
                 hotseatQsbSpace = displayOption.hotseatQsbSpace;
 


### PR DESCRIPTION
## Description

This is the same one used in #4973 (or well, it's not pushed)

~~Right now the icon doesn't scale up well, the preview for changing grid size properly size this.~~

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
✅ Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
