### PR TITLE
fix: clear search state when app drawer is closed

### DIFF
--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -137,9 +137,9 @@ class LawnchairLauncher : QuickstepLauncher() {
     }
     private val clearSearchStateListener = object : StateManager.StateListener<LauncherState> {
         override fun onStateTransitionComplete(finalState: LauncherState) {
-            if (finalState == LauncherState.NORMAL && launcher.appsView?.isSearching() == true) {
-                launcher.appsView?.post {
-                    launcher.appsView?.reset(false, true)
+            if (finalState == LauncherState.NORMAL && mAppsView != null && mAppsView.isSearching) {
+                mAppsView?.post {
+                    mAppsView.reset(false, true)
                 }
             }
         }

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -135,6 +135,15 @@ class LawnchairLauncher : QuickstepLauncher() {
         }
         override fun onStateTransitionComplete(finalState: LauncherState) {}
     }
+    private val clearSearchStateListener = object : StateManager.StateListener<LauncherState> {
+        override fun onStateTransitionComplete(finalState: LauncherState) {
+            if (finalState == LauncherState.NORMAL && launcher.appsView?.isSearching() == true) {
+                launcher.appsView?.post {
+                    launcher.appsView?.reset(false, true)
+                }
+            }
+        }
+    }
 
     private lateinit var colorScheme: ColorScheme
     private var hasBackGesture = false
@@ -158,6 +167,7 @@ class LawnchairLauncher : QuickstepLauncher() {
         preferenceManager2.enableFeed.get().distinctUntilChanged().onEach { enable ->
             defaultOverlay.setEnableFeed(enable)
         }.launchIn(scope = lifecycleScope)
+        launcher.stateManager.addStateListener(clearSearchStateListener)
 
         if (prefs.autoLaunchRoot.get()) {
             lifecycleScope.launch {


### PR DESCRIPTION
Description
Fixes:-  Search UI shown in app drawer once after search when it should show normal app list.

Problem:
When user performs search in app drawer, then presses back/home button, then reopens app drawer - the search UI and results are still visible instead of the normal app list.

#Changes made

Modified LawnchairLauncher.kt to add state listener for app drawer transitions
Clear search state when onStateTransitionComplete detects drawer closure

Testing
Perform search → back button → reopen drawer → shows app list
Perform search → home button → reopen drawer → shows app list
Normal search functionality remains intact
Type of change
❌ Bug fix (A non-breaking change that fixes an issue)