### PR TITLE
build: Rename 'market' flavour to 'play' in Baselineprofile module

### DIFF
--- a/baseline-profile/build.gradle
+++ b/baseline-profile/build.gradle
@@ -20,7 +20,7 @@ android {
         lawn { dimension = "app" }
         withQuickstep { dimension = "recents" }
         github { dimension = "channel" }
-        market { dimension = "channel" }
+        play { dimension = "channel" }
     }
 
     testOptions.managedDevices.devices {


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

Rename 'market' flavour to 'play' in Baselineprofile module

### Reasoning

The baselineprofile for a while has been using the old/already non-existent build variant of Google Play (Market)

### Testing

N/A

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Chore** (Changes to the build process or other tooling)
