### PR TITLE
Use correct intent to launch Kagi search app

### DIFF
--- a/lawnchair/src/app/lawnchair/qsb/providers/Kagi.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Kagi.kt
@@ -14,6 +14,8 @@ data object Kagi : QsbSearchProvider(
     themedIcon = R.drawable.ic_kagi_tinted,
     themingMethod = ThemingMethod.TINT,
     packageName = "com.kagi.search",
+    className = "com.kagi.search.HomeActivity",
+    action = "WIDGET_SEARCH_TEXT",
     website = "https://kagi.com",
     type = QsbSearchProviderType.APP_AND_WEBSITE,
     sponsored = false,


### PR DESCRIPTION
### Description

This very simple PR passes the required intent to the Kagi app so that the search box is selected and the keyboard is opened as soon as the user taps on the search widget. This improves the user experience and matches the behavior of the official Kagi widget.

### Reasoning

Currently, when selecting the Kagi app as search provider, tapping on the search widget opens the app's home activity without passing any intents to it. This means the app's search box is not selected and the keyboard doesn't pop up, like it does when you use the official Kagi widget. Instead, the user has to tap again on the app's search box before they can start typing, which is not a good user experience:

https://github.com/user-attachments/assets/4fd65cb0-522a-41b4-8170-3c1e51a2fb4a

By passing the required action (`WIDGET_SEARCH_TEXT`) to the launch function, as well as the required `className` parameter, we achieve the desired result:

https://github.com/user-attachments/assets/c8042b7e-a51a-46e0-8644-37e2ba252b99

### Testing

- Select the Kagi app as search provider
- Tap on the search widget

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)