### PR TITLE
Fix style in SettingInfo

### DIFF
--- a/lawnchair/src/app/lawnchair/search/algorithms/data/SettingInfo.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/data/SettingInfo.kt
@@ -28,9 +28,7 @@ suspend fun findSettingsByNameAndAction(query: String, max: Int): List<SettingIn
                 .filter {
                     it.type == String::class.java &&
                         Modifier.isStatic(it.modifiers) &&
-                        it.name.startsWith(
-                            "ACTION_",
-                        )
+                        it.name.startsWith("ACTION_")
                 }
                 .map { it.name to it.get(null) as String }
                 .filter { (name, action) ->

--- a/lawnchair/src/app/lawnchair/search/algorithms/data/SettingInfo.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/data/SettingInfo.kt
@@ -26,9 +26,11 @@ suspend fun findSettingsByNameAndAction(query: String, max: Int): List<SettingIn
             Settings::class.java.fields
                 .asSequence()
                 .filter {
-                    it.type == String::class.java && Modifier.isStatic(it.modifiers) && it.name.startsWith(
-                        "ACTION_",
-                    )
+                    it.type == String::class.java &&
+                        Modifier.isStatic(it.modifiers) &&
+                        it.name.startsWith(
+                            "ACTION_",
+                        )
                 }
                 .map { it.name to it.get(null) as String }
                 .filter { (name, action) ->

--- a/lawnchair/src/app/lawnchair/views/LawnchairScrimView.kt
+++ b/lawnchair/src/app/lawnchair/views/LawnchairScrimView.kt
@@ -23,7 +23,8 @@ class LawnchairScrimView(context: Context, attrs: AttributeSet?) : ScrimView(con
     override fun updateSysUiColors() {
         val threshold = STATUS_BAR_COLOR_FORCE_UPDATE_THRESHOLD
         val forceChange = visibility == VISIBLE &&
-            alpha > threshold && Color.alpha(mBackgroundColor) / (255f * drawerOpacity) > threshold
+            alpha > threshold &&
+            Color.alpha(mBackgroundColor) / (255f * drawerOpacity) > threshold
         with(systemUiController) {
             if (forceChange) {
                 updateUiState(SystemUiController.UI_STATE_SCRIM_VIEW, !isScrimDark)


### PR DESCRIPTION
## Description

After the Spotless 7.0.0 merge (3398fce4548355ed3e4c937a02119913e320c6c3), I was getting a couple of style errors in my own custom builds (in unmodified source files), one of which is noted in the style check fail for the last two commits to 15-dev: 3398fce4548355ed3e4c937a02119913e320c6c3 and 06689bf0dd7d63693d4851d3d439557398922dec).
This PR fixes these style errors.


## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
