### PR TITLE
fix: Smartspace can't launch activity due to background startup restrictions on A14^

### DIFF
--- a/lawnchair/src/app/lawnchair/smartspace/BcSmartSpaceUtil.kt
+++ b/lawnchair/src/app/lawnchair/smartspace/BcSmartSpaceUtil.kt
@@ -1,5 +1,6 @@
 package app.lawnchair.smartspace
 
+import android.app.ActivityOptions
 import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
@@ -10,6 +11,7 @@ import android.util.Log
 import android.view.View
 import app.lawnchair.smartspace.model.SmartspaceAction
 import com.android.launcher3.R
+import com.android.launcher3.Utilities
 
 object BcSmartSpaceUtil {
     fun getIconDrawable(icon: Icon?, context: Context): Drawable? {
@@ -27,6 +29,12 @@ object BcSmartSpaceUtil {
         onClickListener: View.OnClickListener? = null,
         str: String?,
     ) {
+        val options = ActivityOptions.makeBasic()
+        if (Utilities.ATLEAST_U) {
+            options.setPendingIntentBackgroundActivityStartMode(
+                ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED,
+            )
+        }
         if (view == null || action == null) {
             Log.e(str, "No tap action can be set up")
             return
@@ -36,7 +44,11 @@ object BcSmartSpaceUtil {
                 if (action.intent != null) {
                     view.context.startActivity(action.intent)
                 } else if (action.pendingIntent != null) {
-                    action.pendingIntent.send()
+                    if (Utilities.ATLEAST_U) {
+                        action.pendingIntent.send(options.toBundle())
+                    } else {
+                        action.pendingIntent.send()
+                    }
                 } else if (action.onClick != null) {
                     action.onClick.run()
                 }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix At-a-Glance media open broke on A14 and above due to https://goo.gle/android-bal with MODE_BACKGROUND_ACTIVITY_START_ALLOWED flag

Fixes #4427

Backport of 16-dev-qpr1 branch: 021236e0

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Requirement of A14

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

0. Set smartspace with media now playing enabled
1. Play music
2. Observe (open the app)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)