### PR TITLE
fix(allapps): Fix logic on hiding drawer folders in work/private profiles

### DIFF
--- a/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
+++ b/lawnchair/src/app/lawnchair/allapps/LawnchairAlphabeticalAppsList.kt
@@ -84,7 +84,7 @@ class LawnchairAlphabeticalAppsList<T>(
         var position = startPosition
 
         // Show app drawer folders only on main profile, to prevent state complexity
-        if (!isWorkOrPrivateSpace(appList)) return super.addAppsWithSections(appList, position)
+        if (isWorkOrPrivateSpace(appList)) return super.addAppsWithSections(appList, position)
 
         if (!drawerListDefault) {
             val categorizedApps = potsManager.categorizeApps(appList)


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

Previous patch at LawnchairLauncher#6002 had inverted condition on `isWorkOrPrivateSpace` which did the actual opposite. Hiding drawers in the main space and showing them in the work/private profiles.


Fixes #5425, #5234 (again)


### Testing
- Android 12 Samsung OneUi 4.1 fresh install debug build
- Create a group in main space, now shows.

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
