### PR TITLE
Revert "Add Lawnfeed to FeedBridge.kt whitelist"

### DIFF
--- a/lawnchair/src/app/lawnchair/FeedBridge.kt
+++ b/lawnchair/src/app/lawnchair/FeedBridge.kt
@@ -163,7 +163,6 @@ class FeedBridge(private val context: Context) {
             whitelist["amirz.aidlbridge"] = 0xb662cc2f
             whitelist["com.google.android.googlequicksearchbox"] = 0xe3ca78d8
             whitelist["com.google.android.apps.nexuslauncher"] = 0xb662cc2f
-            whitelist["app.lawnchair.lawnfeed"] = getSignatureHash(context, "app.lawnchair.lawnfeed")
         }
 
         fun getAvailableProviders(context: Context) = context.packageManager


### PR DESCRIPTION
Reverts LawnchairLauncher/lawnchair#5624

Re-open #5139

This is supposed to be a bridge, not as news provider.

See:

https://github.com/LawnchairLauncher/lawnchair/blob/6e4953042e16747fefcd7b8942a45c82b0c8dd7a/lawnchair/src/app/lawnchair/FeedBridge.kt#L41-L46