### PR TITLE
GitHub Attestation for Lawnchair Release CI

### DIFF
--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -23,6 +23,9 @@ on:
 jobs:
   build-release-apk:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,6 +50,10 @@ jobs:
         run: ./gradlew assembleLawnWithQuickstepGithubRelease
       - name: Rename artifact
         run: mv build/outputs/apk/**/**/*.apk "${{ github.event.inputs.artifactName }}"
+      - name: Attest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ github.event.inputs.artifactName }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Description

Allow GitHub user to verify if the APK is built by the Lawnchair Release CI with security matching up to SLSA v1.0 Level 1 (or almost Level 2). The attestation will be immutable so maintainer cannot interfere with the attestation even after repository deletion.

* Backported from Bubble Tea: https://github.com/LawnchairLauncher/lawnchair/pull/5543

This change is minimal, nice to have but depends on the maintainer.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

✅ General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
