### PR TITLE
Fix: Adapt to missing Flags in android 16 qpr1 beta 2

### DIFF
--- a/flags/src/com/android/systemui/CustomFeatureFlags.java
+++ b/flags/src/com/android/systemui/CustomFeatureFlags.java
@@ -321,6 +321,12 @@ public class CustomFeatureFlags implements FeatureFlags {
         return getValue(Flags.FLAG_FLOATING_MENU_RADII_ANIMATION,
                 FeatureFlags::floatingMenuRadiiAnimation);
     }
+    
+    @Override
+    public boolean generatedPreviews() {
+        return getValue(Flags.FLAG_GENERATED_PREVIEWS,
+            FeatureFlags::generatedPreviews);
+    }
 
     @Override
     public boolean getConnectedDeviceNameUnsynchronized() {

--- a/flags/src/com/android/systemui/FeatureFlags.java
+++ b/flags/src/com/android/systemui/FeatureFlags.java
@@ -106,6 +106,8 @@ public interface FeatureFlags {
     
     boolean floatingMenuRadiiAnimation();
     
+    boolean generatedPreviews();
+    
     boolean getConnectedDeviceNameUnsynchronized();
     
     boolean glanceableHubAllowKeyguardWhenDreaming();

--- a/flags/src/com/android/systemui/FeatureFlagsImpl.java
+++ b/flags/src/com/android/systemui/FeatureFlagsImpl.java
@@ -64,6 +64,7 @@ public final class FeatureFlagsImpl implements FeatureFlags {
     private static boolean floatingMenuNarrowTargetContentObserver = true;
     private static boolean floatingMenuOverlapsNavBarsFlag = true;
     private static boolean floatingMenuRadiiAnimation = true;
+    private static boolean generatedPreviews = true;
     private static boolean getConnectedDeviceNameUnsynchronized = true;
     private static boolean glanceableHubAllowKeyguardWhenDreaming = false;
     private static boolean glanceableHubFullscreenSwipe = false;
@@ -241,6 +242,7 @@ public final class FeatureFlagsImpl implements FeatureFlags {
         fastUnlockTransition = foundPackage;
         fixImageWallpaperCrashSurfaceAlreadyReleased = foundPackage;
         fixScreenshotActionDismissSystemWindows = foundPackage;
+        generatedPreviews = foundPackage;
         getConnectedDeviceNameUnsynchronized = foundPackage;
         glanceableHubAllowKeyguardWhenDreaming = foundPackage;
         glanceableHubFullscreenSwipe = foundPackage;
@@ -529,6 +531,8 @@ public final class FeatureFlagsImpl implements FeatureFlags {
                     properties.getBoolean(Flags.FLAG_FIX_IMAGE_WALLPAPER_CRASH_SURFACE_ALREADY_RELEASED, true);
             fixScreenshotActionDismissSystemWindows =
                     properties.getBoolean(Flags.FLAG_FIX_SCREENSHOT_ACTION_DISMISS_SYSTEM_WINDOWS, true);
+            generatedPreviews =
+                    properties.getBoolean(Flags.FLAG_GENERATED_PREVIEWS, true);
             getConnectedDeviceNameUnsynchronized =
                     properties.getBoolean(Flags.FLAG_GET_CONNECTED_DEVICE_NAME_UNSYNCHRONIZED, true);
             glanceableHubAllowKeyguardWhenDreaming =
@@ -1551,6 +1555,22 @@ public final class FeatureFlagsImpl implements FeatureFlags {
             }
         }
         return floatingMenuRadiiAnimation;
+
+    }
+    
+    @Override
+    
+    public boolean generatedPreviews() {
+        if (isReadFromNew) {
+            if (!isCached) {
+                init();
+            }
+        } else {
+            if (!systemui_is_cached) {
+                load_overrides_systemui();
+            }
+        }
+        return generatedPreviews;
 
     }
 

--- a/flags/src/com/android/systemui/Flags.java
+++ b/flags/src/com/android/systemui/Flags.java
@@ -105,6 +105,8 @@ public final class Flags {
     /** @hide */
     public static final String FLAG_FLOATING_MENU_RADII_ANIMATION = "com.android.systemui.floating_menu_radii_animation";
     /** @hide */
+    public static final String FLAG_GENERATED_PREVIEWS = "android.appwidget.flags.generated_previews";
+    /** @hide */
     public static final String FLAG_GET_CONNECTED_DEVICE_NAME_UNSYNCHRONIZED = "com.android.systemui.get_connected_device_name_unsynchronized";
     /** @hide */
     public static final String FLAG_GLANCEABLE_HUB_ALLOW_KEYGUARD_WHEN_DREAMING = "com.android.systemui.glanceable_hub_allow_keyguard_when_dreaming";
@@ -507,6 +509,10 @@ public final class Flags {
     
     public static boolean floatingMenuRadiiAnimation() {
         return FEATURE_FLAGS.floatingMenuRadiiAnimation();
+    }
+
+    public static boolean generatedPreviews() {
+        return FEATURE_FLAGS.generatedPreviews();
     }
     
     public static boolean getConnectedDeviceNameUnsynchronized() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.hideApiWarning=false
 kotlin.code.style=official
 
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx16g -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.hideApiWarning=false
 kotlin.code.style=official
 
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx16g -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true

--- a/src/com/android/launcher3/widget/WidgetManagerHelper.java
+++ b/src/com/android/launcher3/widget/WidgetManagerHelper.java
@@ -38,6 +38,7 @@ import com.android.launcher3.model.data.LauncherAppWidgetInfo;
 import com.android.launcher3.pm.UserCache;
 import com.android.launcher3.util.PackageUserKey;
 import com.android.launcher3.widget.custom.CustomWidgetManager;
+import com.android.systemui.Flags;
 
 import java.util.Collections;
 import java.util.List;
@@ -161,7 +162,7 @@ public class WidgetManagerHelper {
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
     public RemoteViews loadGeneratedPreview(@NonNull AppWidgetProviderInfo info,
             int widgetCategory) {
-        if (!android.appwidget.flags.Flags.generatedPreviews()) return null;
+        if (!Flags.generatedPreviews()) return null;
         return mAppWidgetManager.getWidgetPreview(info.provider, info.getProfile(), widgetCategory);
     }
 


### PR DESCRIPTION
## Description

Lawnchair immediately crashes after updating to Android 16 QPR1 beta 2 on my Pixel 9 Pro with [this error](https://github.com/LawnchairLauncher/lawnchair/issues/5535#issuecomment-2963598290):
`java.lang.NoClassDefFoundError: Failed resolution of: Landroid/appwidget/flags/Flags;`

I fixed it by copying the flag into an existing Flags file. Note that I copied it into systemui's Flags file, which is probably wrong/an antipattern. If this is unacceptable, it might be safe to just hardcode the flag as `true`, especially since the original flag was annotated with `@AssumeTrueForR8`.

Fixes https://github.com/LawnchairLauncher/lawnchair/issues/5535 for me, but note that (edit: some of) the bug reports in there point to a different error (referenced in #5537) for some reason? But this works fine on my phone at least

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
