### PR TITLE
fix app drawer search algorithm setting freeze

### DIFF
--- a/src/com/android/launcher3/util/BaseContext.kt
+++ b/src/com/android/launcher3/util/BaseContext.kt
@@ -86,8 +86,8 @@ constructor(base: Context, themeResId: Int, private val destroyOnDetach: Boolean
             object : OnAttachStateChangeListener {
 
                 override fun onViewAttachedToWindow(view: View) {
-                    view.rootView.setViewTreeLifecycleOwner(this@BaseContext)
-                    view.rootView.setViewTreeSavedStateRegistryOwner(this@BaseContext)
+                    view.setViewTreeLifecycleOwner(this@BaseContext)
+                    view.setViewTreeSavedStateRegistryOwner(this@BaseContext)
                     lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
 
                     val treeObserver = view.viewTreeObserver


### PR DESCRIPTION

I wasn't able to change the search provider for some strange reason (
Settings -> Search -> App Drawer  -> Search Algorithm), it froze up everything.

**Full disclosure**, I had opencode/opus 4.6 churn on this for probably a cumulative 3-4h with a real device before it came up with the text below which *did* fix the issue but is very hard for me to determine whether this is the correct fix. I don't think this fix is correct but it might be useful for reference. Here's what it wrote:

--- 
Context

When LauncherPreviewRenderer's output view is embedded inside a Compose AndroidView (e.g. in TwoTabPreferenceLayout's HorizontalPager), onViewCreated() was calling view.rootView.setViewTreeLifecycleOwner(), which overwrote the entire window's lifecycle owner. When the pager disposed the preview page, onViewDestroyed() moved the lifecycle to DESTROYED, killing the host Compose tree and causing a freeze/blank screen.

Fix by setting the lifecycle owner on the view itself rather than rootView, so the BaseContext lifecycle is scoped to just the preview view and doesn't interfere with the host window's lifecycle.

### Testing

Settings -> Search -> App Drawer  -> Search Algorithm

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
