### PR TITLE
fix(ui): Prevent crash on race condition when uninstalling an app

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LawnchairShortcut.kt
@@ -94,19 +94,24 @@ class LawnchairShortcut {
             if (mItemInfo.screenId != NO_ID && icon is BitmapInfo.Extender) {
                 icon = icon.getThemedDrawable(launcher)
             }
-            val launcherActivityInfo = outObj[0] as LauncherActivityInfo
-            val defaultTitle = launcherActivityInfo.label.toString()
+            val launcherActivityInfo = outObj[0] as LauncherActivityInfo?
+            if (launcherActivityInfo != null) {
+                val defaultTitle = launcherActivityInfo.label.toString()
 
-            AbstractFloatingView.closeAllOpenViews(launcher)
-            ComposeBottomSheet.show(
-                context = launcher,
-                contentPaddings = PaddingValues(bottom = 64.dp),
-            ) {
-                CustomizeAppDialog(
-                    icon = icon,
-                    defaultTitle = defaultTitle,
-                    componentKey = appInfo.toComponentKey(),
-                ) { close(true) }
+                AbstractFloatingView.closeAllOpenViews(launcher)
+                ComposeBottomSheet.show(
+                    context = launcher,
+                    contentPaddings = PaddingValues(bottom = 64.dp),
+                ) {
+                    CustomizeAppDialog(
+                        icon = icon,
+                        defaultTitle = defaultTitle,
+                        componentKey = appInfo.toComponentKey(),
+                    ) { close(true) }
+                }
+            } else {
+                Toast.makeText(launcher, R.string.activity_not_found, Toast.LENGTH_SHORT).show()
+                AbstractFloatingView.closeAllOpenViews(launcher)
             }
         }
     }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description
This pull requests fixes an ui bug where a race condition could cause a NullPointerException.
When uninstalling an app, there is a short lap of time where you can still open the shortcuts popup in the **app drawer** (due to Android starting uninstallation and only sending the intent once it is completed).

Clicking on the customize button would cause a NPE due to an unconsidered cast: `<...> as LauncherActivityInfo`.
Where <...> could be null, if the app was just uninstalled.

This corrects the cast and adds a safety check.
It will show a short toast to warn about the app not being installed instead of crashing.


### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Even though it is pretty much pointless (many persons don't try to crash their apps on purpose), it makes the app more polished :)

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Android 12 Samsung OneUI 4.1.
- Install hello world app
- Uninstall from lawnchair
- Quickly open shortcut for the app we just uninstalled
- Try to customize
- Notice Lawnchair doesn't crash anymore


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
