### PR TITLE
refactor(permissions): Unify file and media permission handling

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="layout">Layout</string>
 
     <!-- Generic styling options -->
+    <string name="show_wallpaper">Show wallpaper</string>
     <string name="wallpaper">Wallpaper</string>
     <string name="style">Style</string>
     <string name="background_opacity">Background opacity</string>
@@ -212,10 +213,6 @@
     <string name="notification_dots_text_color">Notification counter color</string>
     <string name="notification_dots_color_contrast_warning_always">Warning: Notification dot and counter colors don\'t have enough contrast with each other</string>
     <string name="notification_dots_color_contrast_warning_sometimes">Warning: Notification dot and counter colors might not always have enough contrast with each other</string>
-
-    <string name="missing_notification_access_label">Notification access needed</string>
-    <string name="missing_notification_access_desc">To show Notification Dots, turn on app notifications for <xliff:g id="name" example="My App">%1$s</xliff:g></string>
-
     <!--
 
     Icons
@@ -795,6 +792,10 @@
     <string name="search_pref_result_history_title">Search history</string>
     <string name="all_apps_search_result_calculator">Calculator</string>
 
+    <string name="search_empty_state_title">Start searching</string>
+    <string name="search_empty_state_no_history_subtitle">Find apps, contacts, and more. Your recent searches will appear here.</string>
+    <string name="search_empty_state_history_disabled_subtitle">Find apps, contacts, and more.</string>
+
     <!-- Description for each search result type -->
     <string name="search_pref_files_search_on">Search on</string>
 
@@ -811,38 +812,47 @@
     <string name="max_suggestion_result_count_title">Maximum number of suggestions</string>
     <string name="max_web_suggestion_delay">Maximum web suggestion delay</string>
 
-    <!-- Permission warnings -->
-    <string name="warn_contact_permission_title">Contacts permission needed</string>
-    <string name="warn_contact_permission_content">To search for contacts, grant contacts and phone permissions to Lawnchair</string>
+    <!-- Permission management -->
+    <string name="missing_notification_access_label">Notification access needed</string>
+    <string name="missing_notification_access_desc">To show Notification Dots, turn on app notifications for <xliff:g id="name" example="My App">%1$s</xliff:g></string>
 
-    <string name="warn_files_permission_content">To search your files, grant storage permissions to Lawnchair</string>
+    <string name="warn_contact_permission_title">Contacts permission needed</string>
+    <string name="warn_contact_permission_content">To search for contacts, grant contacts and phone permissions to <xliff:g id="name" example="My App">%1$s</xliff:g></string>
 
     <string name="permissions_music_audio">Music and audio access needed</string>
-    <string name="permissions_music_audio_description">To search your music and other audio files, Lawnchair needs permission to access your media library.</string>
+    <string name="permissions_music_audio_description">To search your music and other audio files, <xliff:g id="name" example="My App">%1$s</xliff:g> needs permission to access your media library.</string>
 
-    <string name="permissions_external_storage">External storage access needed</string>
-    <string name="permissions_external_storage_description">To search your files, Lawnchair needs permission to access your device\'s external storage.</string>
-
-    <string name="permissions_manage_storage">Manage storage access needed</string>
-    <string name="permissions_manage_storage_description">To display your files in search results, Lawnchair requires permission to manage all files on your device. This permission is used solely to list files and will not be used to read or change the content of your personal files.</string>
-    <string name="permissions_manage_storage_description_wallpaper">To display previews of your current wallpaper and include it in backups, Lawnchair requires permission to manage all files on your device. This permission is required due to system limitations for accessing wallpaper data for these features.</string>
-
-    <string name="manage_storage_access_denied_title">Cannot enable manage storage access</string>
-    <string name="manage_storage_access_denied_description">Due to Play Store policy, Lawnchair cannot request full storage access here. To access all files, please download Lawnchair from GitHub. Alternatively, you can grant access to photos, videos, and audio files individually in settings.</string>
-
+    <!-- Photos and videos -->
     <string name="permissions_photos_videos">Photos and videos access needed</string>
-    <string name="permissions_photos_videos_description">To search your photos and videos, Lawnchair needs permission to access your media library.</string>
+    <string name="permissions_photos_videos_description">To search your photos and videos, <xliff:g id="name" example="My App">%1$s</xliff:g> needs permission to access your media library.</string>
 
     <string name="permissions_photos_videos_full">Access your full media library?</string>
-    <string name="permissions_photos_videos_full_description">To search all your photos and videos, Lawnchair needs full access to your media library.</string>
+    <string name="permissions_photos_videos_full_description">To search all your photos and videos, <xliff:g id="name" example="My App">%1$s</xliff:g> needs full access to your media library.</string>
     <string name="permissions_photos_videos_grant_full">Grant full media permissions</string>
     <string name="permissions_photos_videos_manage_selected">Manage selected items</string>
