### PR TITLE
fix(allapps): Hide app drawer folders in work/private profiles

### DIFF
--- a/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
+++ b/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
@@ -83,6 +83,9 @@ class LawnchairAlphabeticalAppsList<T>(
         filteredList.clear()
         var position = startPosition
 
+        // Show app drawer folders only on main profile, to prevent state complexity
+        if (!isWorkOrPrivateSpace(appList)) return super.addAppsWithSections(appList, position)
+
         if (!drawerListDefault) {
             val categorizedApps = potsManager.categorizeApps(appList)
             categorizedApps.forEach { (category, apps) ->

--- a/src/com/android/launcher3/allapps/AlphabeticalAppsList.java
+++ b/src/com/android/launcher3/allapps/AlphabeticalAppsList.java
@@ -431,6 +431,21 @@ public class AlphabeticalAppsList<T extends Context & ActivityContext> implement
         return position;
     }
 
+
+    /**
+     * Checks if the provided list of apps are from the work/private profile.
+     */
+    protected boolean isWorkOrPrivateSpace(List<AppInfo> appList) {
+        PrivateProfileManager mPrivateProfileManager = getPrivateProfileManager();
+        if (appList.isEmpty()) {
+            return false;
+        }
+        return appList.stream().anyMatch(info ->
+                (mWorkProviderManager != null && mWorkProviderManager.getItemInfoMatcher().test(info))
+                        || (mPrivateProfileManager != null
+                        && mPrivateProfileManager.getItemInfoMatcher().test(info)));
+    }
+    
     /**
      * Determines the corner regions that should be rounded for a specific app icon based on its
      * position in a grid. Apps that should only be cared about rounding are the apps in the last

--- a/src/com/android/launcher3/allapps/AlphabeticalAppsList.java
+++ b/src/com/android/launcher3/allapps/AlphabeticalAppsList.java
@@ -436,14 +436,13 @@ public class AlphabeticalAppsList<T extends Context & ActivityContext> implement
      * Checks if the provided list of apps are from the work/private profile.
      */
     protected boolean isWorkOrPrivateSpace(List<AppInfo> appList) {
-        PrivateProfileManager mPrivateProfileManager = getPrivateProfileManager();
         if (appList.isEmpty()) {
             return false;
         }
         return appList.stream().anyMatch(info ->
                 (mWorkProviderManager != null && mWorkProviderManager.getItemInfoMatcher().test(info))
-                        || (mPrivateProfileManager != null
-                        && mPrivateProfileManager.getItemInfoMatcher().test(info)));
+                        || (mPrivateProviderManager != null
+                        && mPrivateProviderManager.getItemInfoMatcher().test(info)));
     }
     
     /**


### PR DESCRIPTION
### Description

Prevents app drawer folders from being displayed within the work or private space profiles to avoid state complexity.

- Fixes #5425
- Fixes #5234

### Testing

1. Enable both work profile and private space.
2. Create an app drawer folder with any items.
3. Check app drawer work profile and private space - notice that it only shows up on the Personal (default) profile.


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
