### PR TITLE
Fix/5915 search UI persistence

### DIFF
--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -135,6 +135,14 @@ class LawnchairLauncher : QuickstepLauncher() {
         }
         override fun onStateTransitionComplete(finalState: LauncherState) {}
     }
+    private val resetSearchStateListener = object : StateManager.StateListener<LauncherState>{
+        override fun onStateTransitionStart(toState: LauncherState?) { }
+        override fun onStateTransitionComplete(finalState: LauncherState?) {
+            if(finalState== LauncherState.NORMAL && mAppsView!= null && mAppsView.isSearching){
+                mAppsView.post { mAppsView.reset(false,true) }
+            }
+        }
+    }
 
     private lateinit var colorScheme: ColorScheme
     private var hasBackGesture = false
@@ -166,6 +174,9 @@ class LawnchairLauncher : QuickstepLauncher() {
                 } catch (_: RootNotAvailableException) {
                 }
             }
+        }
+        with(launcher.stateManager){
+            addStateListener(resetSearchStateListener)
         }
 
         preferenceManager2.showStatusBar.get().distinctUntilChanged().onEach {

--- a/lawnchair/src/app/lawnchair/smartspace/provider/BatteryStatusProvider.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/provider/BatteryStatusProvider.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.graphics.drawable.Icon
 import android.os.BatteryManager
-import android.util.Log
 import androidx.core.content.getSystemService
 import app.lawnchair.smartspace.model.SmartspaceAction
 import app.lawnchair.smartspace.model.SmartspaceScores
@@ -14,8 +13,8 @@ import app.lawnchair.util.broadcastReceiverFlow
 import app.lawnchair.util.formatShortElapsedTimeRoundingUpToMinutes
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
-import kotlinx.coroutines.flow.map
 import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.map
 
 class BatteryStatusProvider(context: Context) :
     SmartspaceDataSource(
@@ -25,14 +24,13 @@ class BatteryStatusProvider(context: Context) :
     ) {
 
     private val batteryManager = context.getSystemService<BatteryManager>()
-    private val battContext = context
+    private val batteryContext = context
     private var lastBatteryLevel: Int = -1
     private var lastChargingTime: Long = -1
     private var chargingRates = mutableListOf<Double>()
-    private val TAG = "BatteryStatusProvider"
 
-    override val internalTargets = broadcastReceiverFlow(context, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
-        .map { intent ->
+    override val internalTargets =
+        broadcastReceiverFlow(context, IntentFilter(Intent.ACTION_BATTERY_CHANGED)).map { intent ->
             updateChargingEstimation(intent)
             val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
             val charging = status == BatteryManager.BATTERY_STATUS_CHARGING
@@ -40,15 +38,21 @@ class BatteryStatusProvider(context: Context) :
                 resetChargingTracking()
             }
             val full = status == BatteryManager.BATTERY_STATUS_FULL
-            val level = (
-                100f *
-                    intent.getIntExtra(BatteryManager.EXTRA_LEVEL, 0) /
-                    intent.getIntExtra(BatteryManager.EXTRA_SCALE, 100)
-                ).toInt()
+            val level =
+                (
+                    100f * intent.getIntExtra(BatteryManager.EXTRA_LEVEL, 0) / intent.getIntExtra(
+                        BatteryManager.EXTRA_SCALE,
+                        100,
+                    )
+                    ).toInt()
             listOfNotNull(getSmartspaceTarget(charging, full, level))
         }
 
-    private fun getSmartspaceTarget(charging: Boolean, full: Boolean, level: Int): SmartspaceTarget? {
+    private fun getSmartspaceTarget(
+        charging: Boolean,
+        full: Boolean,
+        level: Int,
+    ): SmartspaceTarget? {
         val title = when {
             full || level == 100 -> return null
             charging -> context.getString(R.string.smartspace_battery_charging)
@@ -62,7 +66,8 @@ class BatteryStatusProvider(context: Context) :
         }
         val chargingTimeRemaining = computeChargeTimeRemaining()
         val subtitle = if (charging && chargingTimeRemaining > 0) {
-            val chargingTime = formatShortElapsedTimeRoundingUpToMinutes(context, chargingTimeRemaining)
+            val chargingTime =
+                formatShortElapsedTimeRoundingUpToMinutes(context, chargingTimeRemaining)
             context.getString(
                 R.string.battery_charging_percentage_charging_time,
                 level,
@@ -89,14 +94,14 @@ class BatteryStatusProvider(context: Context) :
         val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
         val charging = status == BatteryManager.BATTERY_STATUS_CHARGING
         if (charging) {
-            val level = (
-                100f * intent.getIntExtra(BatteryManager.EXTRA_LEVEL, 0) /
-                    intent.getIntExtra(BatteryManager.EXTRA_SCALE, 100)
-                ).toInt()
-            val rate = calculateCurrentChargingRate(level)
-            if (rate > 0) {
-                Log.d(TAG, "Updated charging rate: %.2f%% per minute".format(rate))
-            }
+            val level =
+                (
+                    100f * intent.getIntExtra(BatteryManager.EXTRA_LEVEL, 0) / intent.getIntExtra(
+                        BatteryManager.EXTRA_SCALE,
+                        100,
+                    )
+                    ).toInt()
+            calculateCurrentChargingRate(level)
         }
     }
 
@@ -111,6 +116,7 @@ class BatteryStatusProvider(context: Context) :
             custom
         }.getOrDefault(-1)
     }
+
     private fun isReasonableChargingTime(timeRemaining: Long): Boolean {
         if (timeRemaining <= 0) return false
         val hoursRemaining = timeRemaining / (60 * 60 * 1000.0)
@@ -126,6 +132,7 @@ class BatteryStatusProvider(context: Context) :
         }
         return calculateFallbackTime(batteryLevel)
     }
+
     private fun calculateCurrentChargingRate(currentLevel: Int): Double {
         val currentTime = System.currentTimeMillis()
         if (lastBatteryLevel == -1 || lastChargingTime == -1L) {
@@ -149,6 +156,7 @@ class BatteryStatusProvider(context: Context) :
         }
         return -1.0
     }
+
     private fun calculateTimeFromRate(currentLevel: Int, ratePerMinute: Double): Long {
         val remainingPercentage = 100 - currentLevel
         val adjustedRate = ratePerMinute * when (currentLevel) {
@@ -168,6 +176,7 @@ class BatteryStatusProvider(context: Context) :
         val result = (roundedMinutes * 60 * 1000).toLong()
         return result
     }
+
     private fun calculateFallbackTime(currentLevel: Int): Long {
         val remainingPercentage = 100 - currentLevel
         val estimatedMinutes = when {
@@ -179,6 +188,7 @@ class BatteryStatusProvider(context: Context) :
                     else -> remainingPercentage * 5.0
                 }
             }
+
             isNormalCharging() -> remainingPercentage * 2.5
             else -> remainingPercentage * 5.0
         }
@@ -192,28 +202,36 @@ class BatteryStatusProvider(context: Context) :
         lastChargingTime = -1
         chargingRates.clear()
     }
+
     private fun isFastCharging(): Boolean {
         return runCatching {
-            val batteryIntent = battContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            val batteryIntent =
+                batteryContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
             val plugType = batteryIntent?.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
             plugType == BatteryManager.BATTERY_PLUGGED_AC
         }.getOrDefault(false)
     }
+
     private fun isNormalCharging(): Boolean {
         return runCatching {
-            val batteryIntent = battContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            val batteryIntent =
+                batteryContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
             val plugType = batteryIntent?.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
             plugType == BatteryManager.BATTERY_PLUGGED_USB
         }.getOrDefault(false)
     }
+
     private fun getCurrentBatteryLevel(): Int {
         return runCatching {
-            val batteryIntent = battContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            val batteryIntent =
+                batteryContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
             val level = batteryIntent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
             val scale = batteryIntent?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
             if (level >= 0 && scale > 0) {
                 (level * 100 / scale.toFloat()).toInt()
-            } else -1
+            } else {
+                -1
+            }
         }.getOrDefault(-1)
     }
 }

