### PR TITLE
Remove usage of MANAGE_EXTERNAL_STORAGE from Play Store builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,6 +308,14 @@ android {
             }
         }
 
+        github {
+            manifest.srcFile "github/AndroidManifest.xml"
+        }
+
+        nightly {
+            manifest.srcFile "nightly/AndroidManifest.xml"
+        }
+
         lawnWithQuickstepGithub {
             manifest.srcFile "quickstep/AndroidManifest-launcher.xml"
         }

--- a/github/AndroidManifest.xml
+++ b/github/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
+
+</manifest>

--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -26,7 +26,6 @@
     <uses-permission android:name="com.kieronquinn.app.smartspacer.permission.ACCESS_SMARTSPACER"/>
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_HISTORY_BOOKMARKS" />
     <uses-permission android:name="android.permission.WRITE_HISTORY_BOOKMARKS" />
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS" tools:ignore="ProtectedPermissions"/>

--- a/lawnchair/src/app/lawnchair/backup/ui/CreateBackupScreen.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/CreateBackupScreen.kt
@@ -45,6 +45,7 @@ import app.lawnchair.ui.preferences.components.WallpaperPreview
 import app.lawnchair.ui.preferences.components.controls.FlagSwitchPreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
+import app.lawnchair.ui.util.isPlayStoreFlavor
 import app.lawnchair.util.BackHandler
 import app.lawnchair.util.checkAndRequestFilesPermission
 import app.lawnchair.util.filesAndStorageGranted
@@ -74,7 +75,7 @@ fun CreateBackupScreen(
     val permissionState = rememberPermissionState(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             android.Manifest.permission.READ_MEDIA_IMAGES
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !isPlayStoreFlavor()) {
             android.Manifest.permission.MANAGE_EXTERNAL_STORAGE
         } else {
             android.Manifest.permission.READ_EXTERNAL_STORAGE

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/WallpaperPreview.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/WallpaperPreview.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.graphics.drawable.toBitmap
 import app.lawnchair.preferences.PreferenceManager
+import app.lawnchair.ui.util.isPlayStoreFlavor
 import app.lawnchair.util.checkAndRequestFilesPermission
 import app.lawnchair.util.filesAndStorageGranted
 import app.lawnchair.util.scaleDownToDisplaySize
@@ -50,7 +51,7 @@ fun wallpaperDrawable(): Drawable? {
     val permissionState = rememberPermissionState(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             android.Manifest.permission.READ_MEDIA_IMAGES
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !isPlayStoreFlavor()) {
             android.Manifest.permission.MANAGE_EXTERNAL_STORAGE
         } else {
             android.Manifest.permission.READ_EXTERNAL_STORAGE

--- a/lawnchair/src/app/lawnchair/ui/util/BuildConfigUtils.kt
+++ b/lawnchair/src/app/lawnchair/ui/util/BuildConfigUtils.kt
@@ -1,0 +1,5 @@
+package app.lawnchair.ui.util
+
+import com.android.launcher3.BuildConfig
+
+fun isPlayStoreFlavor(): Boolean = BuildConfig.FLAVOR_channel == "play"

--- a/nightly/AndroidManifest.xml
+++ b/nightly/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
+
+</manifest>


### PR DESCRIPTION
## Description

Required for unblocking Play Store releases and eventually [#5564](https://github.com/LawnchairLauncher/lawnchair/issues/5564).

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
