### PR TITLE
fix: enable quick launch for local search algorithm

### DIFF
--- a/lawnchair/src/app/lawnchair/search/algorithms/LawnchairLocalSearchAlgorithm.kt
+++ b/lawnchair/src/app/lawnchair/search/algorithms/LawnchairLocalSearchAlgorithm.kt
@@ -80,6 +80,7 @@ class LawnchairLocalSearchAlgorithm(context: Context) : LawnchairSearchAlgorithm
                     val allResults = appResults + shortcutResults + (calcResult ?: emptyList()) + nonAppResults + generateActionResults(query)
 
                     val searchTargets = translateToSearchTargets(allResults)
+                    setFirstItemQuickLaunch(searchTargets)
                     val adapterItems = transformSearchResults(searchTargets)
                     withContext(Dispatchers.Main) {
                         callback.onSearchResult(query, ArrayList(adapterItems))


### PR DESCRIPTION
### Description

Enable pressing Enter to launch the first search result when using Local Search.

The `LocalSearchAlgorithm` was missing the `setFirstItemQuickLaunch()` call that marks the first result as launchable. The other search algorithms (`AppSearchAlgorithm` and `ASISearchAlgorithm`) already had this call.

Fixes #6249

### Testing

Tested on physical device - pressing Enter now launches the first search result.


https://github.com/user-attachments/assets/a1abcd73-aedf-44b5-86b8-881bcae5bf38



### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