--- a/lawnchair/src/app/lawnchair/smartspace/provider/BatteryStatusProvider.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/provider/BatteryStatusProvider.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.graphics.drawable.Icon
 import android.os.BatteryManager
+import android.util.Log
 import androidx.core.content.getSystemService
 import app.lawnchair.smartspace.model.SmartspaceAction
 import app.lawnchair.smartspace.model.SmartspaceScores
@@ -14,6 +15,7 @@ import app.lawnchair.util.formatShortElapsedTimeRoundingUpToMinutes
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
 import kotlinx.coroutines.flow.map
+import kotlin.math.roundToInt
 
 class BatteryStatusProvider(context: Context) :
     SmartspaceDataSource(
@@ -21,12 +23,22 @@ class BatteryStatusProvider(context: Context) :
         R.string.smartspace_battery_status,
         { smartspaceBatteryStatus },
     ) {
+
     private val batteryManager = context.getSystemService<BatteryManager>()
+    private val battContext = context
+    private var lastBatteryLevel: Int = -1
+    private var lastChargingTime: Long = -1
+    private var chargingRates = mutableListOf<Double>()
+    private val TAG = "BatteryStatusProvider"
 
     override val internalTargets = broadcastReceiverFlow(context, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
         .map { intent ->
+            updateChargingEstimation(intent)
             val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
             val charging = status == BatteryManager.BATTERY_STATUS_CHARGING
+            if (!charging) {
+                resetChargingTracking()
+            }
             val full = status == BatteryManager.BATTERY_STATUS_FULL
             val level = (
                 100f *
@@ -73,8 +85,135 @@ class BatteryStatusProvider(context: Context) :
         )
     }
 
+    private fun updateChargingEstimation(intent: Intent) {
+        val status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
+        val charging = status == BatteryManager.BATTERY_STATUS_CHARGING
+        if (charging) {
+            val level = (
+                100f * intent.getIntExtra(BatteryManager.EXTRA_LEVEL, 0) /
+                    intent.getIntExtra(BatteryManager.EXTRA_SCALE, 100)
+                ).toInt()
+            val rate = calculateCurrentChargingRate(level)
+            if (rate > 0) {
+                Log.d(TAG, "Updated charging rate: %.2f%% per minute".format(rate))
+            }
+        }
+    }
+
     private fun computeChargeTimeRemaining(): Long {
         if (!Utilities.ATLEAST_P) return -1
-        return runCatching { batteryManager?.computeChargeTimeRemaining() ?: -1 }.getOrDefault(-1)
+        return runCatching {
+            val systemTimeRemaining = batteryManager?.computeChargeTimeRemaining() ?: -1
+            if (isReasonableChargingTime(systemTimeRemaining)) {
+                return@runCatching systemTimeRemaining
+            }
+            val custom = calculateCustomChargeTimeRemaining()
+            custom
+        }.getOrDefault(-1)
+    }
+    private fun isReasonableChargingTime(timeRemaining: Long): Boolean {
+        if (timeRemaining <= 0) return false
+        val hoursRemaining = timeRemaining / (60 * 60 * 1000.0)
+        return hoursRemaining in 0.1..8.0
+    }
+
+    private fun calculateCustomChargeTimeRemaining(): Long {
+        val batteryLevel = getCurrentBatteryLevel()
+        if (batteryLevel == -1) return -1
+        val currentRate = calculateCurrentChargingRate(batteryLevel)
+        if (currentRate > 0) {
+            return calculateTimeFromRate(batteryLevel, currentRate)
+        }
+        return calculateFallbackTime(batteryLevel)
+    }
+    private fun calculateCurrentChargingRate(currentLevel: Int): Double {
+        val currentTime = System.currentTimeMillis()
+        if (lastBatteryLevel == -1 || lastChargingTime == -1L) {
+            lastBatteryLevel = currentLevel
+            lastChargingTime = currentTime
+            return -1.0
+        }
+        val levelDiff = currentLevel - lastBatteryLevel
+        val timeDiffMinutes = (currentTime - lastChargingTime) / (1000.0 * 60.0)
+        if (levelDiff > 0 && timeDiffMinutes >= 0.5) {
+            val rate = levelDiff / timeDiffMinutes
+            chargingRates.add(rate)
+            if (chargingRates.size > 5) {
+                chargingRates.removeAt(0)
+            }
+            val smoothedRate = chargingRates.mapIndexed { i, r -> r * (i + 1) }
+                .sum() / ((1..chargingRates.size).sum().toDouble())
+            lastBatteryLevel = currentLevel
+            lastChargingTime = currentTime
+            return smoothedRate
+        }
+        return -1.0
+    }
+    private fun calculateTimeFromRate(currentLevel: Int, ratePerMinute: Double): Long {
+        val remainingPercentage = 100 - currentLevel
+        val adjustedRate = ratePerMinute * when (currentLevel) {
+            in 0..60 -> 1.0
+            in 61..80 -> 0.85
+            in 81..90 -> 0.6
+            in 91..97 -> 0.4
+            else -> 0.2
+        }
+        if (adjustedRate <= 0) return -1
+        val estimatedMinutes = remainingPercentage / adjustedRate
+        val roundedMinutes = when {
+            estimatedMinutes <= 10 -> estimatedMinutes.roundToInt()
+            estimatedMinutes <= 30 -> ((estimatedMinutes / 5.0).roundToInt() * 5)
+            else -> ((estimatedMinutes / 10.0).roundToInt() * 10)
+        }.coerceAtLeast(1)
+        val result = (roundedMinutes * 60 * 1000).toLong()
+        return result
+    }
+    private fun calculateFallbackTime(currentLevel: Int): Long {
+        val remainingPercentage = 100 - currentLevel
+        val estimatedMinutes = when {
+            isFastCharging() -> {
+                when (currentLevel) {
+                    in 0..79 -> remainingPercentage * 1.0
+                    in 80..89 -> remainingPercentage * 1.8
+                    in 90..95 -> remainingPercentage * 3.0
+                    else -> remainingPercentage * 5.0
+                }
+            }
+            isNormalCharging() -> remainingPercentage * 2.5
+            else -> remainingPercentage * 5.0
+        }
+        val roundedMinutes = ((estimatedMinutes / 5.0).roundToInt() * 5).coerceAtLeast(1)
+        val result = (roundedMinutes * 60 * 1000).toLong()
+        return result
+    }
+
+    private fun resetChargingTracking() {
+        lastBatteryLevel = -1
+        lastChargingTime = -1
+        chargingRates.clear()
+    }
+    private fun isFastCharging(): Boolean {
+        return runCatching {
+            val batteryIntent = battContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            val plugType = batteryIntent?.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
+            plugType == BatteryManager.BATTERY_PLUGGED_AC
+        }.getOrDefault(false)
+    }
+    private fun isNormalCharging(): Boolean {
+        return runCatching {
+            val batteryIntent = battContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            val plugType = batteryIntent?.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
+            plugType == BatteryManager.BATTERY_PLUGGED_USB
+        }.getOrDefault(false)
+    }
+    private fun getCurrentBatteryLevel(): Int {
+        return runCatching {
+            val batteryIntent = battContext.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            val level = batteryIntent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+            val scale = batteryIntent?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+            if (level >= 0 && scale > 0) {
+                (level * 100 / scale.toFloat()).toInt()
+            } else -1
+        }.getOrDefault(-1)
     }
 }

--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -531,14 +531,6 @@ public class Launcher extends StatefulActivity<LauncherState>
         initDragController();
         mAllAppsController = new AllAppsTransitionController(this);
         mStateManager = new StateManager<>(this, NORMAL);
-        mStateManager.addStateListener(new StateManager.StateListener<LauncherState>() {
-            @Override
-            public void onStateTransitionComplete(LauncherState finalState){
-                if(finalState == NORMAL && mAppsView!=null && mAppsView.isSearching()){
-                    mAppsView.post(()-> mAppsView.reset(false,true));
-                }
-            }
-        });
 
         setupViews();
         updateDisallowBack();

--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -531,6 +531,14 @@ public class Launcher extends StatefulActivity<LauncherState>
         initDragController();
         mAllAppsController = new AllAppsTransitionController(this);
         mStateManager = new StateManager<>(this, NORMAL);
+        mStateManager.addStateListener(new StateManager.StateListener<LauncherState>() {
+            @Override
+            public void onStateTransitionComplete(LauncherState finalState){
+                if(finalState == NORMAL && mAppsView!=null && mAppsView.isSearching()){
+                    mAppsView.post(()-> mAppsView.reset(false,true));
+                }
+            }
+        });
 
         setupViews();
         updateDisallowBack();
@@ -1127,6 +1135,7 @@ public class Launcher extends StatefulActivity<LauncherState>
 
         mAppWidgetHolder.setActivityStarted(true);
         TraceHelper.INSTANCE.endSection();
+        TraceHelper.INSTANCE.endSection();
     }
 
     @Override
