### PR TITLE
Fix/at a glance colors

### DIFF
--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -12,6 +12,7 @@ import android.graphics.drawable.PaintDrawable
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import android.widget.ImageView
+import android.widget.Toast
 import androidx.core.view.ViewCompat
 import androidx.core.view.children
 import androidx.core.view.descendants
@@ -105,6 +106,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         }
 
         if (supportsLens) setUpLensIcon()
+        setUpGoogleIcon()
 
         setOnClickListener {
             val launcher = context.launcher
@@ -113,7 +115,12 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
                     launcher.appsView.searchUiManager.editText?.showKeyboard()
                     launcher.animateToAllApps()
                 } else {
-                    searchProvider.launch(launcher)
+                    val intent = getGoogleSearchIntent(context)
+                    if (intent != null) {
+                        context.startActivity(intent)
+                    } else {
+                        searchProvider.launch(launcher)
+                    }
                 }
             }
         }
@@ -173,6 +180,12 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             .firstOrNull()
             ?.pendingIntent
     }
+    private fun getGoogleSearchIntent(context: Context): Intent? {
+        val intent =
+            Intent(Google.action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+                .setPackage(GOOGLE_APP_PACKAGE)
+        return if (intent.resolveActivity(context.packageManager) != null) intent else null
+    }
 
     private fun setUpLensIcon() {
         val lensIntent = getLensIntent(context) ?: return
@@ -184,7 +197,15 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             }
         }
     }
