### PR TITLE
Update Kagi quick search bat provider to support Kagi app with fallback

### DIFF
--- a/lawnchair/src/app/lawnchair/qsb/providers/Kagi.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Kagi.kt
@@ -3,14 +3,18 @@ package app.lawnchair.qsb.providers
 import app.lawnchair.qsb.ThemingMethod
 import com.android.launcher3.R
 
+/**
+ * Unified Kagi search provider that attempts to launch the Kagi mobile app first,
+ * and falls back to opening the Kagi website if the app is not installed.
+ */
 data object Kagi : QsbSearchProvider(
     id = "kagi",
     name = R.string.search_provider_kagi,
     icon = R.drawable.ic_kagi,
     themedIcon = R.drawable.ic_kagi_tinted,
     themingMethod = ThemingMethod.TINT,
-    packageName = "",
+    packageName = "com.kagi.search",
     website = "https://kagi.com",
-    type = QsbSearchProviderType.LOCAL,
+    type = QsbSearchProviderType.APP_AND_WEBSITE,
     sponsored = false,
 )


### PR DESCRIPTION
- Add package name for Kagi mobile app (com.kagi.search)
- Change type from LOCAL to APP_AND_WEBSITE for unified behavior
- Add documentation explaining app-first, website-fallback approach

## Description

Update Kagi quick search bat provider to support Kagi app with fallback. This is typically faster than navigating to the kagi website in the default browser.

## Type of change

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:white_check_mark: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
