### PR TITLE
Fixing a Bug in Which Lawnchair crashes due to features value not set. Fix #5337

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/LiveInformation.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/LiveInformation.kt
@@ -5,15 +5,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class LiveInformation(
     private val version: Int = 2,
-    val announcements: List<Announcement>,
-    val features: Map<String, String?>,
+    val announcements: List<Announcement> = emptyList(), 
+    val features: Map<String, String?> = emptyMap(),     
 ) {
-
     companion object {
-        val default = LiveInformation(
-            version = 2,
-            announcements = emptyList(),
-            features = emptyMap(),
-        )
+        val default = LiveInformation() 
     }
 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/LiveInformation.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/data/liveinfo/model/LiveInformation.kt
@@ -5,10 +5,15 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class LiveInformation(
     private val version: Int = 2,
-    val announcements: List<Announcement> = emptyList(), 
-    val features: Map<String, String?> = emptyMap(),     
+    val announcements: List<Announcement> = emptyList(),
+    val features: Map<String, String?> = emptyMap(),
 ) {
+
     companion object {
-        val default = LiveInformation() 
+        val default = LiveInformation(
+            version = 2,
+            announcements = emptyList(),
+            features = emptyMap(),
+        )
     }
 }


### PR DESCRIPTION
#5337 Bug Description
Error:
hf.c: Field 'features' is required for type [...] but it was missing from Issues #5337 Cause:
The LiveInformation class expects a non-null features field during deserialization, but the incoming data (e.g., from cached preferences or an API response) lacks this field. This crashes the app when parsing older data formats or incomplete responses.

Fix
Root Issue:
Kotlinx Serialization requires fields marked as non-optional (no default value) to be present in the input data. The features and announcements fields were missing defaults, causing deserialization failures.

Solution:
Add default values to the LiveInformation data class to ensure backward compatibility with legacy data:


@Serializable
data class LiveInformation(
    private val version: Int = 2,
    val announcements: List<Announcement> = emptyList(), // Default empty list
    val features: Map<String, String?> = emptyMap(),     // Default empty map
) {
    companion object {
        val default = LiveInformation() // Simplified
    }
}

## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->


Fixes #5337  <!-- optional -->

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
✅  Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
