### PR TITLE
Reset default search provider to Google from Startpage

### DIFF
--- a/lawnchair/res/values/config.xml
+++ b/lawnchair/res/values/config.xml
@@ -62,7 +62,7 @@
     <dimen name="page_indicator_dot_size_v2">6dp</dimen>
 
     <!-- Which QSB search provider to use by default -->
-    <string name="config_default_qsb_search_provider_id" translatable="false">startpage</string>
+    <string name="config_default_qsb_search_provider_id" translatable="false">google</string>
 
     <!-- Which icon shape to use by default -->
     <string name="config_default_icon_shape" translatable="false">system</string>
@@ -94,7 +94,7 @@
     <string name="config_default_hotseat_mode" translatable="false">lawnchair</string>
 
     <!-- which web search provider to use by default -->
-    <string name="config_default_web_suggestion_provider" translatable="false">startpage</string>
+    <string name="config_default_web_suggestion_provider" translatable="false">google</string>
 
     <bool name="config_default_show_hotseat">true</bool>
     <bool name="config_default_always_reload_icons">true</bool>

--- a/lawnchair/src/app/lawnchair/qsb/providers/Startpage.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Startpage.kt
@@ -14,7 +14,7 @@ data object Startpage : QsbSearchProvider(
     packageName = "",
     website = "https://startpage.com/?segment=startpage.lawnchair",
     type = QsbSearchProviderType.LOCAL,
-    sponsored = true,
+    sponsored = false,
 ) {
     override suspend fun launch(launcher: Launcher, forceWebsite: Boolean) {
         val prefs = PreferenceManager.getInstance(launcher)

--- a/lawnchair/src/app/lawnchair/search/algorithms/data/Web.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/data/Web.kt
@@ -80,8 +80,8 @@ sealed class WebSearchProvider {
          */
         fun values() = listOf(
             Google,
-            StartPage,
             DuckDuckGo,
+            StartPage,
         )
     }
 }


### PR DESCRIPTION
## Description

- Resets default search provider to Google
- Removes Startpage sponsorship disclaimer

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
