### PR TITLE
Use QuickstepCompatFactoryVV for V device

### DIFF
--- a/systemUI/shared/src/app/lawnchair/compat/LawnchairQuickstepCompat.kt
+++ b/systemUI/shared/src/app/lawnchair/compat/LawnchairQuickstepCompat.kt
@@ -39,10 +39,6 @@ object LawnchairQuickstepCompat {
     @JvmField
     val ATLEAST_V: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM
 
-    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.BAKLAVA)
-    @JvmField
-    val ATLEAST_BAKLAVA: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA
-
     @JvmStatic
     val factory: QuickstepCompatFactory = when {
         ATLEAST_V -> QuickstepCompatFactoryVV()

--- a/systemUI/shared/src/app/lawnchair/compat/LawnchairQuickstepCompat.kt
+++ b/systemUI/shared/src/app/lawnchair/compat/LawnchairQuickstepCompat.kt
@@ -7,6 +7,7 @@ import app.lawnchair.compatlib.ActivityOptionsCompat
 import app.lawnchair.compatlib.QuickstepCompatFactory
 import app.lawnchair.compatlib.RemoteTransitionCompat
 import app.lawnchair.compatlib.eleven.QuickstepCompatFactoryVR
+import app.lawnchair.compatlib.fifteen.QuickstepCompatFactoryVV
 import app.lawnchair.compatlib.fourteen.QuickstepCompatFactoryVU
 import app.lawnchair.compatlib.ten.QuickstepCompatFactoryVQ
 import app.lawnchair.compatlib.thirteen.QuickstepCompatFactoryVT
@@ -38,9 +39,13 @@ object LawnchairQuickstepCompat {
     @JvmField
     val ATLEAST_V: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM
 
+    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.BAKLAVA)
+    @JvmField
+    val ATLEAST_BAKLAVA: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA
+
     @JvmStatic
     val factory: QuickstepCompatFactory = when {
-        ATLEAST_V -> QuickstepCompatFactoryVU()
+        ATLEAST_V -> QuickstepCompatFactoryVV()
         ATLEAST_U -> QuickstepCompatFactoryVU()
         ATLEAST_T -> QuickstepCompatFactoryVT()
         ATLEAST_S -> QuickstepCompatFactoryVS()


### PR DESCRIPTION
## Description

Lawnchair use QuickstepCompatFactoryVU (A14 - 34) for V (A15 - 35) device which is incorrect.

* Backported from Bubble Tea: https://github.com/LawnchairLauncher/lawnchair/pull/5543

This should fix some issue with A15 Quickstep/QuickSwitch but I'm not sure, at least we corrected the conditions.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

✅ General change (non-breaking change that doesn't fit the below categories like copyediting)
✅ Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
