### PR TITLE
feat: Add option to clear home screen

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -164,6 +164,8 @@
     <string name="home_screen_label">Home screen</string>
     <string name="home_screen_description">Feed, grid, icons</string>
 
+    <string name="home_screen_actions">Home screen actions</string>
+
     <string name="dock_label">Dock</string>
     <string name="dock_description">Search bar, icon count</string>
 
@@ -259,6 +261,9 @@
 
     <string name="reset_custom_icons">Reset custom icons</string>
     <string name="reset_custom_icons_confirmation">All custom icons will be reset. Do you want to continue?</string>
+
+    <string name="remove_all_views_from_home_screen">Clear home screen</string>
+    <string name="remove_all_views_from_home_screen_desc">Home screen will be cleared. Do you want to continue?</string>
 
     <!-- Icon picker -->
     <string name="icon_picker_default_category">Icons</string>
@@ -887,4 +892,6 @@
     <string name="grant_requested_permissions">Grant permissions</string>
     <string name="permissions_needed">Permissions needed</string>
     <string name="grant_requested_permissions_tap">Tap to grant permissions</string>
+    <!-- Message shown when all home screen views are removed -->
+    <string name="home_screen_all_views_removed_msg">Home screen cleared</string>
 </resources>

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/HomeScreenPreferences.kt
@@ -45,6 +45,7 @@ import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.navigation.HomeScreenGrid
 import app.lawnchair.util.collectAsStateBlocking
+import com.android.launcher3.LauncherAppState
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
 import kotlinx.coroutines.launch
@@ -68,6 +69,7 @@ fun HomeScreenPreferences(
     ) {
         val lockHomeScreenAdapter = prefs2.lockHomeScreen.getAdapter()
         val showDeckLayout = prefs2.showDeckLayout.getAdapter().state.value
+        val context = LocalContext.current
 
         if (showDeckLayout) {
             HomeLayoutSettings()
@@ -88,6 +90,17 @@ fun HomeScreenPreferences(
             GestureHandlerPreference(
                 adapter = prefs2.doubleTapGestureHandler.getAdapter(),
                 label = stringResource(id = R.string.gesture_double_tap),
+            )
+        }
+        PreferenceGroup(heading = stringResource(id = R.string.home_screen_actions)) {
+            ClickablePreference(
+                label = stringResource(id = R.string.remove_all_views_from_home_screen),
+                confirmationText = stringResource(id = R.string.remove_all_views_from_home_screen_desc),
+                onClick = {
+                    scope.launch {
+                        LauncherAppState.getInstance(context).clearAllViewsFromHomeScreen()
+                    }
+                },
             )
         }
         PreferenceGroup(heading = stringResource(id = R.string.minus_one)) {

--- a/src/com/android/launcher3/LauncherAppState.java
+++ b/src/com/android/launcher3/LauncherAppState.java
@@ -39,6 +39,7 @@ import android.content.pm.LauncherApps;
 import android.content.pm.LauncherApps.ArchiveCompatibilityParams;
 import android.os.UserHandle;
 import android.util.Log;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.core.os.BuildCompat;
@@ -218,6 +219,19 @@ public class LauncherAppState implements SafeCloseable {
 
     public void reloadIcons() {
         refreshAndReloadLauncher();
+    }
+
+    public void clearAllViewsFromHomeScreen() {
+        final boolean isViewsRemoved =
+            mLauncher.getModelWriter().clearAllHomeScreenViewsByType(
+                LauncherSettings.Favorites.CONTAINER_DESKTOP);
+        if (isViewsRemoved) {
+            Toast.makeText(
+                mLauncher,
+                R.string.home_screen_all_views_removed_msg,
+                Toast.LENGTH_SHORT
+            ).show();
+        }
     }
 
     private void refreshAndReloadLauncher() {

--- a/src/com/android/launcher3/model/ModelWriter.java
+++ b/src/com/android/launcher3/model/ModelWriter.java
@@ -154,6 +154,35 @@ public class ModelWriter {
             throw e;
         }
     }
+    
+    /**
+     * Clears all views from the home screen.
+     */
+    public boolean clearAllHomeScreenViewsByType(int type) {
+        final ArrayList<ItemInfo> itemsToRemove = new ArrayList<>();
+
+        for (ItemInfo item : mBgDataModel.itemsIdMap) {
+            if (item.container == type) {
+                itemsToRemove.add(item);
+            }
+        }
+
+        if (itemsToRemove.isEmpty()) {
+            return false;
+        }
+
+        enqueueDeleteRunnable(newModelTask(() -> {
+            final ModelDbController db = mModel.getModelDbController();
+
+            for (ItemInfo item : itemsToRemove) {
+                db.delete(TABLE_NAME, itemIdMatch(item.id), null);
+                mBgDataModel.removeItem(mContext, item);
+            }
+        }));
+
+        mModel.forceReload();
+        return true;
+    }
 
     /**
      * Move an item in the DB to a new <container, screen, cellX, cellY>


### PR DESCRIPTION
### Description  
Added a new **“Remove All Home Screen Views”** option in **Home Settings**.  
This allows users to clear all apps and widgets from the home screen in one action, improving usability and reducing manual effort.

---

### Changes  
- Added **Remove All Home Screen Views** setting in **Home Settings**.  
- Implemented logic to clear all apps and widgets from the current home screen.  

---

### Test Plan  
1. Open **Home Settings** from launcher popup menu.  
2. Select **Home screen** option.
3. Select **“Remove all views from home screen”** option.  
4. Verify:
   - All apps and widgets are removed.
   - No crash or UI freeze occurs.
   - Option correctly handles empty home screen state.
   - Shows confirmation toast.

---

### Fixes  
Fixes **#6055**  
[FEATURE] Delete entire home screen instead of icon one by one  

---