### PR TITLE
fix(model): resolve unnecessary model reload

### DIFF
--- a/src/com/android/launcher3/model/LoaderTask.java
+++ b/src/com/android/launcher3/model/LoaderTask.java
@@ -16,6 +16,7 @@
 
 package com.android.launcher3.model;
 
+import static android.os.Process.myUserHandle;
 import static com.android.launcher3.BuildConfigs.WIDGET_ON_FIRST_SCREEN;
 import static com.android.launcher3.Flags.enableLauncherBrMetricsFixed;
 import static com.android.launcher3.LauncherPrefs.IS_FIRST_LOAD_AFTER_RESTORE;
@@ -616,9 +617,12 @@ public class LoaderTask implements Runnable {
             // Query for the set of apps
             final List<LauncherActivityInfo> apps = mLauncherApps.getActivityList(null, user);
             // Fail if we don't have any apps
-            // TODO: Fix this. Only fail for the current user.
             if (apps == null || apps.isEmpty()) {
-                return allActivityList;
+                if (myUserHandle().equals(user)) {
+                    return allActivityList;
+                } else {
+                    continue;
+                }
             }
             // Query UserManager directly for current quiet mode state to avoid stale cached values
             boolean quietMode = mUserManager.isQuietModeEnabled(user);


### PR DESCRIPTION
### Description

Fix unnecessary model reload every time model validation happens

Fixes #6274

### Reasoning

Every time model reload happens, we are checking if `mAppsList.hasShortcutHostPermission()` and `hasShortcutsPermission(mContext)` are equal (inside `ModelDelegate.java`'s validateData).

problem is that on some devices (Happens on my Galaxy S phone), some users apps are inaccessible, thus 
forcing model reload.

problem is that is never set correctly because we never reach that part of the code

### Testing

Happens on devices that have locked user with inaccessible apps list. For example galaxy phones with Secure Folder

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