-
+    private fun setUpGoogleIcon() {
+        val googleIntent = getGoogleIntent(context) ?: return
+        with(gIcon) {
+            isVisible = true
+            setOnClickListener {
+                runCatching { context.startActivity(googleIntent) }
+            }
+        }
+    }
     private fun clipIconRipples() {
         val cornerRadius = getCornerRadius(context, preferenceManager)
         listOf(lensIcon, micIcon).forEach {
@@ -228,6 +249,9 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
     companion object {
         private const val LENS_PACKAGE = "com.google.ar.lens"
         private const val LENS_ACTIVITY = "com.google.vr.apps.ornament.app.lens.LensLauncherActivity"
+        private const val GOOGLE_APP_PACKAGE = "com.google.android.googlequicksearchbox"
+        private const val GOOGLE_PACKAGE = "com.google.android.googlequicksearchbox"
+        private const val GOOGLE_ACTIVITY = "com.google.android.googlequicksearchbox.SearchActivity"
 
         fun getLensIntent(context: Context): Intent? {
             val lensIntent = Intent.makeMainActivity(ComponentName(LENS_PACKAGE, LENS_ACTIVITY))
@@ -235,6 +259,13 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             if (context.packageManager.resolveActivity(lensIntent, 0) == null) return null
 
             return lensIntent
+        }
+        fun getGoogleIntent(context: Context): Intent? {
+            val googleIntent =
+                Intent.makeMainActivity(ComponentName(GOOGLE_PACKAGE, GOOGLE_ACTIVITY))
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+            if (context.packageManager.resolveActivity(googleIntent, 0) == null) return null
+            return googleIntent
         }
 
         fun getSearchProvider(

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -106,8 +106,6 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         }
 
         if (supportsLens) setUpLensIcon()
-        setUpGoogleIcon()
-
         setOnClickListener {
             val launcher = context.launcher
             launcher.lifecycleScope.launch {
@@ -115,12 +113,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
                     launcher.appsView.searchUiManager.editText?.showKeyboard()
                     launcher.animateToAllApps()
                 } else {
-                    val intent = getGoogleSearchIntent(context)
-                    if (intent != null) {
-                        context.startActivity(intent)
-                    } else {
-                        searchProvider.launch(launcher)
-                    }
+                    searchProvider.launch(launcher)
                 }
             }
         }
@@ -180,12 +173,6 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             .firstOrNull()
             ?.pendingIntent
     }
-    private fun getGoogleSearchIntent(context: Context): Intent? {
-        val intent =
-            Intent(Google.action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
-                .setPackage(GOOGLE_APP_PACKAGE)
-        return if (intent.resolveActivity(context.packageManager) != null) intent else null
-    }
 
     private fun setUpLensIcon() {
         val lensIntent = getLensIntent(context) ?: return
@@ -194,15 +181,6 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             isVisible = true
             setOnClickListener {
                 runCatching { context.startActivity(lensIntent) }
-            }
-        }
-    }
-    private fun setUpGoogleIcon() {
-        val googleIntent = getGoogleIntent(context) ?: return
-        with(gIcon) {
-            isVisible = true
-            setOnClickListener {
-                runCatching { context.startActivity(googleIntent) }
             }
         }
     }
@@ -249,9 +227,6 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
     companion object {
         private const val LENS_PACKAGE = "com.google.ar.lens"
         private const val LENS_ACTIVITY = "com.google.vr.apps.ornament.app.lens.LensLauncherActivity"
-        private const val GOOGLE_APP_PACKAGE = "com.google.android.googlequicksearchbox"
-        private const val GOOGLE_PACKAGE = "com.google.android.googlequicksearchbox"
-        private const val GOOGLE_ACTIVITY = "com.google.android.googlequicksearchbox.SearchActivity"
 
         fun getLensIntent(context: Context): Intent? {
             val lensIntent = Intent.makeMainActivity(ComponentName(LENS_PACKAGE, LENS_ACTIVITY))
@@ -259,13 +234,6 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             if (context.packageManager.resolveActivity(lensIntent, 0) == null) return null
 
             return lensIntent
-        }
-        fun getGoogleIntent(context: Context): Intent? {
-            val googleIntent =
-                Intent.makeMainActivity(ComponentName(GOOGLE_PACKAGE, GOOGLE_ACTIVITY))
-                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
-            if (context.packageManager.resolveActivity(googleIntent, 0) == null) return null
-            return googleIntent
         }
 
         fun getSearchProvider(

--- a/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
+++ b/lawnchair/src/app/lawnchair/qsb/LawnQsbLayout.kt
@@ -12,7 +12,6 @@ import android.graphics.drawable.PaintDrawable
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import android.widget.ImageView
-import android.widget.Toast
 import androidx.core.view.ViewCompat
 import androidx.core.view.children
 import androidx.core.view.descendants
@@ -106,6 +105,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         }
 
         if (supportsLens) setUpLensIcon()
+
         setOnClickListener {
             val launcher = context.launcher
             launcher.lifecycleScope.launch {
@@ -184,6 +184,7 @@ class LawnQsbLayout(context: Context, attrs: AttributeSet?) : FrameLayout(contex
             }
         }
     }
+
     private fun clipIconRipples() {
         val cornerRadius = getCornerRadius(context, preferenceManager)
         listOf(lensIcon, micIcon).forEach {

--- a/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
@@ -38,6 +38,14 @@ data object Google : QsbSearchProvider(
                     return
                 }
             }
+            val googleIntent = Intent(action).apply {
+                setPackage(packageName)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            if (googleIntent.resolveActivity(launcher.packageManager) != null) {
+                launcher.startActivity(googleIntent)
+                return
+            }
         }
         super.launch(launcher, forceWebsite)
     }

--- a/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
@@ -2,12 +2,15 @@ package app.lawnchair.qsb.providers
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetHostView
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.view.View
 import androidx.core.view.descendants
+import androidx.core.view.isVisible
 import app.lawnchair.HeadlessWidgetsManager
 import app.lawnchair.qsb.ThemingMethod
+import app.lawnchair.smartspace.BcSmartSpaceUtil.setOnClickListener
 import app.lawnchair.util.pendingIntent
 import com.android.launcher3.Launcher
 import com.android.launcher3.R
@@ -32,14 +35,11 @@ data object Google : QsbSearchProvider(
             val subscription = getSearchIntent(launcher)
             val pendingIntent = subscription.firstOrNull()
             if (pendingIntent != null) {
-                launcher.startIntentSender(
-                    pendingIntent.intentSender,
-                    null,
-                    Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK,
-                    Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK,
-                    0,
-                )
-                return
+                val googleIntent = getGoogleSearchIntent(context = launcher)
+                if (googleIntent != null) {
+                    launcher.startActivity(googleIntent)
+                    return
+                }
             }
         }
         super.launch(launcher, forceWebsite)
@@ -62,5 +62,11 @@ data object Google : QsbSearchProvider(
             .sortedByDescending { it.measuredWidth * it.measuredHeight }
             .firstOrNull()
             ?.pendingIntent
+    }
+    private fun getGoogleSearchIntent(context: Context): Intent? {
+        val intent =
+            Intent(action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+                .setPackage("com.google.android.googlequicksearchbox")
+        return if (intent.resolveActivity(context.packageManager) != null) intent else null
     }
 }

--- a/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
@@ -13,6 +13,7 @@ import com.android.launcher3.Launcher
 import com.android.launcher3.R
 import com.android.launcher3.qsb.QsbContainerView
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -41,12 +42,25 @@ data object Google : QsbSearchProvider(
         }
         super.launch(launcher, forceWebsite)
     }
-
     fun getSearchIntent(context: Context): Flow<PendingIntent?> {
-        val info = QsbContainerView.getSearchWidgetProviderInfo(context, Google.packageName) ?: return flowOf(null)
+        val info = QsbContainerView.getSearchWidgetProviderInfo(context, packageName)
+            ?: return flowOf(null)
         val headlessWidgetsManager = HeadlessWidgetsManager.INSTANCE.get(context)
-        return headlessWidgetsManager.subscribeUpdates(info, "hotseatWidgetId")
-            .map(::findSearchIntent)
+        return headlessWidgetsManager.subscribeUpdates(info, "hotseatWidgetId").map { view ->
+            var pending = findSearchIntent(view)
+            if (pending == null) {
+                try {
+                    val widget = headlessWidgetsManager.getWidget(info, "hotseatWidgetId")
+                    widget.bind()
+                    val updaterView =
+                        headlessWidgetsManager.subscribeUpdates(info, "hotseatWidgetId").first()
+                    pending = findSearchIntent(updaterView)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
+            pending
+        }
     }
 
     private fun findSearchIntent(view: AppWidgetHostView): PendingIntent? {

--- a/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
@@ -38,14 +38,6 @@ data object Google : QsbSearchProvider(
                     return
                 }
             }
-            val googleIntent = Intent(action).apply {
-                setPackage(packageName)
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-            if (googleIntent.resolveActivity(launcher.packageManager) != null) {
-                launcher.startActivity(googleIntent)
-                return
-            }
         }
         super.launch(launcher, forceWebsite)
     }

--- a/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
@@ -38,6 +38,14 @@ data object Google : QsbSearchProvider(
                     return
                 }
             }
+            val fallbackIntent = Intent(action).apply {
+                setPackage(packageName)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            if (fallbackIntent.resolveActivity(launcher.packageManager) != null) {
+                launcher.startActivity(fallbackIntent)
+                return
+            }
         }
         super.launch(launcher, forceWebsite)
     }

