### PR TITLE
feat(about): add "View changes" button with detailed commit history

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -54,7 +54,27 @@
 
     <string name="download_update">Download update</string>
     <string name="install_update">Install update</string>
+    <string name="view_changes">View changes</string>
     <string name="pro_updated">You\'re up-to-date!</string>
+    
+    <!-- Changes dialog strings -->
+    <string name="changes_dialog_title">Updates</string>
+    <string name="changes_dialog_error">Failed to load changes</string>
+    <string name="changes_dialog_no_changes">No changes found</string>
+    <string name="changes_dialog_commit_count">%d new commit</string>
+    <string name="changes_dialog_commit_count_plural">%d new commits</string>
+    <string name="changes_dialog_commit_count_since_version">since your version:</string>
+    <string name="changes_dialog_build_format">Build #%1$d → #%2$d</string>
+    <string name="changes_dialog_commit_info">by %1$s • %2$s • %3$s</string>
+    
+    <!-- Time ago strings -->
+    <string name="time_just_now">just now</string>
+    <string name="time_minutes_ago">%dm</string>
+    <string name="time_hours_ago">%dh</string>
+    <string name="time_days_ago">%dd</string>
+    <string name="time_weeks_ago">%dw</string>
+    <string name="time_months_ago">%dmo</string>
+    <string name="time_years_ago">%dy</string>
 
     <string name="managed_by_lawnchair">Managed by Lawnchair</string>
 

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -56,17 +56,14 @@
     <string name="install_update">Install update</string>
     <string name="view_changes">View changes</string>
     <string name="pro_updated">You\'re up-to-date!</string>
-    
+
     <!-- Changes dialog strings -->
     <string name="changes_dialog_title">Updates</string>
     <string name="changes_dialog_error">Failed to load changes</string>
     <string name="changes_dialog_no_changes">No changes found</string>
-    <string name="changes_dialog_commit_count">%d new commit</string>
-    <string name="changes_dialog_commit_count_plural">%d new commits</string>
-    <string name="changes_dialog_commit_count_since_version">since your version:</string>
     <string name="changes_dialog_build_format">Build #%1$d → #%2$d</string>
     <string name="changes_dialog_commit_info">by %1$s • %2$s • %3$s</string>
