### PR TITLE
Don't call setAccessibilityPaneTitle when device is not at least Android 9

### DIFF
--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarView.java
+++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarView.java
@@ -280,9 +280,10 @@ public class TaskbarView extends FrameLayout implements FolderIcon.FolderIconPar
     }
 
     protected void init(TaskbarViewCallbacks callbacks) {
-        // set taskbar pane title so that accessibility service know it window and
-        // focuses.
-        setAccessibilityPaneTitle(getContext().getString(R.string.taskbar_a11y_title));
+        if (Utilities.ATLEAST_P) {
+            // set taskbar pane title so that accessibility service know it window and focuses.
+            setAccessibilityPaneTitle(getContext().getString(R.string.taskbar_a11y_title));
+        }
         mControllerCallbacks = callbacks;
         mIconClickListener = mControllerCallbacks.getIconOnClickListener();
         mIconLongClickListener = mControllerCallbacks.getIconOnLongClickListener();

--- a/quickstep/src/com/android/quickstep/views/SplitInstructionsView.java
+++ b/quickstep/src/com/android/quickstep/views/SplitInstructionsView.java
@@ -158,7 +158,9 @@ public class SplitInstructionsView extends LinearLayout {
         }
 
         // Set accessibility title, will be announced by a11y tools.
-        instructionTextView.setAccessibilityPaneTitle(instructionTextView.getText());
+        if (Utilities.ATLEAST_P) {
+            instructionTextView.setAccessibilityPaneTitle(instructionTextView.getText());
+        }
     }
 
     private void exitSplitSelection() {

--- a/src/com/android/launcher3/popup/PopupContainerWithArrow.java
+++ b/src/com/android/launcher3/popup/PopupContainerWithArrow.java
@@ -48,6 +48,7 @@ import com.android.launcher3.DropTarget.DragObject;
 import com.android.launcher3.Flags;
 import com.android.launcher3.Launcher;
 import com.android.launcher3.R;
+import com.android.launcher3.Utilities;
 import com.android.launcher3.accessibility.LauncherAccessibilityDelegate;
 import com.android.launcher3.accessibility.ShortcutMenuAccessibilityDelegate;
 import com.android.launcher3.dragndrop.DragController;
@@ -254,7 +255,9 @@ public class PopupContainerWithArrow<T extends Context & ActivityContext>
      * Animates and loads shortcuts on background thread for this popup container
      */
     private void loadAppShortcuts(ItemInfo originalItemInfo) {
-        setAccessibilityPaneTitle(getTitleForAccessibility());
+        if (Utilities.ATLEAST_P) {
+            setAccessibilityPaneTitle(getTitleForAccessibility());
+        }
         mOriginalIcon.setForceHideDot(true);
         // All views are added. Animate layout from now on.
         setLayoutTransition(new LayoutTransition());

--- a/src/com/android/launcher3/widget/picker/WidgetsTwoPaneSheet.java
+++ b/src/com/android/launcher3/widget/picker/WidgetsTwoPaneSheet.java
@@ -281,7 +281,9 @@ public class WidgetsTwoPaneSheet extends WidgetsFullSheet {
             mRightPane.removeAllViews();
             mRightPane.addView(mWidgetRecommendationsContainer);
             mRightPaneScrollView.setScrollY(0);
-            mRightPane.setAccessibilityPaneTitle(suggestionsRightPaneTitle);
+            if (Utilities.ATLEAST_P) {
+                mRightPane.setAccessibilityPaneTitle(suggestionsRightPaneTitle);
+            }
             mSuggestedWidgetsPackageUserKey = PackageUserKey.fromPackageItemInfo(packageItemInfo);
             final boolean isChangingHeaders = mSelectedHeader == null
                     || !mSelectedHeader.equals(mSuggestedWidgetsPackageUserKey);


### PR DESCRIPTION
## Description

... because setAccessibilityPaneTitle doesn't exist in Android 8.1

Fixes #5518

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
