### PR TITLE
Fix upstream bug with dots enabled

### DIFF
--- a/src/com/android/launcher3/notification/NotificationListener.java
+++ b/src/com/android/launcher3/notification/NotificationListener.java
@@ -208,6 +208,10 @@ public class NotificationListener extends NotificationListenerService {
             result = getActiveNotifications(keys);
         } catch (SecurityException e) {
             Log.e(TAG, "SecurityException: failed to fetch notifications");
+        } catch (RuntimeException e) {
+            // This is an upstream bug in the Android framework
+            // https://github.com/GrapheneOS/os-issue-tracker/issues/2601
+            Log.e(TAG, "Workaround for Android framework.");
         }
         return result == null ? new StatusBarNotification[0] : result;
     }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

I did not find any issue reported upstream, but I can confirm that this bug exists on Moto App Launcher (the launcher on Motorola's devices). Further there is an issue on GrapheneOS issue tracker, which seems to imply this is a bug in AOSP itself. I had asked @agnostic-apollo about this is a bug, and he said that this is a bug in Android's libraries itself. I'm not a Android dev, so feel free to suggest any changes to the PR.

With this change, I was able to use Lawnchair without any crashes for around 24+ hours with notification dots on. So, I guess this workaround works

Works around GrapheneOS/os-issue-tracker#2601

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
