### PR TITLE
Restore English Canadian translations

### DIFF
--- a/lawnchair/res/values-en-rCA/strings.xml
+++ b/lawnchair/res/values-en-rCA/strings.xml
@@ -21,9 +21,9 @@
     Actions and Verbs
 
     -->
-    <string name="preview_label">Solanvip1</string>
+    <string name="preview_label">Preview</string>
     <string name="action_create">Create</string>
-    <string name="action_backup"></string>
+    <string name="action_backup">Backup</string>
     <string name="action_restore">Restore</string>
     <string name="action_delete">Delete</string>
     <string name="action_reset">Reset</string>


### PR DESCRIPTION
## Description

Restore two strings for the English Canadian translations

Changes to Crowdin have been applied and this PR changes the string immediately before the Crowdin CI does it.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
✅ Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
