### PR TITLE
feat: Update folder background to newer Launcher3 colour palette

### DIFF
--- a/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
@@ -102,7 +102,7 @@ object ColorTokens {
 
     @JvmField val DotColor = Accent3_200
 
-    @JvmField val FolderBackgroundColor = DayNightColorToken(Neutral1_50.setLStar(94.0), Neutral2_900.setLStar(12.0))
+    @JvmField val FolderBackgroundColor = DayNightColorToken(Neutral1_50.setLStar(94.0), Neutral2_50.setLStar(30.0))
 
     @JvmField val FolderIconBorderColor = ColorPrimary
 

--- a/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
+++ b/lawnchair/src/app/lawnchair/theme/color/tokens/ColorTokens.kt
@@ -102,14 +102,7 @@ object ColorTokens {
 
     @JvmField val DotColor = Accent3_200
 
-    @JvmField
-    val FolderBackgroundColor = DayNightColorToken(
-        SwatchColorToken(
-            Swatch.Accent2,
-            Shade.S200,
-        ),
-        SwatchColorToken(Swatch.Accent2, Shade.S700),
-    )
+    @JvmField val FolderBackgroundColor = DayNightColorToken(Neutral1_50.setLStar(94.0), Neutral2_900.setLStar(12.0))
 
     @JvmField val FolderIconBorderColor = ColorPrimary
 


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes #6107

Match the colour of folder background to newer Launcher3 colour palette. 

Backport of 16-dev | partial of e25b57d9f308bb175f1c224b6f23831fa5dda488

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Lawnchair 15 uses the color variable provided by Launcher3 which some old code had not been updated since Lawnchair 12.x

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Visual, to be completely honest I personally think I dislike the dark mode folder background because it's too dark (is it??), however light mode is fine.

![Screenshot_20251119-221943.png](https://github.com/user-attachments/assets/8fa40e8f-babc-453f-bd26-3786f9be76a5)

![Screenshot_20251119-221954.png](https://github.com/user-attachments/assets/9526f8a0-e14a-4440-a5f3-838824ca186d)




### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)