### PR TITLE
Fix About showing update button despite Lawnchair being its latest version

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/CheckUpdate.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/CheckUpdate.kt
@@ -52,8 +52,13 @@ fun CheckUpdate(
     var isDownloading by remember { mutableStateOf(false) }
     var downloadedFile by remember { mutableStateOf<File?>(null) }
 
+    // As of now the version string looks like this (CI builds only):
+    // <major>.<branch>.(#<CI build number>)
+    // This is done inside build.gradle in the source root. Reflect
+    // changes from there if needed.
     val currentVersionNumber = BuildConfig.VERSION_DISPLAY_NAME
         .substringAfterLast("#")
+        .removeSuffix(")")
         .toIntOrNull() ?: 0
 
     LaunchedEffect(Unit) {


### PR DESCRIPTION
## Description

Fix About showing update button despite Lawnchair being its latest version (#5591)

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:x: General change (non-breaking change that doesn't fit the below categories like copyediting)
:white_check_mark: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
