### PR TITLE
fix: Shortcut get disabled reason crashes on Android 8.1

### DIFF
--- a/src/com/android/launcher3/model/data/WorkspaceItemInfo.java
+++ b/src/com/android/launcher3/model/data/WorkspaceItemInfo.java
@@ -193,14 +193,20 @@ public class WorkspaceItemInfo extends ItemInfoWithIcon {
         if (shortcutInfo.isEnabled()) {
             runtimeStatusFlags &= ~FLAG_DISABLED_BY_PUBLISHER;
         } else {
-            Log.w(TAG, "updateFromDeepShortcutInfo: Updated shortcut has been disabled. "
-                    + " package=" + shortcutInfo.getPackage()
-                    + " disabledReason=" + shortcutInfo.getDisabledReason());
+            if (Utilities.ATLEAST_P) {
+                Log.w(TAG, "updateFromDeepShortcutInfo: Updated shortcut has been disabled. "
+                        + " package=" + shortcutInfo.getPackage()
+                        + " disabledReason=" + shortcutInfo.getDisabledReason());
+            }
             runtimeStatusFlags |= FLAG_DISABLED_BY_PUBLISHER;
         }
 
-        if (shortcutInfo.getDisabledReason() == ShortcutInfo.DISABLED_REASON_VERSION_LOWER) {
-            runtimeStatusFlags |= FLAG_DISABLED_VERSION_LOWER;
+        if (Utilities.ATLEAST_P) {
+            if (shortcutInfo.getDisabledReason() == ShortcutInfo.DISABLED_REASON_VERSION_LOWER) {
+                runtimeStatusFlags |= FLAG_DISABLED_VERSION_LOWER;
+            } else {
+                runtimeStatusFlags &= ~FLAG_DISABLED_VERSION_LOWER;
+            }
         } else {
             runtimeStatusFlags &= ~FLAG_DISABLED_VERSION_LOWER;
         }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes #5734 

Fixes #5829

### Reasoning

Getting disabled reason just crashes on Android 8.1 as the comment pointed out that the API only exist in Android 9 and above


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