@@ -1628,7 +1637,7 @@ public class Launcher extends StatefulActivity<LauncherState>
                 @Override
                 public void onStateTransitionComplete(LauncherState finalState) {
                     if ((mPrevLauncherState == SPRING_LOADED || mPrevLauncherState == EDIT_MODE)
-                            && finalState == NORMAL) {
+                            && finalState == NORMAL) {  
                         AppWidgetResizeFrame.showForWidget(launcherHostView, cellLayout);
                         mStateManager.removeStateListener(this);
                     }

--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -531,14 +531,6 @@ public class Launcher extends StatefulActivity<LauncherState>
         initDragController();
         mAllAppsController = new AllAppsTransitionController(this);
         mStateManager = new StateManager<>(this, NORMAL);
-        mStateManager.addStateListener(new StateManager.StateListener<LauncherState>() {
-            @Override
-            public void onStateTransitionComplete(LauncherState finalState){
-                if(finalState == NORMAL && mAppsView!=null && mAppsView.isSearching()){
-                    mAppsView.post(()-> mAppsView.reset(false,true));
-                }
-            }
-        });
 
         setupViews();
         updateDisallowBack();
@@ -1135,7 +1127,6 @@ public class Launcher extends StatefulActivity<LauncherState>
 
         mAppWidgetHolder.setActivityStarted(true);
         TraceHelper.INSTANCE.endSection();
-        TraceHelper.INSTANCE.endSection();
     }
 
     @Override
