### PR TITLE
fix: remove unnecessary full stop

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -102,7 +102,7 @@
     <string name="edit_label">Edit</string>
     <string name="apply_label">Apply</string>
     <string name="delete_label">Delete</string>
-    <string name="folder_list_note">Swipe left to edit, swipe right to delete, or tap to update items.</string>
+    <string name="folder_list_note">Swipe left to edit, swipe right to delete, or tap to update items</string>
 
     <!-- A11y description -->
     <string name="accessibility_service_description">To lock your phone when performing a gesture, and to open Recents via gesture, Lawnchair requires accessibility access.\n\nLawnchair doesn\'t watch any user action, though the privilege to do so is required for all accessibility services. Lawnchair discards any event sent by the system.\n\nIn order to lock your phone, or to open Recents, Lawnchair uses the performGlobalAction Accessibility service.</string>


### PR DESCRIPTION
## Description

According to the M3 Style guide, periods and unnecessary punctuation should be removed, especially in single sentences such as this one.

Reference: https://m3.material.io/foundations/content-design/style-guide/grammar-and-punctuation#555b17c7-de48-4974-8a82-51106899dc0e

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
