### PR TITLE
fix:page indicator only half displayed

### DIFF
--- a/lawnchair/res/layout/user_folder_icon_normalized.xml
+++ b/lawnchair/res/layout/user_folder_icon_normalized.xml
@@ -58,6 +58,7 @@
             android:id="@+id/folder_page_indicator"
             android:layout_gravity="center_vertical"
             android:layout_width="wrap_content"
+            android:layout_marginEnd="4dp"
             android:layout_height="wrap_content"
             android:elevation="1dp"
             />

--- a/res/layout/user_folder_icon_normalized.xml
+++ b/res/layout/user_folder_icon_normalized.xml
@@ -58,6 +58,7 @@
             android:id="@+id/folder_page_indicator"
             android:layout_gravity="center_vertical"
             android:layout_width="wrap_content"
+            android:layout_marginEnd="4dp"
             android:layout_height="wrap_content"
             android:elevation="1dp"
             />


### PR DESCRIPTION
### Description
Fixes #5885 - The page indicator is only half displayed

**Problem:**
Page indicator in the launcher was only showing half

##Changes made
Just added margin from end in folder_normalized_icon

### Testing
1. Tested via adding 6-7 pages in that folder and checked indicator.
2. Tested via increasing display size too.


### Type of change
:x: **Bug fix** (A non-breaking change that fixes an issue))
