### PR TITLE
fixed crash api 28

### DIFF
--- a/lawnchair/src/app/lawnchair/util/LawnchairWindowManagerProxy.kt
+++ b/lawnchair/src/app/lawnchair/util/LawnchairWindowManagerProxy.kt
@@ -123,7 +123,7 @@ class LawnchairWindowManagerProxy(context: Context) : WindowManagerProxy(Utiliti
     }
 
     override fun rotateCutout(
-        original: DisplayCutout,
+        original: DisplayCutout?,
         startWidth: Int,
         startHeight: Int,
         fromRotation: Int,

--- a/src/com/android/launcher3/util/window/WindowManagerProxy.java
+++ b/src/com/android/launcher3/util/window/WindowManagerProxy.java
@@ -368,7 +368,7 @@ public class WindowManagerProxy implements ResourceBasedOverride, SafeCloseable 
             DisplayCutout rotatedCutout = rotateCutout(
                     displayInfo.cutout, displayInfo.size.x, displayInfo.size.y, rotation, i);
             Rect insets = getSafeInsets(rotatedCutout);
-            if (areBottomDisplayCutoutsSmallAndAtCorners(
+            if (rotatedCutout != null && areBottomDisplayCutoutsSmallAndAtCorners(
                     rotatedCutout.getBoundingRectBottom(),
                     bounds.width(),
                     context.getResources())) {


### PR DESCRIPTION
## Description

method `getBoundingRectBottom()` is not available below api 28 so it causes an crash at app startup

Fixes #(issue) <!-- optional -->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
