### PR TITLE
Use provided text and colour for widget add button

### DIFF
--- a/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
@@ -144,6 +144,12 @@ object ColorTokens {
 
     @JvmField val SurfaceBrightColor = DayNightColorToken(Neutral2_600.setLStar(98.0), Neutral2_600.setLStar(24.0))
 
+    @JvmField val PrimaryButton = Accent1_600
+
+    @JvmField val WidgetAddButtonBackgroundColor = PrimaryButton
+
+    @JvmField val slotPlateColor = Accent1_300
+
     val SwitchThumbOn = Accent1_100
     val SwitchThumbOff = DayNightColorToken(Neutral2_300, Neutral1_400)
     val SwitchThumbDisabled = DayNightColorToken(Neutral2_100, Neutral1_700)

--- a/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
@@ -148,8 +148,6 @@ object ColorTokens {
 
     @JvmField val WidgetAddButtonBackgroundColor = PrimaryButton
 
-    @JvmField val slotPlateColor = Accent1_300
-
     val SwitchThumbOn = Accent1_100
     val SwitchThumbOff = DayNightColorToken(Neutral2_300, Neutral1_400)
     val SwitchThumbDisabled = DayNightColorToken(Neutral2_100, Neutral1_700)

--- a/lawnchair/src/app/lawnchair/theme/drawable/DrawableTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/drawable/DrawableTokens.kt
@@ -3,6 +3,7 @@ package app.lawnchair.theme.drawable
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.InsetDrawable
 import android.graphics.drawable.LayerDrawable
 import android.graphics.drawable.RippleDrawable
 import android.graphics.drawable.StateListDrawable
@@ -186,4 +187,8 @@ object DrawableTokens {
     @JvmField
     val WorkCard = ResourceDrawableToken<GradientDrawable>(R.drawable.work_card)
         .setColor(ColorTokens.Surface)
+
+    @JvmField
+    val WidgetAddButtonBackground = ResourceDrawableToken<InsetDrawable>(R.drawable.widget_cell_add_button_background)
+        .setTint(ColorTokens.WidgetAddButtonBackgroundColor)
 }

--- a/src/com/android/launcher3/widget/WidgetCell.java
+++ b/src/com/android/launcher3/widget/WidgetCell.java
@@ -71,6 +71,7 @@ import java.util.function.Consumer;
 
 import app.lawnchair.LawnchairAppWidgetHostView;
 import app.lawnchair.font.FontManager;
+import app.lawnchair.theme.drawable.DrawableTokens;
 
 /**
  * Represents the individual cell of the widget inside the widget tray. The
@@ -168,6 +169,10 @@ public class WidgetCell extends LinearLayout {
         FontManager fontManager = FontManager.INSTANCE.get(getContext());
         fontManager.setCustomFont(mWidgetName, R.id.font_body_medium);
         fontManager.setCustomFont(mWidgetDescription, R.id.font_body);
+        
+        // LC: Allow customisability to the Add Button, Test: Press on any Widget on the Widget sheet.
+        mWidgetAddButton.setBackground(DrawableTokens.WidgetAddButtonBackground.resolve(getContext()));
+        fontManager.setCustomFont(mWidgetAddButton, R.id.font_body_medium);
     }
 
     public void setRemoteViewsPreview(RemoteViews view) {


### PR DESCRIPTION
## Description

Allow theming of the add widget button

<details>
<summary>After</summary>

Using wallpaper colour instead of system: Samsung M23 - A14 One UI 6.1

![image](https://github.com/user-attachments/assets/fa3037d3-fb34-4835-9899-ed2b52db5b2b)

</details>

<details>
<summary>Before</summary>

Using wallpaper colour instead of system: Honor 10 Lite - A10 EMUI 10

![image](https://github.com/user-attachments/assets/1d96ee8b-d513-4357-8f46-5620e6354ddc)

</details>

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
✅ Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
