### PR TITLE
Fix crash on Android 16 beta caused by missing canImeRenderGesturalNavButtons()

### DIFF
--- a/quickstep/src/com/android/quickstep/RecentsAnimationDeviceState.java
+++ b/quickstep/src/com/android/quickstep/RecentsAnimationDeviceState.java
@@ -107,6 +107,18 @@ public class RecentsAnimationDeviceState implements DisplayInfoChangeListener, E
     private final RotationTouchHelper mRotationTouchHelper;
     private final TaskStackChangeListener mPipListener;
     // Cache for better performance since it doesn't change at runtime.
+
+private static boolean isImeRenderingNavButtons() {
+    try {
+        java.lang.reflect.Method method = android.inputmethodservice.InputMethodService.class
+            .getDeclaredMethod("canImeRenderGesturalNavButtons");
+        return (Boolean) method.invoke(null);
+    } catch (Exception e) {
+        // Method does not exist, assume false or provide fallback
+        return false;
+    }
+}
+
     private final boolean mCanImeRenderGesturalNavButtons = isImeRenderingNavButtons();
 
     private final ArrayList<Runnable> mOnDestroyActions = new ArrayList<>();

--- a/quickstep/src/com/android/quickstep/RecentsAnimationDeviceState.java
+++ b/quickstep/src/com/android/quickstep/RecentsAnimationDeviceState.java
@@ -108,17 +108,6 @@ public class RecentsAnimationDeviceState implements DisplayInfoChangeListener, E
     private final TaskStackChangeListener mPipListener;
     // Cache for better performance since it doesn't change at runtime.
 
-private static boolean isImeRenderingNavButtons() {
-    try {
-        java.lang.reflect.Method method = android.inputmethodservice.InputMethodService.class
-            .getDeclaredMethod("canImeRenderGesturalNavButtons");
-        return (Boolean) method.invoke(null);
-    } catch (Exception e) {
-        // Method does not exist, assume false or provide fallback
-        return false;
-    }
-}
-
     private final boolean mCanImeRenderGesturalNavButtons = isImeRenderingNavButtons();
 
     private final ArrayList<Runnable> mOnDestroyActions = new ArrayList<>();
@@ -621,10 +610,16 @@ private static boolean isImeRenderingNavButtons() {
     /**
      * Returns whether IME is rendering nav buttons, and IME is currently showing.
      */
-    public boolean isImeRenderingNavButtons() {
-        return mCanImeRenderGesturalNavButtons && mMode == NO_BUTTON
-                && ((mSystemUiStateFlags & SYSUI_STATE_IME_SHOWING) != 0);
+    
+public boolean isImeRenderingNavButtons() {
+    try {
+        java.lang.reflect.Method method = android.inputmethodservice.InputMethodService.class
+            .getDeclaredMethod("canImeRenderGesturalNavButtons");
+        return (Boolean) method.invoke(null);
+    } catch (Exception e) {
+        return false;
     }
+}
 
     /**
      * Returns the touch slop for {@link InputConsumer}s to compare against before


### PR DESCRIPTION
Lawnchair crashes immediately on Android 16 beta (e.g., Pixel 8 Pro) due to a missing method in the Android framework:

```
java
InputMethodService.canImeRenderGesturalNavButtons()
```

This method is not present on some builds of Android 16, resulting in a `NoSuchMethodError` at launch.

Fix
Wrapped the method in `isImeRenderingNavButtons()` with a reflection-based check to safely detect and call it only when available. This prevents the launcher from crashing while preserving functionality on supported devices.

Fixes #5535

Type of change
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