-    
+
     <!-- Time ago strings -->
     <string name="time_just_now">just now</string>
     <string name="time_minutes_ago">%dm</string>

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/About.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/About.kt
@@ -60,7 +60,17 @@ fun About(
     viewModel: AboutViewModel = viewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val showChangesDialog by viewModel.showChangesDialog.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    
+    if (showChangesDialog) {
+        ChangesDialog(
+            currentBuild = viewModel.getCurrentBuildNumber(),
+            latestBuild = viewModel.getLatestBuildNumber(),
+            repository = viewModel.nightlyBuildsRepository,
+            onDismiss = viewModel::dismissChangesDialog,
+        )
+    }
 
     PreferenceLayoutLazyColumn(
         label = stringResource(id = R.string.about_label),

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/About.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/About.kt
@@ -28,10 +28,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
@@ -53,21 +59,39 @@ import app.lawnchair.ui.preferences.components.layout.preferenceGroupItems
 import app.lawnchair.ui.preferences.navigation.AboutLicenses
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun About(
     modifier: Modifier = Modifier,
     viewModel: AboutViewModel = viewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val showChangesDialog by viewModel.showChangesDialog.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
-    if (showChangesDialog) {
-        ChangesDialog(
-            changelogState = uiState.changelogState,
-            onDismiss = viewModel::dismissChangesDialog,
-        )
+    val sheetState = rememberModalBottomSheetState(true)
+    var openBottomSheet by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    if (openBottomSheet) {
+        val updateState = uiState.updateState
+        if (updateState is UpdateState.Available) {
+            ChangesDialog(
+                changelogState = updateState.changelogState,
+                onDismiss = {
+                    scope.launch {
+                        sheetState.hide()
+                    }.invokeOnCompletion {
+                        openBottomSheet = false
+                    }
+                },
+                onDownload = {
+                    viewModel.downloadUpdate()
+                },
+                sheetState = sheetState,
+            )
+        }
     }
 
     PreferenceLayoutLazyColumn(
@@ -133,8 +157,15 @@ fun About(
         item {
             UpdateSection(
                 updateState = uiState.updateState,
-                showChangesDialog = uiState.changelogState != null,
-                onEvent = viewModel::onEvent,
+                onInstall = {
+                    viewModel.installUpdate(it)
+                },
+                onViewChanges = {
+                    openBottomSheet = true
+                    scope.launch {
+                        sheetState.show()
+                    }
+                },
             )
         }
         item {

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/About.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/About.kt
@@ -62,7 +62,7 @@ fun About(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val showChangesDialog by viewModel.showChangesDialog.collectAsStateWithLifecycle()
     val context = LocalContext.current
-    
+
     if (showChangesDialog) {
         ChangesDialog(
             currentBuild = viewModel.getCurrentBuildNumber(),

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/About.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/About.kt
@@ -65,9 +65,7 @@ fun About(
 
     if (showChangesDialog) {
         ChangesDialog(
-            currentBuild = viewModel.getCurrentBuildNumber(),
-            latestBuild = viewModel.getLatestBuildNumber(),
-            repository = viewModel.nightlyBuildsRepository,
+            changelogState = uiState.changelogState,
             onDismiss = viewModel::dismissChangesDialog,
         )
     }
@@ -135,6 +133,7 @@ fun About(
         item {
             UpdateSection(
                 updateState = uiState.updateState,
+                showChangesDialog = uiState.changelogState != null,
                 onEvent = viewModel::onEvent,
             )
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/AboutModels.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/AboutModels.kt
@@ -27,13 +27,6 @@ data class AboutUiState(
     val topLinks: List<Link> = emptyList(),
     val bottomLinks: List<Link> = emptyList(),
     val updateState: UpdateState = UpdateState.Hidden,
-    val changelogState: ChangelogState? = null,
-)
-
-data class ChangelogState(
-    val commits: List<GitHubCommit> = emptyList(),
-    val currentBuildNumber: Int = 0,
-    val latestBuildNumber: Int = 0,
 )
 
 /**
@@ -111,7 +104,7 @@ sealed interface UpdateState {
      * @param name The name of the available update (used in `Available` state).
      * @param url The URL to download the update from (used in `Available` state).
      */
-    data class Available(val name: String, val url: String) : UpdateState
+    data class Available(val name: String, val url: String, val changelogState: ChangelogState?) : UpdateState
 
     /**
      * An update is currently being downloaded. Contains the download progress.
@@ -129,17 +122,11 @@ sealed interface UpdateState {
     data object Failed : UpdateState
 }
 
-/**
- * Sealed interface representing user actions that can be triggered from the "About" screen.
- *
- * This interface defines the different types of events related to user interactions,
- * such as initiating a download or an installation.
- */
-sealed interface AboutEvent {
-    data object OnDownloadClicked : AboutEvent
-    data class OnInstallClicked(val file: File) : AboutEvent
-    data object OnViewChangesClicked : AboutEvent
-}
+data class ChangelogState(
+    val commits: List<GitHubCommit> = emptyList(),
+    val currentBuildNumber: Int = 0,
+    val latestBuildNumber: Int = 0,
+)
 
 /**
  * Represents the status of a contributor.

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/AboutModels.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/AboutModels.kt
@@ -27,6 +27,13 @@ data class AboutUiState(
     val topLinks: List<Link> = emptyList(),
     val bottomLinks: List<Link> = emptyList(),
     val updateState: UpdateState = UpdateState.Hidden,
+    val changelogState: ChangelogState? = null,
+)
+
+data class ChangelogState(
+    val commits: List<GitHubCommit> = emptyList(),
+    val currentBuildNumber: Int = 0,
+    val latestBuildNumber: Int = 0,
 )
 
 /**
@@ -103,9 +110,8 @@ sealed interface UpdateState {
      * A new update is available. Contains the name and URL of the update.
      * @param name The name of the available update (used in `Available` state).
      * @param url The URL to download the update from (used in `Available` state).
-     * @param latestBuildNumber The build number of the latest version available.
      */
-    data class Available(val name: String, val url: String, val latestBuildNumber: Int = 0) : UpdateState
+    data class Available(val name: String, val url: String) : UpdateState
 
     /**
      * An update is currently being downloaded. Contains the download progress.
@@ -116,9 +122,8 @@ sealed interface UpdateState {
     /**
      * An update has been successfully downloaded. Contains the downloaded file.
      * @param file The [File] object representing the downloaded update package (used in `Downloaded` state).
-     * @param latestBuildNumber The build number of the latest version available.
      */
-    data class Downloaded(val file: File, val latestBuildNumber: Int = 0) : UpdateState
+    data class Downloaded(val file: File) : UpdateState
 
     /** An update download has failed. */
     data object Failed : UpdateState

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/AboutModels.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/AboutModels.kt
@@ -103,8 +103,9 @@ sealed interface UpdateState {
      * A new update is available. Contains the name and URL of the update.
      * @param name The name of the available update (used in `Available` state).
      * @param url The URL to download the update from (used in `Available` state).
+     * @param latestBuildNumber The build number of the latest version available.
      */
-    data class Available(val name: String, val url: String) : UpdateState
+    data class Available(val name: String, val url: String, val latestBuildNumber: Int = 0) : UpdateState
 
     /**
      * An update is currently being downloaded. Contains the download progress.
@@ -115,8 +116,9 @@ sealed interface UpdateState {
     /**
      * An update has been successfully downloaded. Contains the downloaded file.
      * @param file The [File] object representing the downloaded update package (used in `Downloaded` state).
+     * @param latestBuildNumber The build number of the latest version available.
      */
-    data class Downloaded(val file: File) : UpdateState
+    data class Downloaded(val file: File, val latestBuildNumber: Int = 0) : UpdateState
 
     /** An update download has failed. */
     data object Failed : UpdateState
@@ -131,6 +133,7 @@ sealed interface UpdateState {
 sealed interface AboutEvent {
     data object OnDownloadClicked : AboutEvent
     data class OnInstallClicked(val file: File) : AboutEvent
+    data object OnViewChangesClicked : AboutEvent
 }
 
 /**

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
@@ -17,7 +17,7 @@ class AboutViewModel(
 ) : AndroidViewModel(application) {
 
     private val api: GitHubService = gitHubApiRetrofit.create()
-    
+
     val nightlyBuildsRepository = NightlyBuildsRepository(
         applicationContext = application,
         api = api,
@@ -26,7 +26,7 @@ class AboutViewModel(
     private val _uiState = MutableStateFlow(AboutUiState())
     val uiState = _uiState.asStateFlow()
     val updateState = nightlyBuildsRepository.updateState
-    
+
     private val _showChangesDialog = MutableStateFlow(false)
     val showChangesDialog = _showChangesDialog.asStateFlow()
 
@@ -68,13 +68,13 @@ class AboutViewModel(
             is AboutEvent.OnViewChangesClicked -> _showChangesDialog.update { true }
         }
     }
-    
+
     fun dismissChangesDialog() {
         _showChangesDialog.update { false }
     }
-    
+
     fun getCurrentBuildNumber(): Int = nightlyBuildsRepository.getCurrentBuildNumber()
-    
+
     fun getLatestBuildNumber(): Int = nightlyBuildsRepository.getLatestBuildNumber()
 
     private suspend fun fetchActiveContributors(): Set<String> {

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
@@ -18,7 +18,7 @@ class AboutViewModel(
 
     private val api: GitHubService = gitHubApiRetrofit.create()
 
-    val nightlyBuildsRepository = NightlyBuildsRepository(
+    private val nightlyBuildsRepository = NightlyBuildsRepository(
         applicationContext = application,
         api = api,
     )
@@ -58,6 +58,11 @@ class AboutViewModel(
                     _uiState.update { it.copy(updateState = state) }
                 }
             }
+            viewModelScope.launch {
+                nightlyBuildsRepository.changelogState.collect { state ->
+                    _uiState.update { it.copy(changelogState = state) }
+                }
+            }
         }
     }
 
@@ -73,10 +78,6 @@ class AboutViewModel(
         _showChangesDialog.update { false }
     }
 
-    fun getCurrentBuildNumber(): Int = nightlyBuildsRepository.getCurrentBuildNumber()
-
-    fun getLatestBuildNumber(): Int = nightlyBuildsRepository.getLatestBuildNumber()
-
     private suspend fun fetchActiveContributors(): Set<String> {
         return runCatching {
             nightlyBuildsRepository.api.getRepositoryEvents("LawnchairLauncher", "lawnchair")
@@ -84,6 +85,7 @@ class AboutViewModel(
                 .toSet()
         }.getOrDefault(emptySet())
     }
+
     companion object {
         private val team = listOf(
             TeamMember(

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
@@ -16,14 +16,19 @@ class AboutViewModel(
     application: Application,
 ) : AndroidViewModel(application) {
 
-    private val nightlyBuildsRepository = NightlyBuildsRepository(
+    private val api: GitHubService = gitHubApiRetrofit.create()
+    
+    val nightlyBuildsRepository = NightlyBuildsRepository(
         applicationContext = application,
-        api = gitHubApiRetrofit.create(),
+        api = api,
     )
 
     private val _uiState = MutableStateFlow(AboutUiState())
     val uiState = _uiState.asStateFlow()
     val updateState = nightlyBuildsRepository.updateState
+    
+    private val _showChangesDialog = MutableStateFlow(false)
+    val showChangesDialog = _showChangesDialog.asStateFlow()
 
     init {
         _uiState.update {
@@ -60,8 +65,17 @@ class AboutViewModel(
         when (event) {
             is AboutEvent.OnDownloadClicked -> nightlyBuildsRepository.downloadUpdate()
             is AboutEvent.OnInstallClicked -> nightlyBuildsRepository.installUpdate(event.file)
+            is AboutEvent.OnViewChangesClicked -> _showChangesDialog.update { true }
         }
     }
+    
+    fun dismissChangesDialog() {
+        _showChangesDialog.update { false }
+    }
+    
+    fun getCurrentBuildNumber(): Int = nightlyBuildsRepository.getCurrentBuildNumber()
+    
+    fun getLatestBuildNumber(): Int = nightlyBuildsRepository.getLatestBuildNumber()
 
     private suspend fun fetchActiveContributors(): Set<String> {
         return runCatching {

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/AboutViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.R
+import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,9 +27,6 @@ class AboutViewModel(
     private val _uiState = MutableStateFlow(AboutUiState())
     val uiState = _uiState.asStateFlow()
     val updateState = nightlyBuildsRepository.updateState
-
-    private val _showChangesDialog = MutableStateFlow(false)
-    val showChangesDialog = _showChangesDialog.asStateFlow()
 
     init {
         _uiState.update {
@@ -58,24 +56,15 @@ class AboutViewModel(
                     _uiState.update { it.copy(updateState = state) }
                 }
             }
-            viewModelScope.launch {
-                nightlyBuildsRepository.changelogState.collect { state ->
-                    _uiState.update { it.copy(changelogState = state) }
-                }
-            }
         }
     }
 
-    fun onEvent(event: AboutEvent) {
-        when (event) {
-            is AboutEvent.OnDownloadClicked -> nightlyBuildsRepository.downloadUpdate()
-            is AboutEvent.OnInstallClicked -> nightlyBuildsRepository.installUpdate(event.file)
-            is AboutEvent.OnViewChangesClicked -> _showChangesDialog.update { true }
-        }
+    fun downloadUpdate() {
+        nightlyBuildsRepository.downloadUpdate()
     }
 
-    fun dismissChangesDialog() {
-        _showChangesDialog.update { false }
+    fun installUpdate(file: File) {
+        nightlyBuildsRepository.installUpdate(file)
     }
 
     private suspend fun fetchActiveContributors(): Set<String> {

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/ChangesDialog.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/ChangesDialog.kt
@@ -28,17 +28,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import com.android.launcher3.R
+import java.time.Instant
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.time.Instant
-import java.time.format.DateTimeFormatter
-import java.util.concurrent.TimeUnit
 
 @Composable
 fun ChangesDialog(
@@ -117,7 +115,7 @@ fun ChangesDialog(
                             fontWeight = FontWeight.Bold,
                             modifier = Modifier.padding(bottom = 8.dp),
                         )
-                        
+
                         commits?.forEach { commit ->
                             CommitItem(commit = commit)
                             Spacer(modifier = Modifier.height(8.dp))
@@ -139,11 +137,11 @@ fun ChangesDialog(
 @Composable
 private fun CommitItem(commit: GitHubCommit) {
     val context = LocalContext.current
-    
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable { 
+            .clickable {
                 openCommitInBrowser(context, commit.sha)
             },
         colors = CardDefaults.cardColors(
@@ -156,7 +154,7 @@ private fun CommitItem(commit: GitHubCommit) {
             val message = commit.commit.message
             val title = message.substringBefore("\n").take(100)
             val description = message.substringAfter("\n", "").take(200)
-            
+
             Text(
                 text = title,
                 style = MaterialTheme.typography.bodyMedium,
@@ -164,7 +162,7 @@ private fun CommitItem(commit: GitHubCommit) {
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
-            
+
             if (description.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
@@ -175,7 +173,7 @@ private fun CommitItem(commit: GitHubCommit) {
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            
+
             Spacer(modifier = Modifier.height(4.dp))
             val timeAgo = getTimeAgo(context, commit.commit.author.date)
             Text(
@@ -198,7 +196,7 @@ private fun getTimeAgo(context: Context, dateString: String): String {
         val commitDate = Instant.parse(dateString)
         val currentTime = Instant.now()
         val diffMillis = currentTime.toEpochMilli() - commitDate.toEpochMilli()
-        
+
         when {
             diffMillis < TimeUnit.MINUTES.toMillis(1) -> {
                 context.getString(R.string.time_just_now)

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/ChangesDialog.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/ChangesDialog.kt
@@ -14,17 +14,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -35,32 +28,17 @@ import androidx.compose.ui.window.DialogProperties
 import com.android.launcher3.R
 import java.time.Instant
 import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 @Composable
 fun ChangesDialog(
-    currentBuild: Int,
-    latestBuild: Int,
-    repository: NightlyBuildsRepository,
+    changelogState: ChangelogState?,
     onDismiss: () -> Unit,
 ) {
-    val context = LocalContext.current
-    var commits by remember { mutableStateOf<List<GitHubCommit>?>(null) }
-    var isLoading by remember { mutableStateOf(true) }
-    var errorMessage by remember { mutableStateOf<String?>(null) }
+    if (changelogState == null) return
 
-    LaunchedEffect(Unit) {
-        withContext(Dispatchers.IO) {
-            try {
-                commits = repository.getCommitsSinceCurrentVersion()
-                isLoading = false
-            } catch (e: Exception) {
-                errorMessage = context.getString(R.string.changes_dialog_error)
-                isLoading = false
-            }
-        }
-    }
+    val commits = changelogState.commits
+    val currentBuild = changelogState.currentBuildNumber
+    val latestBuild = changelogState.latestBuildNumber
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -83,44 +61,26 @@ fun ChangesDialog(
                     .fillMaxWidth()
                     .verticalScroll(rememberScrollState()),
             ) {
-                when {
-                    isLoading -> {
-                        CircularProgressIndicator(
-                            modifier = Modifier
-                                .align(Alignment.CenterHorizontally)
-                                .padding(16.dp),
-                        )
-                    }
-                    errorMessage != null -> {
-                        Text(
-                            text = errorMessage ?: stringResource(R.string.changes_dialog_error),
-                            color = MaterialTheme.colorScheme.error,
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    }
-                    commits != null -> {
-                        val commitCount = commits?.size ?: 0
-                        Text(
-                            text = if (commitCount > 0) {
-                                val commitText = if (commitCount > 1) {
-                                    stringResource(R.string.changes_dialog_commit_count_plural, commitCount)
-                                } else {
-                                    stringResource(R.string.changes_dialog_commit_count, commitCount)
-                                }
-                                "$commitText ${stringResource(R.string.changes_dialog_commit_count_since_version)}"
-                            } else {
-                                stringResource(R.string.changes_dialog_no_changes)
-                            },
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            modifier = Modifier.padding(bottom = 8.dp),
-                        )
-
-                        commits?.forEach { commit ->
-                            CommitItem(commit = commit)
-                            Spacer(modifier = Modifier.height(8.dp))
+                val commitCount = commits.size ?: 0
+                Text(
+                    text = if (commitCount > 0) {
+                        val commitText = if (commitCount > 1) {
+                            stringResource(R.string.changes_dialog_commit_count_plural, commitCount)
+                        } else {
+                            stringResource(R.string.changes_dialog_commit_count, commitCount)
                         }
-                    }
+                        "$commitText ${stringResource(R.string.changes_dialog_commit_count_since_version)}"
+                    } else {
+                        stringResource(R.string.changes_dialog_no_changes)
+                    },
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+
+                commits.forEach { commit ->
+                    CommitItem(commit = commit)
+                    Spacer(modifier = Modifier.height(8.dp))
                 }
             }
         },

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/ChangesDialog.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/ChangesDialog.kt
@@ -2,129 +2,142 @@ package app.lawnchair.ui.preferences.about
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.DialogProperties
+import androidx.core.net.toUri
+import app.lawnchair.ui.preferences.components.layout.PreferenceGroupItem
+import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
 import com.android.launcher3.R
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChangesDialog(
     changelogState: ChangelogState?,
+    sheetState: SheetState,
     onDismiss: () -> Unit,
+    onDownload: () -> Unit,
 ) {
-    if (changelogState == null) return
+    val commits = changelogState?.commits
+    val currentBuild = changelogState?.currentBuildNumber ?: 0
+    val latestBuild = changelogState?.latestBuildNumber ?: 0
 
-    val commits = changelogState.commits
-    val currentBuild = changelogState.currentBuildNumber
-    val latestBuild = changelogState.latestBuildNumber
-
-    AlertDialog(
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
-        title = {
-            Column {
-                Text(
-                    text = stringResource(R.string.changes_dialog_title),
-                    style = MaterialTheme.typography.headlineSmall,
-                )
-                Text(
-                    text = stringResource(R.string.changes_dialog_build_format, currentBuild, latestBuild),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        },
-        text = {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState()),
-            ) {
-                val commitCount = commits.size ?: 0
-                Text(
-                    text = if (commitCount > 0) {
-                        val commitText = if (commitCount > 1) {
-                            stringResource(R.string.changes_dialog_commit_count_plural, commitCount)
-                        } else {
-                            stringResource(R.string.changes_dialog_commit_count, commitCount)
-                        }
-                        "$commitText ${stringResource(R.string.changes_dialog_commit_count_since_version)}"
-                    } else {
-                        stringResource(R.string.changes_dialog_no_changes)
-                    },
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(bottom = 8.dp),
-                )
-
-                commits.forEach { commit ->
-                    CommitItem(commit = commit)
-                    Spacer(modifier = Modifier.height(8.dp))
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp)) {
+            Text(
+                text = stringResource(R.string.changes_dialog_title),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            Text(
+                text = stringResource(
+                    R.string.changes_dialog_build_format,
+                    currentBuild,
+                    latestBuild,
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 8.dp, bottom = 16.dp),
+            )
+        }
+        LazyColumn(
+            modifier = Modifier
+                .heightIn(max = 600.dp)
+                .fillMaxWidth(),
+        ) {
+            if (commits != null) {
+                itemsIndexed(commits) { index, commit ->
+                    PreferenceGroupItem(
+                        cutTop = index != 0,
+                        cutBottom = index != commits.lastIndex,
+                    ) {
+                        CommitItem(commit = commit)
+                    }
+                    Spacer(Modifier.height(3.dp))
+                }
+            } else {
+                item {
+                    Text(
+                        text = stringResource(R.string.changes_dialog_error),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
                 }
             }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(android.R.string.ok))
+        }
+        Row(
+            horizontalArrangement = Arrangement.End,
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .fillMaxWidth(),
+        ) {
+            OutlinedButton(
+                onClick = onDismiss,
+            ) {
+                Text(text = stringResource(android.R.string.cancel))
             }
-        },
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-        modifier = Modifier.padding(horizontal = 16.dp),
-    )
+            Spacer(Modifier.width(8.dp))
+            Button(
+                onClick = {
+                    onDownload()
+                    onDismiss()
+                },
+            ) {
+                Text(text = stringResource(R.string.download_update))
+            }
+        }
+    }
 }
 
 @Composable
-private fun CommitItem(commit: GitHubCommit) {
+private fun CommitItem(
+    commit: GitHubCommit,
+    modifier: Modifier = Modifier,
+) {
     val context = LocalContext.current
 
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable {
-                openCommitInBrowser(context, commit.sha)
-            },
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-        ),
-    ) {
-        Column(
-            modifier = Modifier.padding(12.dp),
-        ) {
-            val message = commit.commit.message
-            val title = message.substringBefore("\n").take(100)
-            val description = message.substringAfter("\n", "").take(200)
+    val message = commit.commit.message
+    val title = message.substringBefore("\n").take(100)
+    val description = message.substringAfter("\n", "").take(200)
 
+    PreferenceTemplate(
+        title = {
             Text(
                 text = title,
                 style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
-
+        },
+        description = {
             if (description.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = description,
                     style = MaterialTheme.typography.bodySmall,
@@ -132,22 +145,29 @@ private fun CommitItem(commit: GitHubCommit) {
                     maxLines = 3,
                     overflow = TextOverflow.Ellipsis,
                 )
+                Spacer(modifier = Modifier.height(4.dp))
             }
-
-            Spacer(modifier = Modifier.height(4.dp))
             val timeAgo = getTimeAgo(context, commit.commit.author.date)
             Text(
-                text = stringResource(R.string.changes_dialog_commit_info, commit.commit.author.name, commit.sha.take(7), timeAgo),
+                text = stringResource(
+                    R.string.changes_dialog_commit_info,
+                    commit.commit.author.name,
+                    commit.sha.take(7),
+                    timeAgo,
+                ),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
             )
-        }
-    }
+        },
+        modifier = modifier.clickable {
+            openCommitInBrowser(context, commit.sha)
+        },
+    )
 }
 
 private fun openCommitInBrowser(context: Context, commitSha: String) {
     val commitUrl = "https://github.com/LawnchairLauncher/lawnchair/commit/$commitSha"
-    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(commitUrl))
+    val intent = Intent(Intent.ACTION_VIEW, commitUrl.toUri())
     context.startActivity(intent)
 }
 
@@ -161,26 +181,32 @@ private fun getTimeAgo(context: Context, dateString: String): String {
             diffMillis < TimeUnit.MINUTES.toMillis(1) -> {
                 context.getString(R.string.time_just_now)
             }
+
             diffMillis < TimeUnit.HOURS.toMillis(1) -> {
                 val minutes = TimeUnit.MILLISECONDS.toMinutes(diffMillis)
                 context.getString(R.string.time_minutes_ago, minutes)
             }
+
             diffMillis < TimeUnit.DAYS.toMillis(1) -> {
                 val hours = TimeUnit.MILLISECONDS.toHours(diffMillis)
                 context.getString(R.string.time_hours_ago, hours)
             }
+
             diffMillis < TimeUnit.DAYS.toMillis(7) -> {
                 val days = TimeUnit.MILLISECONDS.toDays(diffMillis)
                 context.getString(R.string.time_days_ago, days)
             }
+
             diffMillis < TimeUnit.DAYS.toMillis(30) -> {
                 val weeks = TimeUnit.MILLISECONDS.toDays(diffMillis) / 7
                 context.getString(R.string.time_weeks_ago, weeks)
             }
+
             diffMillis < TimeUnit.DAYS.toMillis(365) -> {
                 val months = TimeUnit.MILLISECONDS.toDays(diffMillis) / 30
                 context.getString(R.string.time_months_ago, months)
             }
+
             else -> {
                 val years = TimeUnit.MILLISECONDS.toDays(diffMillis) / 365
                 context.getString(R.string.time_years_ago, years)

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/ChangesDialog.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/ChangesDialog.kt
@@ -1,0 +1,235 @@
+package app.lawnchair.ui.preferences.about
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import com.android.launcher3.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.TimeUnit
+
+@Composable
+fun ChangesDialog(
+    currentBuild: Int,
+    latestBuild: Int,
+    repository: NightlyBuildsRepository,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    var commits by remember { mutableStateOf<List<GitHubCommit>?>(null) }
+    var isLoading by remember { mutableStateOf(true) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            try {
+                commits = repository.getCommitsSinceCurrentVersion()
+                isLoading = false
+            } catch (e: Exception) {
+                errorMessage = context.getString(R.string.changes_dialog_error)
+                isLoading = false
+            }
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Column {
+                Text(
+                    text = stringResource(R.string.changes_dialog_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+                Text(
+                    text = stringResource(R.string.changes_dialog_build_format, currentBuild, latestBuild),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                when {
+                    isLoading -> {
+                        CircularProgressIndicator(
+                            modifier = Modifier
+                                .align(Alignment.CenterHorizontally)
+                                .padding(16.dp),
+                        )
+                    }
+                    errorMessage != null -> {
+                        Text(
+                            text = errorMessage ?: stringResource(R.string.changes_dialog_error),
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                    commits != null -> {
+                        val commitCount = commits?.size ?: 0
+                        Text(
+                            text = if (commitCount > 0) {
+                                val commitText = if (commitCount > 1) {
+                                    stringResource(R.string.changes_dialog_commit_count_plural, commitCount)
+                                } else {
+                                    stringResource(R.string.changes_dialog_commit_count, commitCount)
+                                }
+                                "$commitText ${stringResource(R.string.changes_dialog_commit_count_since_version)}"
+                            } else {
+                                stringResource(R.string.changes_dialog_no_changes)
+                            },
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(bottom = 8.dp),
+                        )
+                        
+                        commits?.forEach { commit ->
+                            CommitItem(commit = commit)
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+        modifier = Modifier.padding(horizontal = 16.dp),
+    )
+}
+
+@Composable
+private fun CommitItem(commit: GitHubCommit) {
+    val context = LocalContext.current
+    
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { 
+                openCommitInBrowser(context, commit.sha)
+            },
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+        ) {
+            val message = commit.commit.message
+            val title = message.substringBefore("\n").take(100)
+            val description = message.substringAfter("\n", "").take(200)
+            
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            
+            if (description.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            
+            Spacer(modifier = Modifier.height(4.dp))
+            val timeAgo = getTimeAgo(context, commit.commit.author.date)
+            Text(
+                text = stringResource(R.string.changes_dialog_commit_info, commit.commit.author.name, commit.sha.take(7), timeAgo),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+            )
+        }
+    }
+}
+
+private fun openCommitInBrowser(context: Context, commitSha: String) {
+    val commitUrl = "https://github.com/LawnchairLauncher/lawnchair/commit/$commitSha"
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(commitUrl))
+    context.startActivity(intent)
+}
+
+private fun getTimeAgo(context: Context, dateString: String): String {
+    return try {
+        val commitDate = Instant.parse(dateString)
+        val currentTime = Instant.now()
+        val diffMillis = currentTime.toEpochMilli() - commitDate.toEpochMilli()
+        
+        when {
+            diffMillis < TimeUnit.MINUTES.toMillis(1) -> {
+                context.getString(R.string.time_just_now)
+            }
+            diffMillis < TimeUnit.HOURS.toMillis(1) -> {
+                val minutes = TimeUnit.MILLISECONDS.toMinutes(diffMillis)
+                context.getString(R.string.time_minutes_ago, minutes)
+            }
+            diffMillis < TimeUnit.DAYS.toMillis(1) -> {
+                val hours = TimeUnit.MILLISECONDS.toHours(diffMillis)
+                context.getString(R.string.time_hours_ago, hours)
+            }
+            diffMillis < TimeUnit.DAYS.toMillis(7) -> {
+                val days = TimeUnit.MILLISECONDS.toDays(diffMillis)
+                context.getString(R.string.time_days_ago, days)
+            }
+            diffMillis < TimeUnit.DAYS.toMillis(30) -> {
+                val weeks = TimeUnit.MILLISECONDS.toDays(diffMillis) / 7
+                context.getString(R.string.time_weeks_ago, weeks)
+            }
+            diffMillis < TimeUnit.DAYS.toMillis(365) -> {
+                val months = TimeUnit.MILLISECONDS.toDays(diffMillis) / 30
+                context.getString(R.string.time_months_ago, months)
+            }
+            else -> {
+                val years = TimeUnit.MILLISECONDS.toDays(diffMillis) / 365
+                context.getString(R.string.time_years_ago, years)
+            }
+        }
+    } catch (e: Exception) {
+        // If date parsing fails, fallback to date prefix
+        dateString.substringBefore("T")
+    }
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/GithubService.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/GithubService.kt
@@ -27,6 +27,20 @@ interface GitHubService {
         @Path("owner") owner: String,
         @Path("repo") repo: String,
     ): List<GitHubEvent>
+    
+    @GET("repos/{owner}/{repo}/commits")
+    suspend fun getRepositoryCommits(
+        @Path("owner") owner: String,
+        @Path("repo") repo: String,
+    ): List<GitHubCommit>
+    
+    @GET("repos/{owner}/{repo}/compare/{base}...{head}")
+    suspend fun compareCommits(
+        @Path("owner") owner: String,
+        @Path("repo") repo: String,
+        @Path("base") base: String,
+        @Path("head") head: String,
+    ): GitHubCompareResponse
 
     @Streaming
     @GET
@@ -83,6 +97,53 @@ data class GitHubEvent(
         val login: String,
     )
 }
+
+/**
+ * Represents a GitHub commit.
+ *
+ * @property sha The SHA hash of the commit.
+ * @property commit The commit details.
+ * @property author The author of the commit.
+ */
+@Serializable
+data class GitHubCommit(
+    val sha: String,
+    val commit: CommitDetails,
+    val author: Author? = null,
+) {
+    @Serializable
+    data class CommitDetails(
+        val message: String,
+        val author: CommitAuthor,
+    )
+    
+    @Serializable
+    data class CommitAuthor(
+        val name: String,
+        val date: String,
+    )
+    
+    @Serializable
+    data class Author(
+        val login: String,
+    )
+}
+
+/**
+ * Represents a GitHub comparison response between two commits.
+ *
+ * @property commits List of commits between the base and head.
+ * @property aheadBy Number of commits ahead.
+ * @property behindBy Number of commits behind.
+ */
+@Serializable
+data class GitHubCompareResponse(
+    val commits: List<GitHubCommit>,
+    @SerialName("ahead_by")
+    val aheadBy: Int,
+    @SerialName("behind_by")
+    val behindBy: Int,
+)
 
 internal val gitHubApiRetrofit: Retrofit by lazy {
     Retrofit.Builder()

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/GithubService.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/GithubService.kt
@@ -27,13 +27,13 @@ interface GitHubService {
         @Path("owner") owner: String,
         @Path("repo") repo: String,
     ): List<GitHubEvent>
-    
+
     @GET("repos/{owner}/{repo}/commits")
     suspend fun getRepositoryCommits(
         @Path("owner") owner: String,
         @Path("repo") repo: String,
     ): List<GitHubCommit>
-    
+
     @GET("repos/{owner}/{repo}/compare/{base}...{head}")
     suspend fun compareCommits(
         @Path("owner") owner: String,
@@ -116,13 +116,13 @@ data class GitHubCommit(
         val message: String,
         val author: CommitAuthor,
     )
-    
+
     @Serializable
     data class CommitAuthor(
         val name: String,
         val date: String,
     )
-    
+
     @Serializable
     data class Author(
         val login: String,

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/NightlyBuildsRepository.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/NightlyBuildsRepository.kt
@@ -29,6 +29,10 @@ class NightlyBuildsRepository(
 
     private val _updateState = MutableStateFlow<UpdateState>(UpdateState.UpToDate)
     val updateState = _updateState.asStateFlow()
+    
+    private var currentBuildNumber: Int = 0
+    private var latestBuildNumber: Int = 0
+    private var currentCommitHash: String = BuildConfig.COMMIT_HASH
 
     fun checkForUpdate() {
         coroutineScope.launch(Dispatchers.Default) {
@@ -42,18 +46,19 @@ class NightlyBuildsRepository(
                 // <major>.<branch>.(#<CI build number>)
                 // This is done inside build.gradle in the source root. Reflect
                 // changes from there if needed.
-                val currentVersion = BuildConfig.VERSION_DISPLAY_NAME
+                currentBuildNumber = BuildConfig.VERSION_DISPLAY_NAME
                     .substringAfterLast("#")
                     .removeSuffix(")")
                     .toIntOrNull() ?: 0
-                val latestVersion =
+                latestBuildNumber =
                     asset?.name?.substringAfter("_")?.substringBefore("-")?.toIntOrNull() ?: 0
 
-                if (asset != null && latestVersion > currentVersion) {
+                if (asset != null && latestBuildNumber > currentBuildNumber) {
                     _updateState.update {
                         UpdateState.Available(
                             asset.name,
                             asset.browserDownloadUrl,
+                            latestBuildNumber,
                         )
                     }
                 } else {
@@ -84,7 +89,7 @@ class NightlyBuildsRepository(
                     _updateState.update { UpdateState.Downloading(progress) }
                 }
                 if (file != null) {
-                    _updateState.update { UpdateState.Downloaded(file) }
+                    _updateState.update { UpdateState.Downloaded(file, latestBuildNumber) }
                 } else {
                     Log.e(TAG, "Downloaded file is null")
                     _updateState.update { UpdateState.Failed }
@@ -112,6 +117,33 @@ class NightlyBuildsRepository(
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
         }
         applicationContext.startActivity(intent)
+    }
+    
+    fun getCurrentBuildNumber(): Int = currentBuildNumber
+    
+    fun getLatestBuildNumber(): Int = latestBuildNumber
+    
+    fun getCurrentCommitHash(): String = currentCommitHash
+    
+    suspend fun getCommitsSinceCurrentVersion(): List<GitHubCommit>? {
+        return try {
+            // Get the latest commits (last 100)
+            val commits = api.getRepositoryCommits("LawnchairLauncher", "lawnchair")
+            
+            // Find the index of current commit
+            val currentIndex = commits.indexOfFirst { it.sha.startsWith(currentCommitHash) }
+            
+            if (currentIndex > 0) {
+                // Return all commits newer than current version
+                commits.take(currentIndex)
+            } else {
+                // If current commit not found, show last 30 commits
+                commits.take(30)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to get commits", e)
+            null
+        }
     }
 
     private suspend fun downloadApk(url: String, onProgress: (Float) -> Unit): File? {

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/NightlyBuildsRepository.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/NightlyBuildsRepository.kt
@@ -30,9 +30,6 @@ class NightlyBuildsRepository(
     private val _updateState = MutableStateFlow<UpdateState>(UpdateState.UpToDate)
     val updateState = _updateState.asStateFlow()
 
-    private val _changelogState = MutableStateFlow<ChangelogState?>(null)
-    val changelogState = _changelogState.asStateFlow()
-
     private var currentBuildNumber: Int = 0
     private var latestBuildNumber: Int = 0
     private var currentCommitHash: String = BuildConfig.COMMIT_HASH
@@ -57,24 +54,25 @@ class NightlyBuildsRepository(
                     asset?.name?.substringAfter("_")?.substringBefore("-")?.toIntOrNull() ?: 0
 
                 if (asset != null && latestBuildNumber > currentBuildNumber) {
+                    val commitList = getCommitsSinceCurrentVersion()
+
                     _updateState.update {
                         UpdateState.Available(
                             asset.name,
                             asset.browserDownloadUrl,
-                        )
-                    }
-
-                    _changelogState.update {
-                        ChangelogState(
-                            commits = getCommitsSinceCurrentVersion() ?: emptyList(),
-                            currentBuildNumber = currentBuildNumber,
-                            latestBuildNumber = latestBuildNumber,
+                            changelogState = if (commitList != null) {
+                                ChangelogState(
+                                    commits = commitList,
+                                    currentBuildNumber = currentBuildNumber,
+                                    latestBuildNumber = latestBuildNumber,
+                                )
+                            } else {
+                                null
+                            },
                         )
                     }
                 } else {
                     _updateState.update { UpdateState.UpToDate }
-                    // no changelog to show
-                    _changelogState.value = null
                 }
             } catch (e: Exception) {
                 when (e) {
@@ -85,7 +83,6 @@ class NightlyBuildsRepository(
                         Log.e(TAG, "Failed to check for update", e)
                     }
                 }
-                _changelogState.value = null
                 _updateState.update { UpdateState.Failed }
             }
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/NightlyBuildsRepository.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/NightlyBuildsRepository.kt
@@ -29,7 +29,7 @@ class NightlyBuildsRepository(
 
     private val _updateState = MutableStateFlow<UpdateState>(UpdateState.UpToDate)
     val updateState = _updateState.asStateFlow()
-    
+
     private var currentBuildNumber: Int = 0
     private var latestBuildNumber: Int = 0
     private var currentCommitHash: String = BuildConfig.COMMIT_HASH
@@ -118,21 +118,21 @@ class NightlyBuildsRepository(
         }
         applicationContext.startActivity(intent)
     }
-    
+
     fun getCurrentBuildNumber(): Int = currentBuildNumber
-    
+
     fun getLatestBuildNumber(): Int = latestBuildNumber
-    
+
     fun getCurrentCommitHash(): String = currentCommitHash
-    
+
     suspend fun getCommitsSinceCurrentVersion(): List<GitHubCommit>? {
         return try {
             // Get the latest commits (last 100)
             val commits = api.getRepositoryCommits("LawnchairLauncher", "lawnchair")
-            
+
             // Find the index of current commit
             val currentIndex = commits.indexOfFirst { it.sha.startsWith(currentCommitHash) }
-            
+
             if (currentIndex > 0) {
                 // Return all commits newer than current version
                 commits.take(currentIndex)

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/NightlyBuildsRepository.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/NightlyBuildsRepository.kt
@@ -30,6 +30,9 @@ class NightlyBuildsRepository(
     private val _updateState = MutableStateFlow<UpdateState>(UpdateState.UpToDate)
     val updateState = _updateState.asStateFlow()
 
+    private val _changelogState = MutableStateFlow<ChangelogState?>(null)
+    val changelogState = _changelogState.asStateFlow()
+
     private var currentBuildNumber: Int = 0
     private var latestBuildNumber: Int = 0
     private var currentCommitHash: String = BuildConfig.COMMIT_HASH
@@ -58,11 +61,20 @@ class NightlyBuildsRepository(
                         UpdateState.Available(
                             asset.name,
                             asset.browserDownloadUrl,
-                            latestBuildNumber,
+                        )
+                    }
+
+                    _changelogState.update {
+                        ChangelogState(
+                            commits = getCommitsSinceCurrentVersion() ?: emptyList(),
+                            currentBuildNumber = currentBuildNumber,
+                            latestBuildNumber = latestBuildNumber,
                         )
                     }
                 } else {
                     _updateState.update { UpdateState.UpToDate }
+                    // no changelog to show
+                    _changelogState.value = null
                 }
             } catch (e: Exception) {
                 when (e) {
@@ -73,6 +85,7 @@ class NightlyBuildsRepository(
                         Log.e(TAG, "Failed to check for update", e)
                     }
                 }
+                _changelogState.value = null
                 _updateState.update { UpdateState.Failed }
             }
         }
@@ -89,7 +102,7 @@ class NightlyBuildsRepository(
                     _updateState.update { UpdateState.Downloading(progress) }
                 }
                 if (file != null) {
-                    _updateState.update { UpdateState.Downloaded(file, latestBuildNumber) }
+                    _updateState.update { UpdateState.Downloaded(file) }
                 } else {
                     Log.e(TAG, "Downloaded file is null")
                     _updateState.update { UpdateState.Failed }
@@ -119,13 +132,7 @@ class NightlyBuildsRepository(
         applicationContext.startActivity(intent)
     }
 
-    fun getCurrentBuildNumber(): Int = currentBuildNumber
-
-    fun getLatestBuildNumber(): Int = latestBuildNumber
-
-    fun getCurrentCommitHash(): String = currentCommitHash
-
-    suspend fun getCommitsSinceCurrentVersion(): List<GitHubCommit>? {
+    private suspend fun getCommitsSinceCurrentVersion(): List<GitHubCommit>? {
         return try {
             // Get the latest commits (last 100)
             val commits = api.getRepositoryCommits("LawnchairLauncher", "lawnchair")
@@ -137,8 +144,8 @@ class NightlyBuildsRepository(
                 // Return all commits newer than current version
                 commits.take(currentIndex)
             } else {
-                // If current commit not found, show last 30 commits
-                commits.take(30)
+                // If current commit not found, show last N commits
+                commits.take(MAX_FALLBACK_COMMITS)
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to get commits", e)
@@ -202,3 +209,5 @@ private fun Context.requestInstallPermission() {
         startActivity(intent)
     }
 }
+
+private const val MAX_FALLBACK_COMMITS = 30

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/UpdateSection.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/UpdateSection.kt
@@ -1,16 +1,12 @@
 package app.lawnchair.ui.preferences.about
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -18,12 +14,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.android.launcher3.R
+import java.io.File
 
 @Composable
 fun UpdateSection(
     updateState: UpdateState,
-    showChangesDialog: Boolean,
-    onEvent: (AboutEvent) -> Unit,
+    onViewChanges: () -> Unit,
+    onInstall: (File) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -44,20 +41,10 @@ fun UpdateSection(
                 )
             }
             is UpdateState.Available -> {
-                Row {
-                    Button(
-                        onClick = { onEvent(AboutEvent.OnDownloadClicked) },
-                    ) {
-                        Text(text = stringResource(R.string.download_update))
-                    }
-                    if (showChangesDialog) {
-                        Spacer(modifier = Modifier.width(8.dp))
-                        OutlinedButton(
-                            onClick = { onEvent(AboutEvent.OnViewChangesClicked) },
-                        ) {
-                            Text(text = stringResource(R.string.view_changes))
-                        }
-                    }
+                Button(
+                    onClick = onViewChanges,
+                ) {
+                    Text(text = stringResource(R.string.download_update))
                 }
             }
             is UpdateState.Downloading -> {
@@ -74,7 +61,9 @@ fun UpdateSection(
             }
             is UpdateState.Downloaded -> {
                 Button(
-                    onClick = { onEvent(AboutEvent.OnInstallClicked(updateState.file)) },
+                    onClick = {
+                        onInstall(updateState.file)
+                    },
                 ) {
                     Text(text = stringResource(R.string.install_update))
                 }

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/UpdateSection.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/UpdateSection.kt
@@ -1,13 +1,10 @@
 package app.lawnchair.ui.preferences.about
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Button

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/UpdateSection.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/UpdateSection.kt
@@ -1,15 +1,13 @@
 package app.lawnchair.ui.preferences.about
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Info
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -24,6 +22,7 @@ import com.android.launcher3.R
 @Composable
 fun UpdateSection(
     updateState: UpdateState,
+    showChangesDialog: Boolean,
     onEvent: (AboutEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -45,32 +44,28 @@ fun UpdateSection(
                 )
             }
             is UpdateState.Available -> {
-                Column(
-                    modifier = Modifier.padding(top = 8.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    OutlinedButton(
-                        onClick = { onEvent(AboutEvent.OnViewChangesClicked) },
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Info,
-                            contentDescription = stringResource(R.string.view_changes),
-                            modifier = Modifier.padding(end = 4.dp),
-                        )
-                        Text(text = stringResource(R.string.view_changes))
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
+                Row {
                     Button(
                         onClick = { onEvent(AboutEvent.OnDownloadClicked) },
                     ) {
                         Text(text = stringResource(R.string.download_update))
+                    }
+                    if (showChangesDialog) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        OutlinedButton(
+                            onClick = { onEvent(AboutEvent.OnViewChangesClicked) },
+                        ) {
+                            Text(text = stringResource(R.string.view_changes))
+                        }
                     }
                 }
             }
             is UpdateState.Downloading -> {
                 LinearProgressIndicator(
                     progress = { updateState.progress },
-                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
                 )
                 Text(
                     text = "${(updateState.progress * 100).toInt()}%",
@@ -78,26 +73,10 @@ fun UpdateSection(
                 )
             }
             is UpdateState.Downloaded -> {
-                Column(
-                    modifier = Modifier.padding(top = 8.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
+                Button(
+                    onClick = { onEvent(AboutEvent.OnInstallClicked(updateState.file)) },
                 ) {
-                    OutlinedButton(
-                        onClick = { onEvent(AboutEvent.OnViewChangesClicked) },
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Info,
-                            contentDescription = stringResource(R.string.view_changes),
-                            modifier = Modifier.padding(end = 4.dp),
-                        )
-                        Text(text = stringResource(R.string.view_changes))
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Button(
-                        onClick = { onEvent(AboutEvent.OnInstallClicked(updateState.file)) },
-                    ) {
-                        Text(text = stringResource(R.string.install_update))
-                    }
+                    Text(text = stringResource(R.string.install_update))
                 }
             }
             UpdateState.Failed -> {

--- a/lawnchair/src/app/lawnchair/ui/preferences/about/UpdateSection.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/about/UpdateSection.kt
@@ -1,12 +1,21 @@
 package app.lawnchair.ui.preferences.about
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -39,11 +48,26 @@ fun UpdateSection(
                 )
             }
             is UpdateState.Available -> {
-                Button(
-                    onClick = { onEvent(AboutEvent.OnDownloadClicked) },
+                Column(
                     modifier = Modifier.padding(top = 8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    Text(text = stringResource(R.string.download_update))
+                    OutlinedButton(
+                        onClick = { onEvent(AboutEvent.OnViewChangesClicked) },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Info,
+                            contentDescription = stringResource(R.string.view_changes),
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
+                        Text(text = stringResource(R.string.view_changes))
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Button(
+                        onClick = { onEvent(AboutEvent.OnDownloadClicked) },
+                    ) {
+                        Text(text = stringResource(R.string.download_update))
+                    }
                 }
             }
             is UpdateState.Downloading -> {
@@ -57,11 +81,26 @@ fun UpdateSection(
                 )
             }
             is UpdateState.Downloaded -> {
-                Button(
-                    onClick = { onEvent(AboutEvent.OnInstallClicked(updateState.file)) },
+                Column(
                     modifier = Modifier.padding(top = 8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    Text(text = stringResource(R.string.install_update))
+                    OutlinedButton(
+                        onClick = { onEvent(AboutEvent.OnViewChangesClicked) },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Info,
+                            contentDescription = stringResource(R.string.view_changes),
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
+                        Text(text = stringResource(R.string.view_changes))
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Button(
+                        onClick = { onEvent(AboutEvent.OnInstallClicked(updateState.file)) },
+                    ) {
+                        Text(text = stringResource(R.string.install_update))
+                    }
                 }
             }
             UpdateState.Failed -> {


### PR DESCRIPTION
Add a new "View changes" button in the About screen that displays a detailed changelog dialog when updates are available. This provides users with better visibility into what changes they will receive when updating.

Features added:
- New "View changes" button in update section (Available/Downloaded states)
- ChangesDialog component showing commit history since current version
- Clickable commit cards that open GitHub commit pages in browser
- Relative time display (5m, 2h, 3d, etc.) following GitHub's format
- Full internationalization support for time strings
- Fetches commits using GitHub API and compares with current build
- Clean Material 3 UI with proper styling and animations

Technical changes:
- Extended GitHubService with commits and compare endpoints
- Added GitHubCommit and GitHubCompareResponse data models
- Enhanced NightlyBuildsRepository with commit fetching capabilities
- Added time-relative string resources (time_minutes_ago, time_hours_ago, etc.)
- Updated AboutViewModel to handle changes dialog state
- Modified UpdateState models to include build numbers