### PR TITLE
fix(ui): resolve unnecessary launcherPopupOrder write

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/popup/LauncherOptionsPopup.kt
+++ b/lawnchair/src/app/lawnchair/ui/popup/LauncherOptionsPopup.kt
@@ -40,9 +40,11 @@ object LauncherOptionsPopup {
             defaultItem.identifier !in currentOptions.map { it.identifier }
         }
 
-        prefs2.launcherPopupOrder.setBlocking(
-            (currentOptions + missingItems).toOptionOrderString(),
-        )
+        if (missingItems.isNotEmpty()) {
+            prefs2.launcherPopupOrder.setBlocking(
+                (currentOptions + missingItems).toOptionOrderString(),
+            )
+        }
     }
 
     /**


### PR DESCRIPTION
### Description

When Launcher is created, reload grid is force called:
Everytime `LawnchairLauncher`  `onCreate` is triggered, `LauncherOptionsPopup.restoreMissingPopupOptions` is being called. inside it is unconditionally writing into `launcherPopupOrder`, that is triggering `reloadHelper.reloadGrid`.

This creates flicker, that first loads grids and suddenly reload it again.

### Reasoning

we don't need to writing into preferences if nothing has changed

### Testing

This should happen every time launcher is created


### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
