### PR TITLE
Fix/5947 laucher search bar widget and icon issue

### DIFF
--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -12,6 +12,7 @@ import android.graphics.drawable.PaintDrawable
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import android.widget.ImageView
+import android.widget.Toast
 import androidx.core.view.ViewCompat
 import androidx.core.view.children
 import androidx.core.view.descendants
@@ -105,6 +106,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         }
 
         if (supportsLens) setUpLensIcon()
+        setUpGoogleIcon()
 
         setOnClickListener {
             val launcher = context.launcher
@@ -113,7 +115,12 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
                     launcher.appsView.searchUiManager.editText?.showKeyboard()
                     launcher.animateToAllApps()
                 } else {
-                    searchProvider.launch(launcher)
+                    val intent = getGoogleSearchIntent(context)
+                    if (intent != null) {
+                        context.startActivity(intent)
+                    } else {
+                        searchProvider.launch(launcher)
+                    }
                 }
             }
         }
@@ -173,6 +180,12 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             .firstOrNull()
             ?.pendingIntent
     }
+    private fun getGoogleSearchIntent(context: Context): Intent? {
+        val intent =
+            Intent(Google.action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+                .setPackage(GOOGLE_APP_PACKAGE)
+        return if (intent.resolveActivity(context.packageManager) != null) intent else null
+    }
 
     private fun setUpLensIcon() {
         val lensIntent = getLensIntent(context) ?: return
@@ -184,7 +197,15 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             }
         }
     }
-
+    private fun setUpGoogleIcon() {
+        val googleIntent = getGoogleIntent(context) ?: return
+        with(gIcon) {
+            isVisible = true
+            setOnClickListener {
+                runCatching { context.startActivity(googleIntent) }
+            }
+        }
+    }
     private fun clipIconRipples() {
         val cornerRadius = getCornerRadius(context, preferenceManager)
         listOf(lensIcon, micIcon).forEach {
@@ -228,6 +249,9 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
     companion object {
         private const val LENS_PACKAGE = "com.google.ar.lens"
         private const val LENS_ACTIVITY = "com.google.vr.apps.ornament.app.lens.LensLauncherActivity"
+        private const val GOOGLE_APP_PACKAGE = "com.google.android.googlequicksearchbox"
+        private const val GOOGLE_PACKAGE = "com.google.android.googlequicksearchbox"
+        private const val GOOGLE_ACTIVITY = "com.google.android.googlequicksearchbox.SearchActivity"
 
         fun getLensIntent(context: Context): Intent? {
             val lensIntent = Intent.makeMainActivity(ComponentName(LENS_PACKAGE, LENS_ACTIVITY))
@@ -235,6 +259,13 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             if (context.packageManager.resolveActivity(lensIntent, 0) == null) return null
 
             return lensIntent
+        }
+        fun getGoogleIntent(context: Context): Intent? {
+            val googleIntent =
+                Intent.makeMainActivity(ComponentName(GOOGLE_PACKAGE, GOOGLE_ACTIVITY))
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+            if (context.packageManager.resolveActivity(googleIntent, 0) == null) return null
+            return googleIntent
         }
 
         fun getSearchProvider(

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -12,7 +12,6 @@ import android.graphics.drawable.PaintDrawable
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import android.widget.ImageView
-import android.widget.Toast
 import androidx.core.view.ViewCompat
 import androidx.core.view.children
 import androidx.core.view.descendants
@@ -106,7 +105,6 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         }
 
         if (supportsLens) setUpLensIcon()
-        setUpGoogleIcon()
 
         setOnClickListener {
             val launcher = context.launcher
@@ -115,12 +113,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
                     launcher.appsView.searchUiManager.editText?.showKeyboard()
                     launcher.animateToAllApps()
                 } else {
-                    val intent = getGoogleSearchIntent(context)
-                    if (intent != null) {
-                        context.startActivity(intent)
-                    } else {
-                        searchProvider.launch(launcher)
-                    }
+                    searchProvider.launch(launcher)
                 }
             }
         }
@@ -180,12 +173,6 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             .firstOrNull()
             ?.pendingIntent
     }
-    private fun getGoogleSearchIntent(context: Context): Intent? {
-        val intent =
-            Intent(Google.action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
-                .setPackage(GOOGLE_APP_PACKAGE)
-        return if (intent.resolveActivity(context.packageManager) != null) intent else null
-    }
 
     private fun setUpLensIcon() {
         val lensIntent = getLensIntent(context) ?: return
@@ -197,15 +184,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             }
         }
     }