@@ -1637,7 +1628,7 @@ public class Launcher extends StatefulActivity<LauncherState>
                 @Override
                 public void onStateTransitionComplete(LauncherState finalState) {
                     if ((mPrevLauncherState == SPRING_LOADED || mPrevLauncherState == EDIT_MODE)
-                            && finalState == NORMAL) {  
+                            && finalState == NORMAL) {
                         AppWidgetResizeFrame.showForWidget(launcherHostView, cellLayout);
                         mStateManager.removeStateListener(this);
                     }

--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -531,6 +531,14 @@ public class Launcher extends StatefulActivity<LauncherState>
         initDragController();
         mAllAppsController = new AllAppsTransitionController(this);
         mStateManager = new StateManager<>(this, NORMAL);
+        mStateManager.addStateListener(new StateManager.StateListener<LauncherState>() {
+            @Override
+            public void onStateTransitionComplete(LauncherState finalState){
+                if(finalState == NORMAL && mAppsView!=null && mAppsView.isSearching()){
+                    mAppsView.post(()-> mAppsView.reset(false,true));
+                }
+            }
+        });
 
         setupViews();
         updateDisallowBack();


### PR DESCRIPTION
### Description
Fixes #5915 - Search UI shown in app drawer once after search when it should show normal app list.

**Problem:** 
When user performs search in app drawer, then presses back/home button, then reopens app drawer - the search UI and results are still visible instead of the normal app list.

#Changes made                   

- Modified Launcher.java to add state listener for app drawer transitions
- Clear search state when onStateTransitionComplete detects drawer closure

### Testing

1. Perform search → back button → reopen drawer → shows app list 
2.  Perform search → home button → reopen drawer → shows app list 
3.  Normal search functionality remains intact 


### Type of change
:x: **Bug fix** (A non-breaking change that fixes an issue)

