### PR TITLE
fix: smartspacer padding

### DIFF
--- a/lawnchair/res/values/dimens.xml
+++ b/lawnchair/res/values/dimens.xml
@@ -77,6 +77,7 @@
     <dimen name="enhanced_smartspace_icon_margin">6dp</dimen>
     <dimen name="enhanced_smartspace_icon_size">20dp</dimen>
     <dimen name="enhanced_smartspace_margin_start_launcher">0dp</dimen>
+    <dimen name="enhanced_smartspace_padding_start">16dp</dimen>
     <dimen name="enhanced_smartspace_padding_top">16dp</dimen>
     <dimen name="enhanced_smartspace_secondary_card_corner_radius">28dp</dimen>
     <dimen name="enhanced_smartspace_secondary_card_end_margin">1dp</dimen>

--- a/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
@@ -8,7 +8,6 @@ import android.util.AttributeSet
 import android.view.View
 import app.lawnchair.LawnchairLauncher
 import app.lawnchair.launcher
-import app.lawnchair.launcherNullable
 import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.preferences2.subscribeBlocking
 import app.lawnchair.ui.preferences.PreferenceActivity
@@ -17,6 +16,7 @@ import com.android.launcher3.R
 import com.android.launcher3.logging.StatsLogManager
 import com.android.launcher3.views.OptionsPopupView
 import com.kieronquinn.app.smartspacer.sdk.client.R as SmartspacerR
+import androidx.viewpager.widget.ViewPager
 import com.kieronquinn.app.smartspacer.sdk.client.views.BcSmartspaceView
 import com.kieronquinn.app.smartspacer.sdk.client.views.popup.Popup
 import com.kieronquinn.app.smartspacer.sdk.client.views.popup.PopupFactory
@@ -27,6 +27,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 
 class SmartspacerView(context: Context, attrs: AttributeSet?) : BcSmartspaceView(context, attrs) {
+    private lateinit var viewPager: ViewPager
     private val prefs2 = PreferenceManager2.getInstance(context)
     private val coroutineScope = CoroutineScope(Dispatchers.Default)
     private var targetCount = 5
@@ -69,11 +70,10 @@ class SmartspacerView(context: Context, attrs: AttributeSet?) : BcSmartspaceView
         }
     }
 
-    override fun setPadding(left: Int, top: Int, right: Int, bottom: Int) {
-        val ctx = LawnchairLauncher.instance?.launcherNullable
-        val dp = ctx?.deviceProfile
-        val leftPadding = dp?.widgetPadding?.left ?: (left + 16)
-        super.setPadding(leftPadding, top, right, bottom)
+    override fun onFinishInflate() {
+        super.onFinishInflate()
+        viewPager = findViewById<ViewPager>(SmartspacerR.id.smartspace_card_pager)!!
+        viewPager.setLayoutParams(LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.UNSPECIFIED_GRAVITY))
     }
 
     override val config = SmartspaceConfig(

--- a/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/SmartspacerView.kt
@@ -6,6 +6,7 @@ import android.graphics.Rect
 import android.graphics.RectF
 import android.util.AttributeSet
 import android.view.View
+import androidx.viewpager.widget.ViewPager
 import app.lawnchair.LawnchairLauncher
 import app.lawnchair.launcher
 import app.lawnchair.preferences2.PreferenceManager2
@@ -16,7 +17,6 @@ import com.android.launcher3.R
 import com.android.launcher3.logging.StatsLogManager
 import com.android.launcher3.views.OptionsPopupView
 import com.kieronquinn.app.smartspacer.sdk.client.R as SmartspacerR
-import androidx.viewpager.widget.ViewPager
 import com.kieronquinn.app.smartspacer.sdk.client.views.BcSmartspaceView
 import com.kieronquinn.app.smartspacer.sdk.client.views.popup.Popup
 import com.kieronquinn.app.smartspacer.sdk.client.views.popup.PopupFactory

--- a/res/layout/smartspace_smartspacer.xml
+++ b/res/layout/smartspace_smartspacer.xml
@@ -4,7 +4,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical"
-    android:layout_marginStart="@dimen/enhanced_smartspace_margin_start_launcher">
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:paddingStart="@dimen/enhanced_smartspace_padding_start">
 
     <androidx.viewpager.widget.ViewPager
         android:id="@+id/smartspace_card_pager"


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
The smartspacer card view was off the left edge of the screen causing the text to be too far left and cut off. This PR fixes that issue with a 16dp left margin.

Fixes:
* #4824
* #5134

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
