### PR TITLE
Allow "Tint with accent color" to be translatable

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -239,6 +239,7 @@
     <!-- Icon pack settings -->
     <string name="icon_pack">Icon pack</string>
     <string name="themed_icon_pack">Themed icon source</string>
+    <string name="themed_icon_pack_tint">Tint with accent color</string>
     <string name="system_icons">System icons</string>
 
     <string name="themed_icon_title">Themed icons</string>

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
@@ -199,7 +199,7 @@ fun IconPackPreferences(
                             )
                             SwitchPreference(
                                 adapter = prefs.tintIconPackBackgrounds.getAdapter(),
-                                label = "Tint with accent color",
+                                label = stringResource(id = R.string.themed_icon_pack_tint),
                             )
                         }
                     }


### PR DESCRIPTION
## Description

Add "Tint with accent color" string to list of translatable strings.


## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