+
+    <!-- External storage -->
+    <string name="permissions_external_storage">External storage access needed</string>
+    <string name="permissions_external_storage_description">To search your files, <xliff:g id="name" example="My App">%1$s</xliff:g> needs permission to access your device\'s external storage.</string>
+
+    <string name="permissions_manage_storage">Manage storage access needed</string>
+    <string name="permissions_manage_storage_description">To display your files in search results, <xliff:g id="name" example="My App">%1$s</xliff:g> requires permission to manage all files on your device. This permission is used solely to list files and will not be used to read or change the content of your personal files.</string>
+
+    <string name="permission_desc_wallpaper_base">To display wallpaper previews and include them in backups, <xliff:g id="name" example="My App">%1$s</xliff:g> requires permission %2$s. This is due to system limitations for accessing wallpaper data.</string>
+    <string name="permission_desc_ending_read_all_files">to read all files on your device</string>
+    <string name="permission_desc_ending_manage_all_files">to manage all files on your device</string>
+
+    <string name="permission_desc_wallpaper_multiple">Multiple permissions needed</string>
+    <string name="permission_desc_wallpaper_multiple_desc">To display wallpaper previews and include them in backups, <xliff:g id="name" example="My App">%1$s</xliff:g> requires the following permissions. This is due to system limitations for accessing wallpaper data.</string>
+
+    <string name="permission_label_manage_all_files">Manage all files on device</string>
+    <string name="permission_label_read_photos_videos">Read photos and videos</string>
+
+    <string name="manage_storage_access_denied_title">Cannot enable manage storage access</string>
+    <string name="manage_storage_access_denied_description">Due to Play Store policy, <xliff:g id="name" example="My App">%1$s</xliff:g> cannot request full storage access here. To access all files, please download <xliff:g id="name" example="My App">%1$s</xliff:g> from GitHub. Alternatively, you can grant access to photos, videos, and audio files individually in settings.</string>
 
     <string name="open_permission_settings">Open settings</string>
     <string name="grant_requested_permissions">Grant permissions</string>
     <string name="permissions_needed">Permissions needed</string>
-
-
-    <string name="search_empty_state_title">Start searching</string>
-    <string name="search_empty_state_no_history_subtitle">Find apps, contacts, and more. Your recent searches will appear here.</string>
-    <string name="search_empty_state_history_disabled_subtitle">Find apps, contacts, and more.</string></resources>
+    <string name="grant_requested_permissions_tap">Tap to grant permissions</string>
+</resources>

--- a/lawnchair/src/app/lawnchair/backup/ui/CreateBackupScreen.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/CreateBackupScreen.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.app.WallpaperManager
 import android.content.Intent
 import android.content.res.Configuration
-import android.os.Build
 import android.provider.DocumentsContract
 import android.util.Log
 import android.widget.Toast
@@ -37,27 +36,22 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.backup.LawnchairBackup
-import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.ui.preferences.LocalIsExpandedScreen
 import app.lawnchair.ui.preferences.LocalNavController
 import app.lawnchair.ui.preferences.components.DummyLauncherBox
+import app.lawnchair.ui.preferences.components.WallpaperAccessPermissionDialog
 import app.lawnchair.ui.preferences.components.WallpaperPreview
+import app.lawnchair.ui.preferences.components.WithWallpaper
 import app.lawnchair.ui.preferences.components.controls.FlagSwitchPreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
-import app.lawnchair.ui.util.isPlayStoreFlavor
 import app.lawnchair.util.BackHandler
