### PR TITLE
Allow overriding default search providers remotely

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/LiveInformation.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/LiveInformation.kt
@@ -6,12 +6,14 @@ import kotlinx.serialization.Serializable
 data class LiveInformation(
     private val version: Int = 2,
     val announcements: List<Announcement>,
+    val features: Map<String, String?>,
 ) {
 
     companion object {
         val default = LiveInformation(
             version = 2,
             announcements = emptyList(),
+            features = emptyMap(),
         )
     }
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

Loads content of the new "features" data from the [live-information.json](https://lawnchair.app/live-information.json) and uses them to override the local default value with the remote default value.

For now, it will be used only for search providers but we can expand the usages later on.

Fixes #(issue) <!-- optional -->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