--- a/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
@@ -38,14 +38,6 @@ data object Google : QsbSearchProvider(
                     return
                 }
             }
-            val fallbackIntent = Intent(action).apply {
-                setPackage(packageName)
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-            if (fallbackIntent.resolveActivity(launcher.packageManager) != null) {
-                launcher.startActivity(fallbackIntent)
-                return
-            }
         }
         super.launch(launcher, forceWebsite)
     }

--- a/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Google.kt
@@ -2,15 +2,12 @@ package app.lawnchair.qsb.providers
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetHostView
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.view.View
 import androidx.core.view.descendants
-import androidx.core.view.isVisible
 import app.lawnchair.HeadlessWidgetsManager
 import app.lawnchair.qsb.ThemingMethod
-import app.lawnchair.smartspace.BcSmartSpaceUtil.setOnClickListener
 import app.lawnchair.util.pendingIntent
 import com.android.launcher3.Launcher
 import com.android.launcher3.R
@@ -66,7 +63,7 @@ data object Google : QsbSearchProvider(
     private fun getGoogleSearchIntent(context: Context): Intent? {
         val intent =
             Intent(action).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
-                .setPackage("com.google.android.googlequicksearchbox")
+                .setPackage(packageName)
         return if (intent.resolveActivity(context.packageManager) != null) intent else null
     }
 }

--- a/lawnchair/src/app/lawnchair/util/WallpaperUtils.kt
+++ b/lawnchair/src/app/lawnchair/util/WallpaperUtils.kt
@@ -2,15 +2,15 @@ package app.lawnchair.util
 
 import android.content.Context
 import android.graphics.Color
-import app.lawnchair.wallpaper.WallpaperColorsCompat
 import app.lawnchair.wallpaper.WallpaperManagerCompat
 
 fun isWallpaperDark(context: Context): Boolean {
     val wallpaperManager = WallpaperManagerCompat.INSTANCE.get(context)
-    val colors: WallpaperColorsCompat? = wallpaperManager.wallpaperColors
-    return colors?.primaryColor?.let { argb ->
-        val darkness =
-            1 - (0.299 * Color.red(argb) + 0.587 * Color.green(argb) + 0.114 * Color.blue(argb)) / 255
-        darkness >= 0.5
-    } ?: false
+    val colors = wallpaperManager.wallpaperColors
+    val primaryColor = colors?.primaryColor ?: return false
+    val brightness = getBrightness(primaryColor)
+    return brightness < 0.5
+}
+private fun getBrightness(color: Int): Double {
+    return (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) / 255.0
 }


### PR DESCRIPTION
### Description

Fixes the issue #5959 where the "At a Glance" widget colors were broken.  

Fixes #5959

### Reasoning
This change ensures that the primary wallpaper color is correctly analyzed and the resulting widget colors match the current system theme.

### Testing
1. Open the At a Glance widget on your device.
2. Change your wallpaper to a dark image and verify the text/icons are visible.  
3. Change your wallpaper to a light image and verify the text/icons remain readable.  
4. Tested on multiple devices by contributors @justeepin and @allmazz.

### Type of change
- [x] **Bug fix** (A non-breaking change that fixes an issue)