-import app.lawnchair.util.checkAndRequestFilesPermission
-import app.lawnchair.util.filesAndStorageGranted
+import app.lawnchair.util.FileAccessState
 import app.lawnchair.util.hasFlag
 import app.lawnchair.util.removeFlag
 import com.android.launcher3.R
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.isGranted
-import com.google.accompanist.permissions.rememberPermissionState
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun CreateBackupScreen(
     viewModel: CreateBackupViewModel,
@@ -72,16 +66,11 @@ fun CreateBackupScreen(
 
     val context = LocalContext.current
     val hasLiveWallpaper = remember { WallpaperManager.getInstance(context).wallpaperInfo != null }
-    val permissionState = rememberPermissionState(
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            android.Manifest.permission.READ_MEDIA_IMAGES
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !isPlayStoreFlavor()) {
-            android.Manifest.permission.MANAGE_EXTERNAL_STORAGE
-        } else {
-            android.Manifest.permission.READ_EXTERNAL_STORAGE
-        },
-    )
-    val hasStoragePermission = permissionState.status.isGranted || filesAndStorageGranted(context)
+    val allFilesAccessState by viewModel.allFilesAccessState.collectAsStateWithLifecycle()
+    val wallpaperAccessState by viewModel.wallpaperAccessState.collectAsStateWithLifecycle()
+    val hasWallpaperPermission = wallpaperAccessState == FileAccessState.Full
+
+    var showPermissionDialog by remember { mutableStateOf(false) }
 
     val scope = rememberCoroutineScope()
     var creatingBackup by remember { mutableStateOf(false) }
@@ -120,11 +109,12 @@ fun CreateBackupScreen(
     PreferenceLayout(
         label = stringResource(id = R.string.create_backup),
         modifier = modifier,
+        isExpandedScreen = true,
         backArrowVisible = !LocalIsExpandedScreen.current,
         scrollState = if (isPortrait) null else scrollState,
     ) {
-        DisposableEffect(contents, hasLiveWallpaper, hasStoragePermission) {
-            val canBackupWallpaper = hasLiveWallpaper || !hasStoragePermission
+        DisposableEffect(contents, hasLiveWallpaper, hasWallpaperPermission) {
+            val canBackupWallpaper = hasLiveWallpaper || !hasWallpaperPermission
             if (contents.hasFlag(LawnchairBackup.INCLUDE_WALLPAPER) && canBackupWallpaper) {
                 viewModel.setBackupContents(contents.removeFlag(LawnchairBackup.INCLUDE_WALLPAPER))
             }
@@ -132,23 +122,30 @@ fun CreateBackupScreen(
         }
 
         if (isPortrait) {
-            DummyLauncherBox(
-                modifier = Modifier
-                    .padding(top = 8.dp)
-                    .weight(1f)
-                    .align(Alignment.CenterHorizontally)
-                    .clip(MaterialTheme.shapes.large),
-            ) {
-                if (contents.hasFlag(LawnchairBackup.INCLUDE_WALLPAPER)) {
-                    WallpaperPreview(modifier = Modifier.fillMaxSize())
-                }
-                if (contents.hasFlag(LawnchairBackup.INCLUDE_LAYOUT_AND_SETTINGS)) {
-                    Image(
-                        bitmap = screenshot.asImageBitmap(),
-                        contentDescription = null,
-                        modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.FillHeight,
-                    )
+            WithWallpaper(
+                displayWallpaperButton = false,
+            ) { wallpaper ->
+                DummyLauncherBox(
+                    modifier = Modifier
+                        .padding(top = 8.dp)
+                        .weight(1f)
+                        .align(Alignment.CenterHorizontally)
+                        .clip(MaterialTheme.shapes.large),
+                ) {
+                    if (contents.hasFlag(LawnchairBackup.INCLUDE_WALLPAPER)) {
+                        WallpaperPreview(
+                            wallpaper = wallpaper,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                    if (contents.hasFlag(LawnchairBackup.INCLUDE_LAYOUT_AND_SETTINGS)) {
+                        Image(
+                            bitmap = screenshot.asImageBitmap(),
+                            contentDescription = null,
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.FillHeight,
+                        )
+                    }
                 }
             }
         }
@@ -163,8 +160,8 @@ fun CreateBackupScreen(
             FlagSwitchPreference(
                 flags = contents,
                 setFlags = {
-                    if (it.hasFlag(LawnchairBackup.INCLUDE_WALLPAPER) && !hasStoragePermission) {
-                        checkAndRequestFilesPermission(context, PreferenceManager.getInstance(context))
+                    if (it.hasFlag(LawnchairBackup.INCLUDE_WALLPAPER) && !hasWallpaperPermission) {
+                        showPermissionDialog = true
                     } else {
                         viewModel.setBackupContents(it)
                     }
@@ -189,6 +186,16 @@ fun CreateBackupScreen(
             ) {
                 Text(text = stringResource(id = R.string.action_create))
             }
+        }
+
+        if (showPermissionDialog) {
+            WallpaperAccessPermissionDialog(
+                managedFilesChecked = allFilesAccessState == FileAccessState.Full,
+                onDismiss = {
+                    showPermissionDialog = false
+                    viewModel.refreshFilePermissionStates()
+                },
+            )
         }
     }
 }

--- a/lawnchair/src/app/lawnchair/backup/ui/CreateBackupScreen.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/CreateBackupScreen.kt
@@ -193,6 +193,8 @@ fun CreateBackupScreen(
                 managedFilesChecked = allFilesAccessState == FileAccessState.Full,
                 onDismiss = {
                     showPermissionDialog = false
+                },
+                onPermissionRequest = {
                     viewModel.refreshFilePermissionStates()
                 },
             )

--- a/lawnchair/src/app/lawnchair/backup/ui/CreateBackupViewModel.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/CreateBackupViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import app.lawnchair.backup.LawnchairBackup
+import app.lawnchair.util.FileAccessManager
 import app.lawnchair.views.LauncherPreviewView
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.R
@@ -27,6 +28,14 @@ class CreateBackupViewModel(
 ) : AndroidViewModel(application) {
     val screenshot = MutableStateFlow(Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
     val screenshotDone = MutableStateFlow(false)
+
+    private val fileAccessManager = FileAccessManager.getInstance(application)
+    val allFilesAccessState = fileAccessManager.allFilesAccessState
+    val wallpaperAccessState = fileAccessManager.wallpaperAccessState
+
+    fun refreshFilePermissionStates() {
+        fileAccessManager.refresh()
+    }
 
     val backupContents = savedStateHandle.getStateFlow(
         "contents",

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/About.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/About.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,7 +43,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import app.lawnchair.preferences.preferenceManager
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.ui.preferences.LocalIsExpandedScreen
 import app.lawnchair.ui.preferences.components.CheckUpdate
 import app.lawnchair.ui.preferences.components.NavigationActionPreference
@@ -50,7 +51,8 @@ import app.lawnchair.ui.preferences.components.controls.ClickablePreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.navigation.AboutLicenses
-import app.lawnchair.util.checkAndRequestFilesPermission
+import app.lawnchair.util.FileAccessManager
+import app.lawnchair.util.FileAccessState
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
 
@@ -254,11 +256,11 @@ fun About(
                     },
                 ),
             )
+            val fileAccessManager = remember { FileAccessManager.getInstance(context) }
+            val allFileAccessState = fileAccessManager.allFilesAccessState.collectAsStateWithLifecycle().value
+
             if (BuildConfig.APPLICATION_ID.contains("nightly") &&
-                checkAndRequestFilesPermission(
-                    context,
-                    preferenceManager(),
-                )
+                allFileAccessState == FileAccessState.Full
             ) {
                 Spacer(modifier = Modifier.height(8.dp))
                 CheckUpdate()

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/GridOverridesPreview.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/GridOverridesPreview.kt
@@ -1,27 +1,41 @@
 package app.lawnchair.ui.preferences.components
 
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import app.lawnchair.DeviceProfileOverrides
 import app.lawnchair.preferences.preferenceManager
 import com.android.launcher3.InvariantDeviceProfile
 
 @Composable
-fun GridOverridesPreview(
+fun ColumnScope.GridOverridesPreview(
     modifier: Modifier = Modifier,
     updateGridOptions: DeviceProfileOverrides.DBGridInfo.() -> DeviceProfileOverrides.DBGridInfo,
 ) {
-    DummyLauncherBox(modifier = modifier) {
-        WallpaperPreview(modifier = Modifier.fillMaxSize())
-        DummyLauncherLayout(
-            idp = createPreviewIdp(updateGridOptions),
-            modifier = Modifier.fillMaxSize(),
-        )
+    WithWallpaper { wallpaper ->
+        DummyLauncherBox(
+            modifier = modifier
+                .weight(1f)
+                .align(Alignment.CenterHorizontally)
+                .clip(MaterialTheme.shapes.large),
+        ) {
+            WallpaperPreview(
+                wallpaper = wallpaper,
+                modifier = Modifier.fillMaxSize(),
+            )
+            DummyLauncherLayout(
+                idp = createPreviewIdp(updateGridOptions),
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
     }
 }
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/LauncherPreview.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/LauncherPreview.kt
@@ -11,9 +11,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.toInt
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.coerceAtLeast
+import androidx.compose.ui.unit.width
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import app.lawnchair.LauncherPreviewManager
@@ -88,6 +92,45 @@ fun createPreviewView(idp: InvariantDeviceProfile = invariantDeviceProfile()): V
     }
     val previewManager = remember { LauncherPreviewManager(context) }
     return remember(idp) { previewManager.createPreviewView(idp) }
+}
+
+/**
+ * A Modifier that clips a composable to visually show only its bottom portion,
+ * defined by the `percentageToShow` (e.g., 0.3f for the bottom 30%).
+ *
+ * It adjusts the layout bounds of the composable to match this visible percentage
+ * and translates the content within those bounds so that the bottom part is visible.
+ *
+ * @param percentageToShow The fraction of the composable's bottom to show (0.0f to 1.0f).
+ *                         0.0f would show nothing, 1.0f would show everything.
+ */
+fun Modifier.clipToBottomPercentage(percentageToShow: Float): Modifier {
+    if (percentageToShow <= 0f) {
+        return this.layout { measurable, constraints ->
+            val placeable = measurable.measure(constraints)
+            layout(placeable.width, 0) {}
+        }
+    }
+    if (percentageToShow >= 1.0f) {
+        return this
+    }
+
+    return this
+        .layout { measurable, constraints ->
+            val placeable = measurable.measure(constraints)
+
+            val visibleHeight = (placeable.height * percentageToShow).toInt().coerceAtLeast(0)
+
+            val translationYValue = -(placeable.height - visibleHeight).toFloat()
+
+            layout(placeable.width, visibleHeight) {
+                placeable.placeRelative(
+                    x = 0,
+                    y = translationYValue.toInt(),
+                )
+            }
+        }
+        .clipToBounds()
 }
 
 fun Modifier.clipToPercentage(percentage: Float): Modifier {

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/LauncherPreview.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/LauncherPreview.kt
@@ -11,13 +11,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshots.toInt
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.coerceAtLeast
-import androidx.compose.ui.unit.width
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import app.lawnchair.LauncherPreviewManager

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/PermissionDialog.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/PermissionDialog.kt
@@ -1,0 +1,254 @@
+package app.lawnchair.ui.preferences.components
+
+import android.Manifest
+import android.os.Build
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.lawnchair.ui.util.isPlayStoreFlavor
+import app.lawnchair.util.openAppPermissionSettings
+import app.lawnchair.util.requestManageAllFilesAccessPermission
+import com.android.launcher3.R
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.google.accompanist.permissions.rememberPermissionState
+import com.google.accompanist.permissions.shouldShowRationale
+
+/**
+ * A dialog that requests a permission.
+ *
+ * @param title The title of the dialog.
+ * @param text The text of the dialog.
+ * @param isPermanentlyDenied Whether the permission is permanently denied.
+ * @param onConfirm Called when the user confirms the dialog.
+ * @param onDismiss Called when the dialog is dismissed.
+ * @param onGoToSettings Called when the user clicks the "Go to settings" button.
+ * @param modifier The modifier to be applied to the dialog.
+ */
+@Composable
+fun PermissionDialog(
+    title: String,
+    text: String,
+    isPermanentlyDenied: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    onGoToSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        title = { Text(title) },
+        text = { Text(text) },
+        confirmButton = {
+            Button(
+                onClick = {
+                    if (isPermanentlyDenied) onGoToSettings() else onConfirm()
+                    onDismiss()
+                },
+            ) {
+                Text(
+                    stringResource(
+                        if (isPermanentlyDenied) R.string.open_permission_settings else R.string.grant_requested_permissions,
+                    ),
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(android.R.string.cancel)) }
+        },
+    )
+}
+
+/**
+ * A dialog that requests wallpaper access permission.
+ *
+ * @param onDismiss Called when the dialog is dismissed.
+ * @param modifier The modifier to be applied to the dialog.
+ * @param onPermissionRequest Called when a permission request is initiated.
+ */
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun WallpaperAccessPermissionDialog(
+    managedFilesChecked: Boolean,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    onPermissionRequest: () -> Unit = {},
+) {
+    val context = LocalContext.current
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        if (isPlayStoreFlavor()) {
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                modifier = modifier,
+                title = {
+                    Text(stringResource(R.string.manage_storage_access_denied_title))
+                },
+                text = {
+                    Text(stringResource(R.string.manage_storage_access_denied_description, stringResource(id = R.string.derived_app_name)))
+                },
+                confirmButton = {
+                    FilledTonalButton(onClick = onDismiss) { Text(stringResource(R.string.dismiss)) }
+                },
+            )
+        } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                AlertDialog(
+                    onDismissRequest = onDismiss,
+                    modifier = modifier,
+                    title = {
+                        Text(stringResource(R.string.permission_desc_wallpaper_multiple))
+                    },
+                    text = {
+                        val mediaPermission = rememberMultiplePermissionsState(
+                            listOf(Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO),
+                        )
+
+                        Column {
+                            Text(stringResource(R.string.permission_desc_wallpaper_multiple_desc, stringResource(id = R.string.derived_app_name)))
+
+                            Spacer(modifier = Modifier.height(8.dp))
+                            PermissionRow(
+                                isChecked = managedFilesChecked,
+                                onClick = {
+                                    onPermissionRequest()
+                                    context.requestManageAllFilesAccessPermission()
+                                },
+                                permissionName = stringResource(R.string.permission_label_manage_all_files),
+                            )
+                            PermissionRow(
+                                isChecked = mediaPermission.allPermissionsGranted,
+                                onClick = {
+                                    onPermissionRequest()
+                                    if (mediaPermission.shouldShowRationale) {
+                                        context.openAppPermissionSettings()
+                                    } else {
+                                        mediaPermission.launchMultiplePermissionRequest()
+                                    }
+                                },
+                                permissionName = stringResource(id = R.string.permission_label_read_photos_videos),
+                            )
+                        }
+                    },
+                    confirmButton = {
+                        TextButton(onClick = onDismiss) { Text(stringResource(android.R.string.cancel)) }
+                    },
+                )
+            } else {
+                PermissionDialog(
+                    title = stringResource(R.string.permissions_manage_storage),
+                    modifier = modifier,
+                    text = stringResource(
+                        R.string.permission_desc_wallpaper_base,
+                        stringResource(id = R.string.derived_app_name),
+                        stringResource(R.string.permission_desc_ending_manage_all_files),
+                    ),
+                    isPermanentlyDenied = true,
+                    onConfirm = {},
+                    onDismiss = onDismiss,
+                    onGoToSettings = {
+                        context.requestManageAllFilesAccessPermission()
+                    },
+                )
+            }
+        }
+    } else {
+        val permission = rememberPermissionState(Manifest.permission.READ_EXTERNAL_STORAGE)
+
+        PermissionDialog(
+            title = stringResource(R.string.permissions_external_storage),
+            modifier = modifier,
+            text = stringResource(
+                R.string.permission_desc_wallpaper_base,
+                stringResource(id = R.string.derived_app_name),
+                stringResource(R.string.permission_desc_ending_read_all_files),
+            ),
+            isPermanentlyDenied = permission.status.shouldShowRationale,
+            onConfirm = {
+                onPermissionRequest()
+                permission.launchPermissionRequest()
+            },
+            onDismiss = onDismiss,
+            onGoToSettings = { context.openAppPermissionSettings() },
+        )
+    }
+}
+
+@Composable
+fun PermissionRow(
+    isChecked: Boolean,
+    onClick: () -> Unit,
+    permissionName: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .clip(MaterialTheme.shapes.large)
+            .clickable(onClick = onClick, enabled = !isChecked)
+            .fillMaxWidth()
+            .padding(vertical = 16.dp, horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val color = if (isChecked) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.errorContainer
+
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .background(
+                    color = color,
+                    shape = CircleShape,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = if (isChecked) Icons.Rounded.Check else Icons.Rounded.Close,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = contentColorFor(color),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+        Column {
+            Text(
+                permissionName,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (!isChecked) {
+                Text(
+                    stringResource(R.string.grant_requested_permissions_tap),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/PermissionDialog.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/PermissionDialog.kt
@@ -26,6 +26,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -120,7 +123,13 @@ fun WallpaperAccessPermissionDialog(
                 },
             )
         } else {
+            val latestOnDismiss by rememberUpdatedState(onDismiss)
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val mediaPermission = rememberMultiplePermissionsState(
+                    listOf(Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO),
+                )
+
                 AlertDialog(
                     onDismissRequest = onDismiss,
                     modifier = modifier,
@@ -128,10 +137,6 @@ fun WallpaperAccessPermissionDialog(
                         Text(stringResource(R.string.permission_desc_wallpaper_multiple))
                     },
                     text = {
-                        val mediaPermission = rememberMultiplePermissionsState(
-                            listOf(Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO),
-                        )
-
                         Column {
                             Text(stringResource(R.string.permission_desc_wallpaper_multiple_desc, stringResource(id = R.string.derived_app_name)))
 
@@ -162,6 +167,12 @@ fun WallpaperAccessPermissionDialog(
                         TextButton(onClick = onDismiss) { Text(stringResource(android.R.string.cancel)) }
                     },
                 )
+
+                LaunchedEffect(managedFilesChecked, mediaPermission.allPermissionsGranted) {
+                    if (managedFilesChecked && mediaPermission.allPermissionsGranted) {
+                        latestOnDismiss()
+                    }
+                }
             } else {
                 PermissionDialog(
                     title = stringResource(R.string.permissions_manage_storage),
@@ -178,6 +189,11 @@ fun WallpaperAccessPermissionDialog(
                         context.requestManageAllFilesAccessPermission()
                     },
                 )
+                LaunchedEffect(managedFilesChecked) {
+                    if (managedFilesChecked) {
+                        latestOnDismiss()
+                    }
+                }
             }
         }
     } else {

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/WallpaperPreview.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/WallpaperPreview.kt
@@ -85,7 +85,6 @@ fun ColumnScope.WithWallpaper(
             managedFilesChecked = allFilesAccessState != FileAccessState.Denied,
             onDismiss = {
                 showPermissionDialog = false
-                fileAccessManager.refresh()
             },
             onPermissionRequest = {
                 fileAccessManager.refresh()

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/WallpaperPreview.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/WallpaperPreview.kt
@@ -2,37 +2,110 @@ package app.lawnchair.ui.preferences.components
 
 import android.annotation.SuppressLint
 import android.app.WallpaperManager
-import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
-import android.os.Build
 import android.util.Size
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Wallpaper
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
-import app.lawnchair.preferences.PreferenceManager
+import androidx.core.graphics.drawable.toDrawable
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.lawnchair.ui.util.isPlayStoreFlavor
-import app.lawnchair.util.checkAndRequestFilesPermission
-import app.lawnchair.util.filesAndStorageGranted
+import app.lawnchair.util.FileAccessManager
+import app.lawnchair.util.FileAccessState
 import app.lawnchair.util.scaleDownToDisplaySize
+import com.android.launcher3.R
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.isGranted
-import com.google.accompanist.permissions.rememberPermissionState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 @Composable
+fun ColumnScope.WithWallpaper(
+    modifier: Modifier = Modifier,
+    displayWallpaperButton: Boolean = true,
+    content: @Composable ColumnScope.(wallpaper: Drawable?) -> Unit,
+) {
+    val context = LocalContext.current
+    val fileAccessManager = remember { FileAccessManager.getInstance(context) }
+    val wallpaperAccessState by fileAccessManager.wallpaperAccessState.collectAsStateWithLifecycle()
+    val allFilesAccessState by fileAccessManager.allFilesAccessState.collectAsStateWithLifecycle()
+    val hasPermission = wallpaperAccessState == FileAccessState.Full
+    var showPermissionDialog by remember { mutableStateOf(false) }
+
+    val wallpaperDrawable = wallpaperDrawable(hasPermission)
+
+    content(wallpaperDrawable)
+
+    if (displayWallpaperButton && !hasPermission && !isPlayStoreFlavor()) {
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(bottom = 8.dp, top = 8.dp),
+        ) {
+            FilledTonalButton(
+                onClick = { showPermissionDialog = true },
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Wallpaper,
+                    contentDescription = null,
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    stringResource(R.string.show_wallpaper),
+                )
+            }
+        }
+    }
+
+    if (showPermissionDialog) {
+        WallpaperAccessPermissionDialog(
+            managedFilesChecked = allFilesAccessState != FileAccessState.Denied,
+            onDismiss = {
+                showPermissionDialog = false
+                fileAccessManager.refresh()
+            },
+            onPermissionRequest = {
+                fileAccessManager.refresh()
+            },
+        )
+    }
+
+    LifecycleResumeEffect(Unit) {
+        showPermissionDialog = false
+        fileAccessManager.refresh()
+        onPauseOrDispose { }
+    }
+}
+
+@Composable
 fun WallpaperPreview(
+    wallpaper: Drawable?,
     modifier: Modifier = Modifier,
 ) {
-    val painter = rememberDrawablePainter(wallpaperDrawable())
+    val painter = rememberDrawablePainter(wallpaper)
     Image(
         painter = painter,
         contentDescription = "",
@@ -41,41 +114,31 @@ fun WallpaperPreview(
     )
 }
 
-@OptIn(ExperimentalPermissionsApi::class)
 @SuppressLint("MissingPermission")
 @Composable
-fun wallpaperDrawable(): Drawable? {
+fun wallpaperDrawable(
+    hasPermission: Boolean,
+): Drawable? {
     val context = LocalContext.current
     val wallpaperManager = remember { WallpaperManager.getInstance(context) }
     val wallpaperInfo = wallpaperManager.wallpaperInfo
-    val permissionState = rememberPermissionState(
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            android.Manifest.permission.READ_MEDIA_IMAGES
-        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !isPlayStoreFlavor()) {
-            android.Manifest.permission.MANAGE_EXTERNAL_STORAGE
-        } else {
-            android.Manifest.permission.READ_EXTERNAL_STORAGE
-        },
-    )
-    val wallpaperDrawable by produceState<Drawable?>(initialValue = null) {
+
+    val wallpaperDrawable by produceState<Drawable?>(
+        key1 = hasPermission,
+        initialValue = null,
+    ) {
         value = when {
             wallpaperInfo != null -> wallpaperInfo.loadThumbnail(context.packageManager)
-            filesAndStorageGranted(context) -> {
+            hasPermission -> {
                 withContext(Dispatchers.IO) {
                     wallpaperManager.drawable?.let {
                         val size = Size(it.intrinsicWidth, it.intrinsicHeight).scaleDownToDisplaySize(context)
                         val bitmap = it.toBitmap(size.width, size.height)
-                        BitmapDrawable(context.resources, bitmap)
+                        bitmap.toDrawable(context.resources)
                     }
                 }
             }
             else -> null
-        }
-    }
-
-    if (!permissionState.status.isGranted) {
-        SideEffect {
-            checkAndRequestFilesPermission(context, PreferenceManager.getInstance(context))
         }
     }
 

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/DrawerSearchPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/DrawerSearchPreferences.kt
@@ -187,7 +187,7 @@ private fun LocalSearchSettings(
         onClick = {
             navController.navigate(SearchProviderPreference(SearchProviderId.FILES))
         },
-        enabled = FileAccessManager.getInstance(context).hasAnyPermission.collectAsStateWithLifecycle().value,
+        enabled = remember { FileAccessManager.getInstance(context) }.hasAnyPermission.collectAsStateWithLifecycle().value,
     )
     SearchProviderPreferenceItem(
         adapter = prefs.searchResultSettingsEntry.getAdapter(),

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/search/SearchProviderPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/search/SearchProviderPreference.kt
@@ -26,6 +26,7 @@ import app.lawnchair.preferences.PreferenceAdapter
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
 import app.lawnchair.preferences2.preferenceManager2
+import app.lawnchair.ui.preferences.components.PermissionDialog
 import app.lawnchair.ui.preferences.components.controls.MainSwitchPreference
 import app.lawnchair.ui.preferences.components.controls.SliderPreference
 import app.lawnchair.ui.preferences.components.controls.SwitchPreference
@@ -160,7 +161,7 @@ fun ContactsSearchProvider(
 
         PermissionDialog(
             title = stringResource(R.string.warn_contact_permission_title),
-            text = stringResource(id = R.string.warn_contact_permission_content),
+            text = stringResource(id = R.string.warn_contact_permission_content, stringResource(id = R.string.derived_app_name)),
             isPermanentlyDenied = contactsPermissionState.status.shouldShowRationale,
             onConfirm = { contactsPermissionState.launchPermissionRequest() },
             onDismiss = {

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/DockPreferences.kt
@@ -19,6 +19,7 @@ package app.lawnchair.ui.preferences.destinations
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
@@ -27,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences.preferenceManager
@@ -36,8 +38,8 @@ import app.lawnchair.ui.preferences.LocalIsExpandedScreen
 import app.lawnchair.ui.preferences.components.DummyLauncherBox
 import app.lawnchair.ui.preferences.components.DummyLauncherLayout
 import app.lawnchair.ui.preferences.components.WallpaperPreview
-import app.lawnchair.ui.preferences.components.clipToPercentage
-import app.lawnchair.ui.preferences.components.clipToVisiblePercentage
+import app.lawnchair.ui.preferences.components.WithWallpaper
+import app.lawnchair.ui.preferences.components.clipToBottomPercentage
 import app.lawnchair.ui.preferences.components.colorpreference.ColorPreference
 import app.lawnchair.ui.preferences.components.controls.MainSwitchPreference
 import app.lawnchair.ui.preferences.components.controls.SliderPreference
@@ -46,6 +48,7 @@ import app.lawnchair.ui.preferences.components.createPreviewIdp
 import app.lawnchair.ui.preferences.components.layout.DividerColumn
 import app.lawnchair.ui.preferences.components.layout.ExpandAndShrink
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
+import app.lawnchair.ui.preferences.components.layout.PreferenceGroupHeading
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import com.android.launcher3.R
 
@@ -182,24 +185,30 @@ fun ColumnScope.DockPreferencesPreview(modifier: Modifier = Modifier) {
             prefs.hotseatBGAlpha.getAdapter(),
         )
 
-        PreferenceGroup(
+        PreferenceGroupHeading(
             heading = stringResource(id = R.string.preview_label),
-            modifier = modifier,
+        )
+        DividerColumn(
+            modifier = modifier.padding(horizontal = 16.dp),
         ) {
-            DummyLauncherBox(
-                modifier = Modifier
-                    .weight(1f)
-                    .align(Alignment.CenterHorizontally)
-                    .clip(MaterialTheme.shapes.large)
-                    .clipToVisiblePercentage(0.3f)
-                    .clipToPercentage(1.0f),
-            ) {
-                WallpaperPreview(modifier = Modifier.fillMaxSize())
-                key(adapters.map { it.state.value }.toTypedArray()) {
-                    DummyLauncherLayout(
-                        idp = createPreviewIdp { copy(numHotseatColumns = prefs.hotseatColumns.get()) },
+            WithWallpaper { wallpaper ->
+                DummyLauncherBox(
+                    modifier = Modifier
+                        .weight(1f)
+                        .align(Alignment.CenterHorizontally)
+                        .clip(MaterialTheme.shapes.large)
+                        .clipToBottomPercentage(0.3f),
+                ) {
+                    WallpaperPreview(
+                        wallpaper = wallpaper,
                         modifier = Modifier.fillMaxSize(),
                     )
+                    key(adapters.map { it.state.value }.toTypedArray()) {
+                        DummyLauncherLayout(
+                            idp = createPreviewIdp { copy(numHotseatColumns = prefs.hotseatColumns.get()) },
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
                 }
             }
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenGridPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenGridPreferences.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableIntStateOf
@@ -14,7 +13,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -53,13 +51,7 @@ fun HomeScreenGridPreferences(
         val rows = rememberSaveable { mutableIntStateOf(originalRows) }
 
         if (isPortrait) {
-            GridOverridesPreview(
-                modifier = Modifier
-                    .padding(top = 8.dp)
-                    .weight(1f)
-                    .align(Alignment.CenterHorizontally)
-                    .clip(MaterialTheme.shapes.large),
-            ) {
+            GridOverridesPreview {
                 copy(numColumns = columns.intValue, numRows = rows.intValue)
             }
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/IconPackPreferences.kt
@@ -65,6 +65,7 @@ import app.lawnchair.ui.preferences.LocalPreferenceInteractor
 import app.lawnchair.ui.preferences.components.DummyLauncherBox
 import app.lawnchair.ui.preferences.components.DummyLauncherLayout
 import app.lawnchair.ui.preferences.components.WallpaperPreview
+import app.lawnchair.ui.preferences.components.WithWallpaper
 import app.lawnchair.ui.preferences.components.controls.ListPreference
 import app.lawnchair.ui.preferences.components.controls.ListPreferenceEntry
 import app.lawnchair.ui.preferences.components.controls.SwitchPreference
@@ -139,18 +140,23 @@ fun IconPackPreferences(
                     .fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                DummyLauncherBox(
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .padding(top = 8.dp)
-                        .clip(MaterialTheme.shapes.large),
-                ) {
-                    WallpaperPreview(modifier = Modifier.fillMaxSize())
-                    key(iconPackAdapter.state.value, themedIconPackAdapter.state.value, themedIconsAdapter.state.value, tintIconpack.state.value) {
-                        DummyLauncherLayout(
-                            idp = invariantDeviceProfile(),
+                WithWallpaper { wallpaper ->
+                    DummyLauncherBox(
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .padding(top = 8.dp)
+                            .clip(MaterialTheme.shapes.large),
+                    ) {
+                        WallpaperPreview(
+                            wallpaper = wallpaper,
                             modifier = Modifier.fillMaxSize(),
                         )
+                        key(iconPackAdapter.state.value, themedIconPackAdapter.state.value, themedIconsAdapter.state.value, tintIconpack.state.value) {
+                            DummyLauncherLayout(
+                                idp = invariantDeviceProfile(),
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
                     }
                 }
             }

--- a/src/com/android/launcher3/LauncherRootView.java
+++ b/src/com/android/launcher3/LauncherRootView.java
@@ -2,8 +2,6 @@ package com.android.launcher3;
 
 import static com.android.launcher3.config.FeatureFlags.SEPARATE_RECENTS_ACTIVITY;
 
-import static app.lawnchair.util.FileAccessManagerKt.checkAndRequestFilesPermission;
-
 import android.app.WallpaperManager;
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -28,6 +26,7 @@ import java.util.List;
 
 import app.lawnchair.preferences.PreferenceManager;
 import app.lawnchair.preferences2.PreferenceManager2;
+import app.lawnchair.util.FileAccessManager;
 
 public class LauncherRootView extends InsettableFrameLayout {
 
@@ -53,15 +52,17 @@ public class LauncherRootView extends InsettableFrameLayout {
         super(context, attrs);
         mActivity = StatefulActivity.fromContext(context);
         mSysUiScrim = new SysUiScrim(this);
-        PreferenceManager2 prefs2 = PreferenceManager2.getInstance(getContext());
+
+        pref = PreferenceManager.getInstance(context);
+        PreferenceManager2 prefs2 = PreferenceManager2.getInstance(context);
+        
         mEnableTaskbarOnPhone = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableTaskbarOnPhone());
 
-        pref = PreferenceManager.getInstance(getContext());
+        FileAccessManager fileAccessManager = FileAccessManager.getInstance(context);
+        Boolean hasFileAccessPermission = fileAccessManager.getHasAnyPermission().getValue();
 
-        if (pref.getEnableWallpaperBlur().get()){
-            if (checkAndRequestFilesPermission(context, pref)){
-                setUpBlur(context);
-            }
+        if (pref.getEnableWallpaperBlur().get() && hasFileAccessPermission) {
+            setUpBlur(context);
         }
     }
 

--- a/src/com/android/launcher3/LauncherRootView.java
+++ b/src/com/android/launcher3/LauncherRootView.java
@@ -27,6 +27,7 @@ import java.util.List;
 import app.lawnchair.preferences.PreferenceManager;
 import app.lawnchair.preferences2.PreferenceManager2;
 import app.lawnchair.util.FileAccessManager;
+import app.lawnchair.util.FileAccessState;
 
 public class LauncherRootView extends InsettableFrameLayout {
 
@@ -59,9 +60,8 @@ public class LauncherRootView extends InsettableFrameLayout {
         mEnableTaskbarOnPhone = PreferenceExtensionsKt.firstBlocking(prefs2.getEnableTaskbarOnPhone());
 
         FileAccessManager fileAccessManager = FileAccessManager.getInstance(context);
-        Boolean hasFileAccessPermission = fileAccessManager.getHasAnyPermission().getValue();
-
-        if (pref.getEnableWallpaperBlur().get() && hasFileAccessPermission) {
+        FileAccessState wallpaperAccessState = fileAccessManager.getWallpaperAccessState().getValue();
+        if (pref.getEnableWallpaperBlur().get() && wallpaperAccessState != FileAccessState.Denied.INSTANCE) {
             setUpBlur(context);
         }
     }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change. Please also include relevant motivation and context. -->

This commit completes the work started in the search refactor by migrating all remaining legacy file/media permission checks to the new, centralized `FileAccessManager`.

Previously, features like the wallpaper preview and backup system used the side-effect based permission model that created a poor user experience, especially on modern Android versions.

This change unifies all file and media access logic under the new, observable `StateFlow`-based system. This includes:

- Refactoring the wallpaper drawable access logic to correctly handle the various states of media permissions on Android 13+. This is disabled by default on Play Store builds, due to lack of `MANAGE_EXTERNAL_STORAGE` permission.
- Updating the backup/restore system to use the new manager.
- Migrating the OTA update check to use the new manager.
- Replacing the "Notification Dots" permission bottom sheet with the new, simpler `PermissionDialog` for UI consistency.

Credit-to: @lebao3105 for the initial analysis of the wallpaper permission issue.

- Fixes #5632.
- Fixes #5676.

## Type of change
<!-- Replace :x: with :white_check_mark: to "check" the specified bullet -->

:white_check_mark: General change (non-breaking change that doesn't fit the below categories like copyediting)
:x: Bug fix (non-breaking change which fixes an issue)
:x: New feature (non-breaking change which adds functionality)
:x: Breaking change (fix or feature that would cause existing functionality to not work as expected)
