### PR TITLE
fix: make app drawer search reliable by overriding SearchAdapterItem.isSameAs 

### DIFF
--- a/lawnchair/src/app/lawnchair/search/adapter/SearchAdapterItem.kt
+++ b/lawnchair/src/app/lawnchair/search/adapter/SearchAdapterItem.kt
@@ -16,6 +16,10 @@ data class SearchAdapterItem(
     val viewType: Int,
 ) : BaseAllAppsAdapter.AdapterItem(viewType) {
 
+    override fun isSameAs(other: BaseAllAppsAdapter.AdapterItem): Boolean {
+        return other is SearchAdapterItem && other.searchTarget.id == searchTarget.id
+    }
+
     fun setRippleEffect(child: View) {
         val shape = RoundRectShape(background?.cornerRadii, null, null)
         val shapeDrawable = ShapeDrawable(shape)


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

SearchAdapterItem did not override isSameAs(), causing DiffUtil to treat different search results as identical when they shared the same viewType. This resulted in the RecyclerView displaying stale results.




### Testing

I had a specific repro case with my list of apps. I reproed on a emulator, with placeholder apps generated from the real apps on my phone.

Screen recording before (notice "audible" does not show for "aud"):

https://github.com/user-attachments/assets/f7f5d762-4347-4d7b-99ec-6f9d65314603

Screen recording after:


https://github.com/user-attachments/assets/ca6174f6-b269-4df9-897c-0c28a6661193

- closes: #4182


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

 :white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
