### PR TITLE
Fixed grid migration to keep item positions

### DIFF
--- a/flags/src/com/android/launcher3/FeatureFlagsImpl.java
+++ b/flags/src/com/android/launcher3/FeatureFlagsImpl.java
@@ -303,7 +303,7 @@ public final class FeatureFlagsImpl implements FeatureFlags {
 
     @Override
     public boolean enableGridMigrationFix() {
-        return true;
+        return false;
 
     }
 
@@ -360,7 +360,7 @@ public final class FeatureFlagsImpl implements FeatureFlags {
 
     @Override
     public boolean enableNarrowGridRestore() {
-        return true;
+        return false;
 
     }
 

--- a/src/com/android/launcher3/InvariantDeviceProfile.java
+++ b/src/com/android/launcher3/InvariantDeviceProfile.java
@@ -399,7 +399,8 @@ public class InvariantDeviceProfile implements SafeCloseable {
                 closestProfile = displayOption.grid;
                 numRows = dbGridInfo.getNumRows();
                 numColumns = dbGridInfo.getNumColumns();
-                numSearchContainerColumns = closestProfile.numSearchContainerColumns;
+                numSearchContainerColumns = deviceType == TYPE_MULTI_DISPLAY
+                        ? closestProfile.numSearchContainerColumns : dbGridInfo.getNumHotseatColumns();
                 dbFile = dbGridInfo.getDbFile();
                 defaultLayoutId = closestProfile.defaultLayoutId;
                 demoModeLayoutId = closestProfile.demoModeLayoutId;
@@ -452,7 +453,7 @@ public class InvariantDeviceProfile implements SafeCloseable {
                 horizontalMargin = displayOption.horizontalMargin;
 
                 numShownHotseatIcons = deviceType == TYPE_MULTI_DISPLAY 
-                        ? closestProfile.numHotseatIcons : dbGridInfo.getNumHotseatColumns();
+                        ? closestProfile.numDatabaseHotseatIcons : dbGridInfo.getNumHotseatColumns();
                 numDatabaseHotseatIcons = deviceType == TYPE_MULTI_DISPLAY
                         ? closestProfile.numDatabaseHotseatIcons : numShownHotseatIcons;
                 hotseatBarBottomSpace = displayOption.hotseatBarBottomSpace;
@@ -463,7 +464,7 @@ public class InvariantDeviceProfile implements SafeCloseable {
                 numAllAppsColumns = closestProfile.numAllAppsColumns;
 
                 numDatabaseAllAppsColumns = deviceType == TYPE_MULTI_DISPLAY
-                        ? closestProfile.numDatabaseAllAppsColumns : closestProfile.numAllAppsColumns;
+                        ? closestProfile.numDatabaseAllAppsColumns : numAllAppsColumns;
 
                 allAppsCellSize = displayOption.allAppsCellSize;
                 allAppsBorderSpaces = displayOption.allAppsBorderSpaces;


### PR DESCRIPTION
## Description
These changes address issues with item positioning, screen merging, and maintain a more intuitive layout when changing grid sizes. The migration now respects the original screen structure and preserves relative item positions as much as possible

- Revised migrate method to process each screen independently, preventing merging of items from different screens
- Implemented dynamic item placement logic to maintain relative positions when changing grid sizes

- closes : #5016
- closes : #5003
- closes : #4809

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
