### PR TITLE
fix: Window Insets crashes on less than Android 11

### DIFF
--- a/src/com/android/launcher3/widget/AddItemWidgetsBottomSheet.java
+++ b/src/com/android/launcher3/widget/AddItemWidgetsBottomSheet.java
@@ -168,7 +168,7 @@ public class AddItemWidgetsBottomSheet extends AbstractSlideInView<AddItemActivi
                 windowInsets.getSystemWindowInsetBottom());
         }
         int contentHorizontalMarginInPx = getResources().getDimensionPixelSize(
-            R.dimen.widget_list_horizontal_margin);
+                R.dimen.widget_list_horizontal_margin);
         if (contentHorizontalMarginInPx != mContentHorizontalMarginInPx) {
             setContentHorizontalMargin(findViewById(R.id.widget_appName),
                     contentHorizontalMarginInPx);

--- a/src/com/android/launcher3/widget/AddItemWidgetsBottomSheet.java
+++ b/src/com/android/launcher3/widget/AddItemWidgetsBottomSheet.java
@@ -26,10 +26,12 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.WindowInsets;
+import android.view.WindowInsets.Type;
 import android.widget.ScrollView;
 
 import com.android.launcher3.DeviceProfile;
 import com.android.launcher3.R;
+import com.android.launcher3.Utilities;
 import com.android.launcher3.dragndrop.AddItemActivity;
 import com.android.launcher3.views.AbstractSlideInView;
 
@@ -153,13 +155,20 @@ public class AddItemWidgetsBottomSheet extends AbstractSlideInView<AddItemActivi
     @SuppressLint("NewApi") // Already added API check.
     @Override
     public WindowInsets onApplyWindowInsets(View view, WindowInsets windowInsets) {
-        Insets insets = windowInsets.getInsets(WindowInsets.Type.systemBars());
-        mInsets.set(insets.left, insets.top, insets.right, insets.bottom);
-        mContent.setPadding(mContent.getPaddingStart(), mContent.getPaddingTop(),
-                mContent.getPaddingEnd(), mInsets.bottom);
-
+        Insets insets;
+        if (Utilities.ATLEAST_R) {
+            insets = windowInsets.getInsets(Type.systemBars());
+            mInsets.set(insets.left, insets.top, insets.right, insets.bottom);
+            mContent.setPadding(mContent.getPaddingStart(), mContent.getPaddingTop(),
+                    mContent.getPaddingEnd(), mInsets.bottom);
+        } else {
+            mInsets.set(windowInsets.getSystemWindowInsetLeft(),
+                windowInsets.getSystemWindowInsetTop(),
+                windowInsets.getSystemWindowInsetRight(),
+                windowInsets.getSystemWindowInsetBottom());
+        }
         int contentHorizontalMarginInPx = getResources().getDimensionPixelSize(
-                R.dimen.widget_list_horizontal_margin);
+            R.dimen.widget_list_horizontal_margin);
         if (contentHorizontalMarginInPx != mContentHorizontalMarginInPx) {
             setContentHorizontalMargin(findViewById(R.id.widget_appName),
                     contentHorizontalMarginInPx);


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes #6047

### Reasoning

At some time ago, AOSP removes compatibility code for device older than Android 11

This restores that change.

~~Unlike the changes in 16-dev, this time I remember to import the dependencies~~

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
