### PR TITLE
fix: smartspacer layout

### DIFF
--- a/lawnchair/res/values/dimens.xml
+++ b/lawnchair/res/values/dimens.xml
@@ -78,6 +78,7 @@
     <dimen name="enhanced_smartspace_icon_size">20dp</dimen>
     <dimen name="enhanced_smartspace_margin_start_launcher">0dp</dimen>
     <dimen name="enhanced_smartspace_padding_start">16dp</dimen>
+    <dimen name="enhanced_smartspace_padding_end">16dp</dimen>
     <dimen name="enhanced_smartspace_padding_top">16dp</dimen>
     <dimen name="enhanced_smartspace_secondary_card_corner_radius">28dp</dimen>
     <dimen name="enhanced_smartspace_secondary_card_end_margin">1dp</dimen>

--- a/res/layout/smartspace_smartspacer.xml
+++ b/res/layout/smartspace_smartspacer.xml
@@ -4,9 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center_vertical"
-    android:clipChildren="false"
-    android:clipToPadding="false"
-    android:paddingStart="@dimen/enhanced_smartspace_padding_start">
+    android:paddingStart="@dimen/enhanced_smartspace_padding_start"
+    android:paddingEnd="@dimen/enhanced_smartspace_padding_end">
 
     <androidx.viewpager.widget.ViewPager
         android:id="@+id/smartspace_card_pager"


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
Modified the smartspacer layout to be more like the stock At a Glance layout by adding equal padding to both sides and clipping the pages as they are scrolled.

Fixes #5206

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
