### PR TITLE
Fix foldable device layout issue on Pixel 9 Pro Fold

### DIFF
--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -378,7 +378,10 @@ public class DeviceProfile {
         mInfo = info;
         isTablet = info.isTablet(windowBounds);
         isPhone = !isTablet;
-        isTwoPanels = isTablet && isMultiDisplay;
+        // Enable two-panel layout for multi-display devices (foldables)
+        // This ensures foldable devices like Pixel 9 Pro Fold use proper layout when unfolded
+        // even if they don't meet the traditional tablet width threshold (600dp)
+        isTwoPanels = isMultiDisplay;
         boolean isTaskBarEnabled = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getEnableTaskbarOnPhone());
         isTaskbarPresent = isTaskBarEnabled && (isTablet || (enableTinyTaskbar() && isGestureMode))
                 && WindowManagerProxy.INSTANCE.get(context).isTaskbarDrawnInProcess();

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -378,9 +378,6 @@ public class DeviceProfile {
         mInfo = info;
         isTablet = info.isTablet(windowBounds);
         isPhone = !isTablet;
-        // Enable two-panel layout for multi-display devices (foldables)
-        // This ensures foldable devices like Pixel 9 Pro Fold use proper layout when unfolded
-        // even if they don't meet the traditional tablet width threshold (600dp)
         isTwoPanels = isMultiDisplay;
         boolean isTaskBarEnabled = PreferenceExtensionsKt.firstBlocking(preferenceManager2.getEnableTaskbarOnPhone());
         isTaskbarPresent = isTaskBarEnabled && (isTablet || (enableTinyTaskbar() && isGestureMode))


### PR DESCRIPTION
## Description
This PR fixes the home screen layout issue on foldable devices like the Google Pixel 9 Pro Fold where the layout appears squashed and doesn't utilize the full available screen space when unfolded.

## Problem
The issue was in the `DeviceProfile.java` file where the `isTwoPanels` property determines whether to use a two-panel layout. The original logic required both conditions:
- `isTablet` - device has smallest width ≥ 600dp  
- `isMultiDisplay` - device is classified as TYPE_MULTI_DISPLAY (foldables)

For foldable devices like the Pixel 9 Pro Fold, when unfolded, the device might not meet the 600dp tablet width threshold, causing `isTablet` to be `false`, which prevented the two-panel layout from being used.

## Solution
Changed the logic to enable two-panel layout for all multi-display devices (foldables) regardless of whether they meet the traditional tablet width threshold:

```java
// Before
isTwoPanels = isTablet && isMultiDisplay;

// After  
isTwoPanels = isMultiDisplay;
```

This ensures foldable devices properly utilize the available screen space when unfolded.

## Testing
- Verified no compilation errors
- Logic change is conservative and only affects multi-display devices
- Maintains existing behavior for traditional tablets

Fixes #5920