-    private fun setUpGoogleIcon() {
-        val googleIntent = getGoogleIntent(context) ?: return
-        with(gIcon) {
-            isVisible = true
-            setOnClickListener {
-                runCatching { context.startActivity(googleIntent) }
-            }
-        }
-    }
+
     private fun clipIconRipples() {
         val cornerRadius = getCornerRadius(context, preferenceManager)
         listOf(lensIcon, micIcon).forEach {
@@ -249,9 +228,6 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
     companion object {
         private const val LENS_PACKAGE = "com.google.ar.lens"
         private const val LENS_ACTIVITY = "com.google.vr.apps.ornament.app.lens.LensLauncherActivity"
-        private const val GOOGLE_APP_PACKAGE = "com.google.android.googlequicksearchbox"
-        private const val GOOGLE_PACKAGE = "com.google.android.googlequicksearchbox"
-        private const val GOOGLE_ACTIVITY = "com.google.android.googlequicksearchbox.SearchActivity"
 
         fun getLensIntent(context: Context): Intent? {
             val lensIntent = Intent.makeMainActivity(ComponentName(LENS_PACKAGE, LENS_ACTIVITY))
@@ -259,13 +235,6 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             if (context.packageManager.resolveActivity(lensIntent, 0) == null) return null
 
             return lensIntent
-        }
-        fun getGoogleIntent(context: Context): Intent? {
-            val googleIntent =
-                Intent.makeMainActivity(ComponentName(GOOGLE_PACKAGE, GOOGLE_ACTIVITY))
-                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
-            if (context.packageManager.resolveActivity(googleIntent, 0) == null) return null
-            return googleIntent
         }
 
         fun getSearchProvider(

--- a/lawnchair/src/app/lawnchair/smartspace/CardPagerAdapter.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/CardPagerAdapter.kt
@@ -74,7 +74,7 @@ class CardPagerAdapter(context: Context) : PagerAdapter() {
         val card = viewHolder.card
         card.setSmartspaceTarget(target, smartspaceTargets.size > 1)
         val isDark = isWallpaperDark(card.context)
-        val dynamicColors = if(isDark) Color.WHITE else Color.BLACK
+        val dynamicColors = if (isDark) Color.WHITE else Color.BLACK
         card.setPrimaryTextColor(dynamicColors)
     }
 

--- a/lawnchair/src/app/lawnchair/smartspace/CardPagerAdapter.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/CardPagerAdapter.kt
@@ -1,12 +1,14 @@
 package app.lawnchair.smartspace
 
 import android.content.Context
+import android.graphics.Color
 import android.util.SparseArray
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.viewpager.widget.PagerAdapter
 import app.lawnchair.smartspace.model.SmartspaceTarget
+import app.lawnchair.util.isWallpaperDark
 import com.android.launcher3.R
 import com.android.launcher3.util.Themes
 
@@ -71,7 +73,9 @@ class CardPagerAdapter(context: Context) : PagerAdapter() {
         val target = smartspaceTargets[viewHolder.position]
         val card = viewHolder.card
         card.setSmartspaceTarget(target, smartspaceTargets.size > 1)
-        card.setPrimaryTextColor(currentTextColor)
+        val isDark = isWallpaperDark(card.context)
+        val dynamicColors = if(isDark) Color.WHITE else Color.BLACK
+        card.setPrimaryTextColor(dynamicColors)
     }
 
     override fun getCount() = smartspaceTargets.size

--- a/lawnchair/src/app/lawnchair/util/WallpaperUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/WallpaperUtils.kt
@@ -1,22 +1,17 @@
 package app.lawnchair.util
 
-import android.app.WallpaperColors
-import android.app.WallpaperManager
 import android.content.Context
 import android.graphics.Color
-import android.os.Build
+import app.lawnchair.wallpaper.WallpaperColorsCompat
+import app.lawnchair.wallpaper.WallpaperManagerCompat
 
 fun isWallpaperDark(context: Context): Boolean {
-    val wallpaperManager = WallpaperManager.getInstance(context)
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        val colors: WallpaperColors? =
-            wallpaperManager.getWallpaperColors(WallpaperManager.FLAG_SYSTEM)
-        colors?.primaryColor?.toArgb()?.let { argb ->
-            val darkness =
-                1 - (0.299 * Color.red(argb) + 0.587 * Color.green(argb) + 0.114 * Color.blue(argb)) / 255
-            darkness >= 0.5
-        } ?: false
-    } else {
-        false
-    }
+    val wallpaperManager = WallpaperManagerCompat.INSTANCE.get(context)
+    val colors: WallpaperColorsCompat? = wallpaperManager.wallpaperColors
+    return colors?.primaryColor?.let { argb ->
+        val darkness =
+            1 - (0.299 * Color.red(argb) + 0.587 * Color.green(argb) + 0.114 * Color.blue(argb)) / 255
+        darkness >= 0.5
+    } ?: false
 }
+

--- a/lawnchair/src/app/lawnchair/util/WallpaperUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/WallpaperUtils.kt
@@ -1,0 +1,24 @@
+package app.lawnchair.util
+
+import android.app.WallpaperColors
+import android.app.WallpaperManager
+import android.content.Context
+import android.graphics.Color
+import android.os.Build
+
+fun isWallpaperDark(context: Context): Boolean {
+    val wallpaperManager = WallpaperManager.getInstance(context)
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        val colors: WallpaperColors? =
+            wallpaperManager.getWallpaperColors(WallpaperManager.FLAG_SYSTEM)
+        colors?.primaryColor?.toArgb()?.let { argb ->
+            val darkness =
+                1 - (0.299 * Color.red(argb) + 0.587 * Color.green(argb) + 0.114 * Color.blue(argb)) / 255
+            darkness >= 0.5
+        } ?: false
+    } else {
+        false
+    }
+}
+
+

--- a/lawnchair/src/app/lawnchair/util/WallpaperUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/WallpaperUtils.kt
@@ -14,4 +14,3 @@ fun isWallpaperDark(context: Context): Boolean {
         darkness >= 0.5
     } ?: false
 }
-

--- a/lawnchair/src/app/lawnchair/util/WallpaperUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/WallpaperUtils.kt
@@ -20,5 +20,3 @@ fun isWallpaperDark(context: Context): Boolean {
         false
     }
 }
-
-


### PR DESCRIPTION
### Description

Fixes the launcher search bar widget and Google icon so that tapping them correctly opens the Google app.

Fixes #5947

### Reasoning

The search bar and Google icon were not opening the Google app.
This change ensures that the intent is properly created, validated with `resolveActivity`, and launched, with a fallback to the in-app search if the Google app is not installed.

### Testing

1. Launch the Lawnchair launcher.
2. Tap the search bar widget:
   - If the Google app is installed, it should open.
3. Tap the Google icon:
   - Should open the Google app.



### Type of change
:x: **Bug fix** (A non-breaking change that fixes an issue)

