### PR TITLE
feat: Port shortcut support for triggering gestures

### DIFF
--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -72,6 +72,29 @@
         </activity>
 
         <activity
+            android:label="@string/lawnchair_actions"
+            android:icon="@mipmap/ic_launcher_home"
+            android:name="app.lawnchair.gestures.ui.LawnchairShortcutActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Lawnchair">
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_SHORTCUT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name="app.lawnchair.gestures.ui.RunHandlerActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Lawnchair">
+            <intent-filter>
+                <action android:name="app.lawnchair.START_ACTION" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+
+        <activity
             android:name="com.android.launcher3.secondarydisplay.SecondaryDisplayLauncher"
             tools:node="remove" />
 

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -962,4 +962,6 @@
     <string name="grant_requested_permissions_tap">Tap to grant permissions</string>
     <!-- Message shown when all home screen views are removed -->
     <string name="home_screen_all_views_removed_msg">Home screen cleared</string>
+    <string name="lawnchair_actions">Actions</string>
+    <string name="lawnchair_action_failed">Failed to trigger action</string>
 </resources>

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -251,8 +251,9 @@ class LawnchairLauncher : QuickstepLauncher() {
     override fun onNewIntent(intent: Intent?) {
         if (intent != null && intent.action == LawnchairShortcutActivity.START_ACTION) {
             val handlerString = intent.getStringExtra(LawnchairShortcutActivity.EXTRA_HANDLER)
-            handlerString?.let {
-                gestureController.handle(GestureHandlerConfig.fromString(it))
+            val config = handlerString?.let { GestureHandlerConfig.fromString(it) }
+            if (config != null && config.isExternallyInvokable()) {
+                gestureController.handle(config)
             }
         }
 

--- a/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
+++ b/lawnchair/src/app/lawnchair/LawnchairLauncher.kt
@@ -38,6 +38,7 @@ import app.lawnchair.data.wallpaper.service.WallpaperService
 import app.lawnchair.gestures.GestureController
 import app.lawnchair.gestures.VerticalSwipeTouchController
 import app.lawnchair.gestures.config.GestureHandlerConfig
+import app.lawnchair.gestures.ui.LawnchairShortcutActivity
 import app.lawnchair.nexuslauncher.OverlayCallbackImpl
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
@@ -245,6 +246,17 @@ class LawnchairLauncher : QuickstepLauncher() {
         reloadIconsIfNeeded()
 
         AppDatabase.INSTANCE.get(this).checkpointSync()
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        if (intent != null && intent.action == LawnchairShortcutActivity.START_ACTION) {
+            val handlerString = intent.getStringExtra(LawnchairShortcutActivity.EXTRA_HANDLER)
+            handlerString?.let {
+                gestureController.handle(GestureHandlerConfig.fromString(it))
+            }
+        }
+
+        super.onNewIntent(intent)
     }
 
     override fun collectStateHandlers(out: MutableList<StateHandler<LauncherState>>) {

--- a/lawnchair/src/app/lawnchair/gestures/GestureController.kt
+++ b/lawnchair/src/app/lawnchair/gestures/GestureController.kt
@@ -64,6 +64,13 @@ class GestureController(private val launcher: LawnchairLauncher) {
         triggerHandler(backPressHandler, false)
     }
 
+    fun handle(handler: GestureHandlerConfig) {
+        launcher.lifecycleScope.launch {
+            val handler = handler.createHandler(launcher)
+            handler.onTrigger(launcher)
+        }
+    }
+
     private fun triggerHandler(handlerFlow: Flow<GestureHandler>, withHaptic: Boolean = true) {
         launcher.lifecycleScope.launch {
             val handler = handlerFlow.first()

--- a/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerConfig.kt
+++ b/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerConfig.kt
@@ -2,8 +2,11 @@ package app.lawnchair.gestures.config
 
 import android.content.Context
 import android.content.pm.LauncherApps
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.graphics.drawable.Icon
 import androidx.annotation.DrawableRes
+import androidx.appcompat.content.res.AppCompatResources
 import app.lawnchair.gestures.handlers.GestureHandler
 import app.lawnchair.gestures.handlers.NoOpGestureHandler
 import app.lawnchair.gestures.handlers.OpenAppDrawerGestureHandler
@@ -16,6 +19,7 @@ import app.lawnchair.gestures.handlers.OpenQuickSettingsHandler
 import app.lawnchair.gestures.handlers.OpenSearchGestureHandler
 import app.lawnchair.gestures.handlers.RecentsGestureHandler
 import app.lawnchair.gestures.handlers.SleepGestureHandler
+import app.lawnchair.theme.color.tokens.ColorTokens
 import app.lawnchair.util.kotlinxJson
 import com.android.launcher3.AppFilter
 import com.android.launcher3.LauncherAppState
@@ -29,6 +33,8 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import androidx.core.graphics.createBitmap
+import com.android.launcher3.icons.LauncherIcons
 
 @Serializable
 sealed class GestureHandlerConfig {
@@ -40,6 +46,8 @@ sealed class GestureHandlerConfig {
     abstract fun getLabel(context: Context): String
     abstract fun createHandler(context: Context): GestureHandler
 
+    open fun getDisplayLabel(context: Context) = getLabel(context)
+
     @Serializable
     sealed class Simple(
         val labelRes: Int,
@@ -47,7 +55,18 @@ sealed class GestureHandlerConfig {
             throw IllegalArgumentException("default creator not supported")
         },
     ) : GestureHandlerConfig() {
-        override fun getIcon(context: Context) = Icon.createWithResource(context, iconRes)
+        override fun getIcon(context: Context): Icon {
+            val drawable = AppCompatResources.getDrawable(context, iconRes)!!
+            drawable.setTint(ColorTokens.ColorAccent.resolveColor(context))
+
+            val bitmap = createBitmap(drawable.intrinsicWidth, drawable.intrinsicHeight)
+            val canvas = Canvas(bitmap)
+            drawable.setBounds(0, 0, canvas.width, canvas.height)
+            drawable.draw(canvas)
+
+            return Icon.createWithBitmap(bitmap)
+        }
+
         override fun getLabel(context: Context) = context.getString(labelRes)
         override fun createHandler(context: Context) = creator(context)
     }
@@ -138,13 +157,13 @@ sealed class GestureHandlerConfig {
                             DEFAULT_LOOKUP_FLAG,
                         )
 
-                        LauncherAppState.getInstance(context).iconCache
-
                         Icon.createWithBitmap(appInfo.bitmap.icon)
                     }
                 }
             }
         }
+
+        override fun getDisplayLabel(context: Context) = appName
         override fun getLabel(context: Context) = context.getString(R.string.gesture_handler_open_app_config, appName)
         override fun createHandler(context: Context) = OpenAppGestureHandler(context, target)
     }

--- a/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerConfig.kt
+++ b/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerConfig.kt
@@ -1,6 +1,7 @@
 package app.lawnchair.gestures.config
 
 import android.content.Context
+import androidx.annotation.DrawableRes
 import app.lawnchair.gestures.handlers.GestureHandler
 import app.lawnchair.gestures.handlers.NoOpGestureHandler
 import app.lawnchair.gestures.handlers.OpenAppDrawerGestureHandler
@@ -13,6 +14,7 @@ import app.lawnchair.gestures.handlers.OpenQuickSettingsHandler
 import app.lawnchair.gestures.handlers.OpenSearchGestureHandler
 import app.lawnchair.gestures.handlers.RecentsGestureHandler
 import app.lawnchair.gestures.handlers.SleepGestureHandler
+import app.lawnchair.util.kotlinxJson
 import com.android.launcher3.R
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -20,6 +22,9 @@ import kotlinx.serialization.Transient
 
 @Serializable
 sealed class GestureHandlerConfig {
+
+    @get:DrawableRes
+    open val iconRes: Int = R.drawable.ic_launcher_home
 
     abstract fun getLabel(context: Context): String
     abstract fun createHandler(context: Context): GestureHandler
@@ -58,7 +63,11 @@ sealed class GestureHandlerConfig {
 
     @Serializable
     @SerialName("openAppDrawer")
-    data object OpenAppDrawer : Simple(R.string.gesture_handler_open_app_drawer, ::OpenAppDrawerGestureHandler)
+    data object OpenAppDrawer :
+        Simple(R.string.gesture_handler_open_app_drawer, ::OpenAppDrawerGestureHandler) {
+        // todo: change this
+        override val iconRes = R.drawable.ic_apps
+    }
 
     @Serializable
     @SerialName("openAppSearch")
@@ -77,5 +86,19 @@ sealed class GestureHandlerConfig {
     data class OpenApp(val appName: String, val target: OpenAppTarget) : GestureHandlerConfig() {
         override fun getLabel(context: Context) = context.getString(R.string.gesture_handler_open_app_config, appName)
         override fun createHandler(context: Context) = OpenAppGestureHandler(context, target)
+    }
+
+    companion object {
+        fun toString(config: GestureHandlerConfig): String {
+            return kotlinxJson.encodeToString(config)
+        }
+
+        fun fromString(string: String): GestureHandlerConfig {
+            return try {
+                kotlinxJson.decodeFromString<GestureHandlerConfig>(string)
+            } catch (_: Exception) {
+                NoOp
+            }
+        }
     }
 }

--- a/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerConfig.kt
+++ b/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerConfig.kt
@@ -50,36 +50,51 @@ sealed class GestureHandlerConfig {
 
     @Serializable
     @SerialName("recents")
-    data object Recents : Simple(R.string.gesture_handler_recents, ::RecentsGestureHandler)
+    data object Recents : Simple(R.string.gesture_handler_recents, ::RecentsGestureHandler) {
+        override val iconRes = R.drawable.ic_quickstep
+    }
 
     @Serializable
     @SerialName("openNotificationdata")
-    data object OpenNotifications : Simple(R.string.gesture_handler_open_notifications, ::OpenNotificationsHandler)
+    data object OpenNotifications :
+        Simple(R.string.gesture_handler_open_notifications, ::OpenNotificationsHandler) {
+        override val iconRes = R.drawable.ic_sysbar_notifications
+    }
 
     @Serializable
     @SerialName("openQuickSettings")
     data object OpenQuickSettings :
-        Simple(R.string.gesture_handler_open_quick_settings, ::OpenQuickSettingsHandler)
+        Simple(R.string.gesture_handler_open_quick_settings, ::OpenQuickSettingsHandler) {
+        override val iconRes = R.drawable.ic_setting
+    }
 
     @Serializable
     @SerialName("openAppDrawer")
     data object OpenAppDrawer :
         Simple(R.string.gesture_handler_open_app_drawer, ::OpenAppDrawerGestureHandler) {
-        // todo: change this
         override val iconRes = R.drawable.ic_apps
     }
 
     @Serializable
     @SerialName("openAppSearch")
-    data object OpenAppSearch : Simple(R.string.gesture_handler_open_app_search, ::OpenAppSearchGestureHandler)
+    data object OpenAppSearch :
+        Simple(R.string.gesture_handler_open_app_search, ::OpenAppSearchGestureHandler) {
+        override val iconRes = R.drawable.ic_search
+    }
 
     @Serializable
     @SerialName("openSearch")
-    data object OpenSearch : Simple(R.string.gesture_handler_open_search, ::OpenSearchGestureHandler)
+    data object OpenSearch :
+        Simple(R.string.gesture_handler_open_search, ::OpenSearchGestureHandler) {
+        override val iconRes = R.drawable.ic_search
+    }
 
     @Serializable
     @SerialName("openAssistant")
-    data object OpenAssistant : Simple(R.string.gesture_handler_open_assistant, ::OpenAssistantHandler)
+    data object OpenAssistant :
+        Simple(R.string.gesture_handler_open_assistant, ::OpenAssistantHandler) {
+        override val iconRes = R.drawable.ic_mic_flat
+    }
 
     @Serializable
     @SerialName("openApp")

--- a/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerConfig.kt
+++ b/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerConfig.kt
@@ -2,11 +2,11 @@ package app.lawnchair.gestures.config
 
 import android.content.Context
 import android.content.pm.LauncherApps
-import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.Icon
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.createBitmap
 import app.lawnchair.gestures.handlers.GestureHandler
 import app.lawnchair.gestures.handlers.NoOpGestureHandler
 import app.lawnchair.gestures.handlers.OpenAppDrawerGestureHandler
@@ -26,15 +26,12 @@ import com.android.launcher3.LauncherAppState
 import com.android.launcher3.R
 import com.android.launcher3.icons.cache.CacheLookupFlag.Companion.DEFAULT_LOOKUP_FLAG
 import com.android.launcher3.model.data.AppInfo
-import com.android.launcher3.pm.UserCache
 import com.android.launcher3.util.Executors.MODEL_EXECUTOR
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import androidx.core.graphics.createBitmap
-import com.android.launcher3.icons.LauncherIcons
 
 @Serializable
 sealed class GestureHandlerConfig {
@@ -47,6 +44,7 @@ sealed class GestureHandlerConfig {
     abstract fun createHandler(context: Context): GestureHandler
 
     open fun getDisplayLabel(context: Context) = getLabel(context)
+    open fun isExternallyInvokable(): Boolean = false
 
     @Serializable
     sealed class Simple(
@@ -104,6 +102,8 @@ sealed class GestureHandlerConfig {
     data object OpenAppDrawer :
         Simple(R.string.gesture_handler_open_app_drawer, ::OpenAppDrawerGestureHandler) {
         override val iconRes = R.drawable.ic_apps
+
+        override fun isExternallyInvokable() = true
     }
 
     @Serializable
@@ -111,6 +111,8 @@ sealed class GestureHandlerConfig {
     data object OpenAppSearch :
         Simple(R.string.gesture_handler_open_app_search, ::OpenAppSearchGestureHandler) {
         override val iconRes = R.drawable.ic_search
+
+        override fun isExternallyInvokable() = true
     }
 
     @Serializable
@@ -138,19 +140,30 @@ sealed class GestureHandlerConfig {
                 }
 
                 is OpenAppTarget.App -> {
-                    val filter = AppFilter(context)
+                    val fallback = Icon.createWithResource(context, iconRes)
 
-                    val packageName = target.key.componentName.packageName
+                    val filter = AppFilter(context)
+                    val componentName = target.key.componentName
+                    val user = target.key.user
+
+                    if (!filter.shouldShowApp(componentName)) {
+                        // Fallback to default icon
+                        return fallback
+                    }
+
                     val launcherApps = context.getSystemService(LauncherApps::class.java)
 
                     return runBlocking(MODEL_EXECUTOR.asCoroutineDispatcher()) {
-                        val appInfo = UserCache.INSTANCE.get(context).userProfiles.asSequence()
-                            .flatMap { launcherApps.getActivityList(packageName, it) }
-                            .filter { filter.shouldShowApp(it.componentName) }
-                            .map {
-                                AppInfo(context, it, it.user)
-                            }
-                            .first()
+                        val activityInfo = launcherApps.resolveActivity(
+                            AppInfo.makeLaunchIntent(componentName),
+                            target.key.user,
+                        ) ?: return@runBlocking fallback
+
+                        val appInfo = AppInfo(
+                            context,
+                            activityInfo,
+                            user,
+                        )
 
                         LauncherAppState.getInstance(context).iconCache.getTitleAndIcon(
                             appInfo,
@@ -162,6 +175,8 @@ sealed class GestureHandlerConfig {
                 }
             }
         }
+
+        override fun isExternallyInvokable() = target is OpenAppTarget.App
 
         override fun getDisplayLabel(context: Context) = appName
         override fun getLabel(context: Context) = context.getString(R.string.gesture_handler_open_app_config, appName)

--- a/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerConfig.kt
+++ b/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerConfig.kt
@@ -1,6 +1,8 @@
 package app.lawnchair.gestures.config
 
 import android.content.Context
+import android.content.pm.LauncherApps
+import android.graphics.drawable.Icon
 import androidx.annotation.DrawableRes
 import app.lawnchair.gestures.handlers.GestureHandler
 import app.lawnchair.gestures.handlers.NoOpGestureHandler
@@ -15,7 +17,15 @@ import app.lawnchair.gestures.handlers.OpenSearchGestureHandler
 import app.lawnchair.gestures.handlers.RecentsGestureHandler
 import app.lawnchair.gestures.handlers.SleepGestureHandler
 import app.lawnchair.util.kotlinxJson
+import com.android.launcher3.AppFilter
+import com.android.launcher3.LauncherAppState
 import com.android.launcher3.R
+import com.android.launcher3.icons.cache.CacheLookupFlag.Companion.DEFAULT_LOOKUP_FLAG
+import com.android.launcher3.model.data.AppInfo
+import com.android.launcher3.pm.UserCache
+import com.android.launcher3.util.Executors.MODEL_EXECUTOR
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -26,6 +36,7 @@ sealed class GestureHandlerConfig {
     @get:DrawableRes
     open val iconRes: Int = R.drawable.ic_launcher_home
 
+    abstract fun getIcon(context: Context): Icon
     abstract fun getLabel(context: Context): String
     abstract fun createHandler(context: Context): GestureHandler
 
@@ -36,6 +47,7 @@ sealed class GestureHandlerConfig {
             throw IllegalArgumentException("default creator not supported")
         },
     ) : GestureHandlerConfig() {
+        override fun getIcon(context: Context) = Icon.createWithResource(context, iconRes)
         override fun getLabel(context: Context) = context.getString(labelRes)
         override fun createHandler(context: Context) = creator(context)
     }
@@ -99,6 +111,40 @@ sealed class GestureHandlerConfig {
     @Serializable
     @SerialName("openApp")
     data class OpenApp(val appName: String, val target: OpenAppTarget) : GestureHandlerConfig() {
+        override fun getIcon(context: Context): Icon {
+            when (target) {
+                is OpenAppTarget.Shortcut -> {
+                    // fallback
+                    return Icon.createWithResource(context, iconRes)
+                }
+
+                is OpenAppTarget.App -> {
+                    val filter = AppFilter(context)
+
+                    val packageName = target.key.componentName.packageName
+                    val launcherApps = context.getSystemService(LauncherApps::class.java)
+
+                    return runBlocking(MODEL_EXECUTOR.asCoroutineDispatcher()) {
+                        val appInfo = UserCache.INSTANCE.get(context).userProfiles.asSequence()
+                            .flatMap { launcherApps.getActivityList(packageName, it) }
+                            .filter { filter.shouldShowApp(it.componentName) }
+                            .map {
+                                AppInfo(context, it, it.user)
+                            }
+                            .first()
+
+                        LauncherAppState.getInstance(context).iconCache.getTitleAndIcon(
+                            appInfo,
+                            DEFAULT_LOOKUP_FLAG,
+                        )
+
+                        LauncherAppState.getInstance(context).iconCache
+
+                        Icon.createWithBitmap(appInfo.bitmap.icon)
+                    }
+                }
+            }
+        }
         override fun getLabel(context: Context) = context.getString(R.string.gesture_handler_open_app_config, appName)
         override fun createHandler(context: Context) = OpenAppGestureHandler(context, target)
     }

--- a/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerOption.kt
+++ b/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerOption.kt
@@ -17,8 +17,7 @@ sealed class GestureHandlerOption(
 
     abstract suspend fun buildConfig(activity: Activity): GestureHandlerConfig?
 
-    sealed class Simple(labelRes: Int, iconRes: Int, val obj: GestureHandlerConfig) :
-        GestureHandlerOption(labelRes, iconRes, obj::class.java) {
+    sealed class Simple(labelRes: Int, iconRes: Int, val obj: GestureHandlerConfig) : GestureHandlerOption(labelRes, iconRes, obj::class.java) {
         constructor(obj: GestureHandlerConfig.Simple) : this(obj.labelRes, obj.iconRes, obj)
         override suspend fun buildConfig(activity: Activity) = obj
     }

--- a/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerOption.kt
+++ b/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerOption.kt
@@ -10,16 +10,16 @@ import com.android.launcher3.R
 
 sealed class GestureHandlerOption(
     private val labelRes: Int,
+    val iconRes: Int,
     val configClass: Class<*>,
 ) {
-
     fun getLabel(context: Context) = context.getString(labelRes)
 
     abstract suspend fun buildConfig(activity: Activity): GestureHandlerConfig?
 
-    sealed class Simple(labelRes: Int, val obj: GestureHandlerConfig) : GestureHandlerOption(labelRes, obj::class.java) {
-        constructor(obj: GestureHandlerConfig.Simple) : this(obj.labelRes, obj)
-
+    sealed class Simple(labelRes: Int, iconRes: Int, val obj: GestureHandlerConfig) :
+        GestureHandlerOption(labelRes, iconRes, obj::class.java) {
+        constructor(obj: GestureHandlerConfig.Simple) : this(obj.labelRes, obj.iconRes, obj)
         override suspend fun buildConfig(activity: Activity) = obj
     }
 
@@ -35,6 +35,7 @@ sealed class GestureHandlerOption(
 
     data object OpenApp : GestureHandlerOption(
         R.string.gesture_handler_open_app_option,
+        R.drawable.ic_launcher_home,
         GestureHandlerConfig.OpenApp::class.java,
     ) {
         override suspend fun buildConfig(activity: Activity): GestureHandlerConfig? {

--- a/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerOptions.kt
+++ b/lawnchair/src/app/lawnchair/gestures/config/GestureHandlerOptions.kt
@@ -1,0 +1,32 @@
+package app.lawnchair.gestures.config
+
+import android.app.Activity
+import android.content.Context
+
+val gestureHandlerOptions = listOf(
+    GestureHandlerOption.NoOp,
+    GestureHandlerOption.Sleep,
+    GestureHandlerOption.Recents,
+    GestureHandlerOption.OpenNotifications,
+    GestureHandlerOption.OpenQuickSettings,
+    GestureHandlerOption.OpenAppDrawer,
+    GestureHandlerOption.OpenAppSearch,
+    GestureHandlerOption.OpenSearch,
+    GestureHandlerOption.OpenApp,
+    GestureHandlerOption.OpenAssistant,
+)
+
+private val optionsDisabledInDeckLayout = setOf(
+    GestureHandlerOption.OpenAppDrawer,
+    GestureHandlerOption.OpenAppSearch,
+)
+
+fun filterGestureHandlerOptions(deckLayoutEnabled: Boolean): List<GestureHandlerOption> {
+    if (!deckLayoutEnabled) return gestureHandlerOptions
+    return gestureHandlerOptions.filterNot { it in optionsDisabledInDeckLayout }
+}
+
+suspend fun GestureHandlerOption.buildConfigFrom(context: Context): GestureHandlerConfig? {
+    val activity = context as? Activity ?: return null
+    return buildConfig(activity)
+}

--- a/lawnchair/src/app/lawnchair/gestures/ui/CreateActionsScreen.kt
+++ b/lawnchair/src/app/lawnchair/gestures/ui/CreateActionsScreen.kt
@@ -1,0 +1,56 @@
+package app.lawnchair.gestures.ui
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import app.lawnchair.gestures.config.GestureHandlerConfig
+import app.lawnchair.gestures.config.GestureHandlerOption
+import app.lawnchair.preferences2.preferenceManager2
+import app.lawnchair.ui.preferences.components.controls.ClickablePreference
+import app.lawnchair.ui.preferences.components.gestureHandlerOptions
+import app.lawnchair.ui.preferences.components.layout.PreferenceLayoutLazyColumn
+import app.lawnchair.ui.preferences.components.layout.preferenceGroupItems
+import com.android.launcher3.R
+import com.patrykmichalik.opto.core.firstBlocking
+import kotlin.collections.contains
+import kotlinx.coroutines.launch
+
+@Composable
+fun CreateActionsScreen(
+    modifier: Modifier = Modifier,
+    onSelect: (GestureHandlerConfig) -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val prefs2 = preferenceManager2()
+    val newOptions = gestureHandlerOptions.filterNot { option ->
+        option in listOf(
+            GestureHandlerOption.OpenAppDrawer,
+            GestureHandlerOption.OpenAppSearch,
+        ) &&
+            prefs2.deckLayout.firstBlocking()
+    }
+
+    fun onClick(option: GestureHandlerOption) {
+        scope.launch {
+            val config = option.buildConfig(context as Activity) ?: return@launch
+            onSelect(config)
+        }
+    }
+
+    PreferenceLayoutLazyColumn(
+        label = stringResource(id = R.string.lawnchair_actions),
+        modifier = modifier,
+    ) {
+        preferenceGroupItems(items = newOptions, isFirstChild = true) { index, it ->
+            ClickablePreference(
+                label = it.getLabel(context),
+                onClick = { onClick(it) },
+            )
+        }
+    }
+}

--- a/lawnchair/src/app/lawnchair/gestures/ui/CreateActionsScreen.kt
+++ b/lawnchair/src/app/lawnchair/gestures/ui/CreateActionsScreen.kt
@@ -10,6 +10,7 @@ import app.lawnchair.gestures.config.GestureHandlerConfig
 import app.lawnchair.gestures.config.GestureHandlerOption
 import app.lawnchair.gestures.config.buildConfigFrom
 import app.lawnchair.gestures.config.filterGestureHandlerOptions
+import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.preferences.components.controls.ClickablePreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayoutLazyColumn
@@ -28,13 +29,11 @@ fun CreateActionsScreen(
 
     val prefs2 = preferenceManager2()
     val newOptions =
-        filterGestureHandlerOptions(deckLayoutEnabled = prefs2.deckLayout.firstBlocking())
+        filterGestureHandlerOptions(deckLayoutEnabled = prefs2.deckLayout.getAdapter().state.value)
 
     fun onClick(option: GestureHandlerOption) {
         scope.launch {
             val config = option.buildConfigFrom(context) ?: return@launch
-
-            Log.d("CreateActionsScreen", "config: $config")
             onSelect(config)
         }
     }

--- a/lawnchair/src/app/lawnchair/gestures/ui/CreateActionsScreen.kt
+++ b/lawnchair/src/app/lawnchair/gestures/ui/CreateActionsScreen.kt
@@ -1,6 +1,6 @@
 package app.lawnchair.gestures.ui
 
-import android.app.Activity
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -8,14 +8,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import app.lawnchair.gestures.config.GestureHandlerConfig
 import app.lawnchair.gestures.config.GestureHandlerOption
+import app.lawnchair.gestures.config.buildConfigFrom
+import app.lawnchair.gestures.config.filterGestureHandlerOptions
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.preferences.components.controls.ClickablePreference
-import app.lawnchair.ui.preferences.components.gestureHandlerOptions
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayoutLazyColumn
 import app.lawnchair.ui.preferences.components.layout.preferenceGroupItems
 import com.android.launcher3.R
 import com.patrykmichalik.opto.core.firstBlocking
-import kotlin.collections.contains
 import kotlinx.coroutines.launch
 
 @Composable
@@ -27,17 +27,14 @@ fun CreateActionsScreen(
     val scope = rememberCoroutineScope()
 
     val prefs2 = preferenceManager2()
-    val newOptions = gestureHandlerOptions.filterNot { option ->
-        option in listOf(
-            GestureHandlerOption.OpenAppDrawer,
-            GestureHandlerOption.OpenAppSearch,
-        ) &&
-            prefs2.deckLayout.firstBlocking()
-    }
+    val newOptions =
+        filterGestureHandlerOptions(deckLayoutEnabled = prefs2.deckLayout.firstBlocking())
 
     fun onClick(option: GestureHandlerOption) {
         scope.launch {
-            val config = option.buildConfig(context as Activity) ?: return@launch
+            val config = option.buildConfigFrom(context) ?: return@launch
+
+            Log.d("CreateActionsScreen", "config: $config")
             onSelect(config)
         }
     }
@@ -46,7 +43,7 @@ fun CreateActionsScreen(
         label = stringResource(id = R.string.lawnchair_actions),
         modifier = modifier,
     ) {
-        preferenceGroupItems(items = newOptions, isFirstChild = true) { index, it ->
+        preferenceGroupItems(items = newOptions, isFirstChild = true) { _, it ->
             ClickablePreference(
                 label = it.getLabel(context),
                 onClick = { onClick(it) },

--- a/lawnchair/src/app/lawnchair/gestures/ui/LawnchairShortcutActivity.kt
+++ b/lawnchair/src/app/lawnchair/gestures/ui/LawnchairShortcutActivity.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026, Lawnchair
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.lawnchair.gestures.ui
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ShortcutInfo
+import android.content.pm.ShortcutManager
+import android.graphics.drawable.Icon
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import app.lawnchair.gestures.config.GestureHandlerConfig
+import app.lawnchair.ui.theme.EdgeToEdge
+import app.lawnchair.ui.theme.LawnchairTheme
+import app.lawnchair.ui.util.addIf
+import app.lawnchair.util.ProvideLifecycleState
+import com.android.launcher3.LauncherAppState.Companion.getInstance
+import com.android.launcher3.icons.CacheableShortcutCachingLogic.loadIcon
+import com.android.launcher3.icons.CacheableShortcutInfo
+import com.android.launcher3.model.data.WorkspaceItemInfo
+
+class LawnchairShortcutActivity : ComponentActivity() {
+    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        setContent {
+            LawnchairTheme {
+                EdgeToEdge()
+                val windowSizeClass = calculateWindowSizeClass(this)
+
+                val isExpandedScreen =
+                    windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded &&
+                        windowSizeClass.heightSizeClass in
+                        setOf(WindowHeightSizeClass.Expanded, WindowHeightSizeClass.Medium)
+
+                ProvideLifecycleState {
+                    Surface(
+                        color = MaterialTheme.colorScheme.surface,
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                    ) {
+                        Box(
+                            modifier = Modifier.addIf(isExpandedScreen) { requiredWidth(640.dp) },
+                        ) {
+                            val context = LocalContext.current
+                            CreateActionsScreen(
+                                onSelect = {
+                                    saveChanges(context, it)
+                                    finish()
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun saveChanges(context: Context, selectedHandler: GestureHandlerConfig) {
+        val shortcutManager =
+            ContextCompat.getSystemService(applicationContext, ShortcutManager::class.java)
+                ?: return
+
+        val icon = Icon.createWithResource(context, selectedHandler.iconRes)
+
+        val shortcutInfo = ShortcutInfo.Builder(context, selectedHandler::class.java.name)
+            .apply {
+                setShortLabel(selectedHandler.getLabel(context))
+                setIcon(icon)
+                setIntent(
+                    Intent(context, RunHandlerActivity::class.java).apply {
+                        action = START_ACTION
+                        putExtra(EXTRA_HANDLER, GestureHandlerConfig.toString(selectedHandler))
+                    },
+                )
+            }.build()
+
+        val intent = shortcutManager.createShortcutResultIntent(shortcutInfo)
+        setResult(RESULT_OK, intent)
+    }
+
+    companion object {
+        const val START_ACTION = "app.lawnchair.START_ACTION"
+        const val EXTRA_HANDLER = "app.lawnchair.EXTRA_HANDLER"
+    }
+}

--- a/lawnchair/src/app/lawnchair/gestures/ui/LawnchairShortcutActivity.kt
+++ b/lawnchair/src/app/lawnchair/gestures/ui/LawnchairShortcutActivity.kt
@@ -16,12 +16,10 @@
 
 package app.lawnchair.gestures.ui
 
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ShortcutInfo
 import android.content.pm.ShortcutManager
-import android.graphics.drawable.Icon
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -44,10 +42,6 @@ import app.lawnchair.ui.theme.EdgeToEdge
 import app.lawnchair.ui.theme.LawnchairTheme
 import app.lawnchair.ui.util.addIf
 import app.lawnchair.util.ProvideLifecycleState
-import com.android.launcher3.LauncherAppState.Companion.getInstance
-import com.android.launcher3.icons.CacheableShortcutCachingLogic.loadIcon
-import com.android.launcher3.icons.CacheableShortcutInfo
-import com.android.launcher3.model.data.WorkspaceItemInfo
 
 class LawnchairShortcutActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
@@ -94,12 +88,10 @@ class LawnchairShortcutActivity : ComponentActivity() {
             ContextCompat.getSystemService(applicationContext, ShortcutManager::class.java)
                 ?: return
 
-        val icon = Icon.createWithResource(context, selectedHandler.iconRes)
-
-        val shortcutInfo = ShortcutInfo.Builder(context, selectedHandler::class.java.name)
+        val shortcutInfo = ShortcutInfo.Builder(context, selectedHandler.toString())
             .apply {
                 setShortLabel(selectedHandler.getLabel(context))
-                setIcon(icon)
+                setIcon(selectedHandler.getIcon(context))
                 setIntent(
                     Intent(context, RunHandlerActivity::class.java).apply {
                         action = START_ACTION

--- a/lawnchair/src/app/lawnchair/gestures/ui/LawnchairShortcutActivity.kt
+++ b/lawnchair/src/app/lawnchair/gestures/ui/LawnchairShortcutActivity.kt
@@ -92,7 +92,7 @@ class LawnchairShortcutActivity : ComponentActivity() {
 
         val shortcutInfo = ShortcutInfo.Builder(
             context,
-            "$GESTURE_SHORTCUT_ID_PREFIX:${selectedHandler}",
+            "$GESTURE_SHORTCUT_ID_PREFIX:$selectedHandler",
         )
             .apply {
                 setShortLabel(selectedHandler.getDisplayLabel(context))
@@ -115,10 +115,9 @@ class LawnchairShortcutActivity : ComponentActivity() {
         const val GESTURE_SHORTCUT_ID_PREFIX = "gesture:"
 
         fun shouldSkipShortcutBadge(context: Context, si: ShortcutInfo): Boolean {
-            val value = context.packageName == si.`package`
-                && si.id.startsWith(GESTURE_SHORTCUT_ID_PREFIX)
+            val value = context.packageName == si.`package` &&
+                si.id.startsWith(GESTURE_SHORTCUT_ID_PREFIX)
 
-            Log.d("LawnchairShortcutActivity", "shouldSkipShortcutBadge: $value")
             return value
         }
     }

--- a/lawnchair/src/app/lawnchair/gestures/ui/LawnchairShortcutActivity.kt
+++ b/lawnchair/src/app/lawnchair/gestures/ui/LawnchairShortcutActivity.kt
@@ -21,6 +21,8 @@ import android.content.Intent
 import android.content.pm.ShortcutInfo
 import android.content.pm.ShortcutManager
 import android.os.Bundle
+import android.os.PersistableBundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -88,7 +90,10 @@ class LawnchairShortcutActivity : ComponentActivity() {
             ContextCompat.getSystemService(applicationContext, ShortcutManager::class.java)
                 ?: return
 
-        val shortcutInfo = ShortcutInfo.Builder(context, selectedHandler.toString())
+        val shortcutInfo = ShortcutInfo.Builder(
+            context,
+            "$GESTURE_SHORTCUT_ID_PREFIX:${selectedHandler}",
+        )
             .apply {
                 setShortLabel(selectedHandler.getLabel(context))
                 setIcon(selectedHandler.getIcon(context))
@@ -107,5 +112,14 @@ class LawnchairShortcutActivity : ComponentActivity() {
     companion object {
         const val START_ACTION = "app.lawnchair.START_ACTION"
         const val EXTRA_HANDLER = "app.lawnchair.EXTRA_HANDLER"
+        const val GESTURE_SHORTCUT_ID_PREFIX = "gesture:"
+
+        fun shouldSkipShortcutBadge(context: Context, si: ShortcutInfo): Boolean {
+            val value = context.packageName == si.`package`
+                && si.id.startsWith(GESTURE_SHORTCUT_ID_PREFIX)
+
+            Log.d("LawnchairShortcutActivity", "shouldSkipShortcutBadge: $value")
+            return value
+        }
     }
 }

--- a/lawnchair/src/app/lawnchair/gestures/ui/LawnchairShortcutActivity.kt
+++ b/lawnchair/src/app/lawnchair/gestures/ui/LawnchairShortcutActivity.kt
@@ -95,7 +95,7 @@ class LawnchairShortcutActivity : ComponentActivity() {
             "$GESTURE_SHORTCUT_ID_PREFIX:${selectedHandler}",
         )
             .apply {
-                setShortLabel(selectedHandler.getLabel(context))
+                setShortLabel(selectedHandler.getDisplayLabel(context))
                 setIcon(selectedHandler.getIcon(context))
                 setIntent(
                     Intent(context, RunHandlerActivity::class.java).apply {

--- a/lawnchair/src/app/lawnchair/gestures/ui/RunHandlerActivity.kt
+++ b/lawnchair/src/app/lawnchair/gestures/ui/RunHandlerActivity.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026, Lawnchair
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.lawnchair.gestures.ui
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import app.lawnchair.LawnchairLauncher
+
+class RunHandlerActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (intent.action == LawnchairShortcutActivity.START_ACTION) {
+            startActivity(
+                Intent(this, LawnchairLauncher::class.java).apply {
+                    action = LawnchairShortcutActivity.START_ACTION
+                    putExtra(
+                        LawnchairShortcutActivity.EXTRA_HANDLER,
+                        intent.getStringExtra(LawnchairShortcutActivity.EXTRA_HANDLER),
+                    )
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                },
+            )
+        }
+        finish()
+    }
+}

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
@@ -39,7 +39,7 @@ import com.android.launcher3.util.ComponentKey
 import com.patrykmichalik.opto.core.firstBlocking
 import kotlinx.coroutines.launch
 
-val options = listOf(
+val gestureHandlerOptions = listOf(
     GestureHandlerOption.NoOp,
     GestureHandlerOption.Sleep,
     GestureHandlerOption.Recents,
@@ -73,7 +73,7 @@ fun GestureHandlerPreference(
         }
     }
 
-    val newOptions = options.filterNot { option ->
+    val newOptions = gestureHandlerOptions.filterNot { option ->
         option in listOf(
             GestureHandlerOption.OpenAppDrawer,
             GestureHandlerOption.OpenAppSearch,
@@ -167,7 +167,7 @@ fun AppGesturePreference(
                 LazyColumn(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    itemsIndexed(options) { index, option ->
+                    itemsIndexed(gestureHandlerOptions) { index, option ->
                         if (index > 0) {
                             PreferenceDivider(startIndent = 40.dp)
                         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
@@ -134,6 +134,8 @@ fun AppGesturePreference(
         }
     }
 
+    val options = filterGestureHandlerOptions(deckLayoutEnabled = prefs.deckLayout.getAdapter().state.value)
+
     Column(modifier = modifier.fillMaxWidth()) {
         PreferenceTemplate(
             title = { Text(text = label) },
@@ -152,7 +154,7 @@ fun AppGesturePreference(
                 LazyColumn(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    itemsIndexed(gestureHandlerOptions) { index, option ->
+                    itemsIndexed(options) { index, option ->
                         if (index > 0) {
                             PreferenceDivider(startIndent = 40.dp)
                         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
@@ -1,7 +1,6 @@
 package app.lawnchair.ui.preferences.components
 
 import android.R as AndroidR
-import android.app.Activity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -28,6 +27,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.lawnchair.gestures.config.GestureHandlerConfig
 import app.lawnchair.gestures.config.GestureHandlerOption
+import app.lawnchair.gestures.config.buildConfigFrom
+import app.lawnchair.gestures.config.filterGestureHandlerOptions
+import app.lawnchair.gestures.config.gestureHandlerOptions
 import app.lawnchair.gestures.type.GestureType
 import app.lawnchair.preferences.PreferenceAdapter
 import app.lawnchair.preferences2.preferenceManager2
@@ -38,19 +40,6 @@ import app.lawnchair.ui.util.LocalBottomSheetHandler
 import com.android.launcher3.util.ComponentKey
 import com.patrykmichalik.opto.core.firstBlocking
 import kotlinx.coroutines.launch
-
-val gestureHandlerOptions = listOf(
-    GestureHandlerOption.NoOp,
-    GestureHandlerOption.Sleep,
-    GestureHandlerOption.Recents,
-    GestureHandlerOption.OpenNotifications,
-    GestureHandlerOption.OpenQuickSettings,
-    GestureHandlerOption.OpenAppDrawer,
-    GestureHandlerOption.OpenAppSearch,
-    GestureHandlerOption.OpenSearch,
-    GestureHandlerOption.OpenApp,
-    GestureHandlerOption.OpenAssistant,
-)
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -68,18 +57,13 @@ fun GestureHandlerPreference(
 
     fun onSelect(option: GestureHandlerOption) {
         scope.launch {
-            val config = option.buildConfig(context as Activity) ?: return@launch
+            val config = option.buildConfigFrom(context) ?: return@launch
             adapter.onChange(config)
         }
     }
 
-    val newOptions = gestureHandlerOptions.filterNot { option ->
-        option in listOf(
-            GestureHandlerOption.OpenAppDrawer,
-            GestureHandlerOption.OpenAppSearch,
-        ) &&
-            pref2.deckLayout.firstBlocking()
-    }
+    val newOptions =
+        filterGestureHandlerOptions(deckLayoutEnabled = pref2.deckLayout.firstBlocking())
 
     PreferenceTemplate(
         title = { Text(text = label) },
@@ -143,7 +127,7 @@ fun AppGesturePreference(
 
     fun onSelect(option: GestureHandlerOption) {
         scope.launch {
-            val config = option.buildConfig(context as Activity) ?: return@launch
+            val config = option.buildConfigFrom(context) ?: return@launch
             prefs.setGestureForApp(cmp, gestureType, config)
             isExpanded = false
         }

--- a/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/GestureHandlerPreference.kt
@@ -32,6 +32,7 @@ import app.lawnchair.gestures.config.filterGestureHandlerOptions
 import app.lawnchair.gestures.config.gestureHandlerOptions
 import app.lawnchair.gestures.type.GestureType
 import app.lawnchair.preferences.PreferenceAdapter
+import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.ModalBottomSheetContent
 import app.lawnchair.ui.preferences.components.layout.PreferenceDivider
@@ -51,7 +52,7 @@ fun GestureHandlerPreference(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val bottomSheetHandler = LocalBottomSheetHandler.current
-    val pref2 = preferenceManager2()
+    val prefs2 = preferenceManager2()
 
     val currentConfig = adapter.state.value
 
@@ -63,7 +64,7 @@ fun GestureHandlerPreference(
     }
 
     val newOptions =
-        filterGestureHandlerOptions(deckLayoutEnabled = pref2.deckLayout.firstBlocking())
+        filterGestureHandlerOptions(deckLayoutEnabled = prefs2.deckLayout.getAdapter().state.value)
 
     PreferenceTemplate(
         title = { Text(text = label) },

--- a/src/com/android/launcher3/icons/IconCache.java
+++ b/src/com/android/launcher3/icons/IconCache.java
@@ -69,6 +69,7 @@ import com.android.launcher3.shortcuts.ShortcutRequest;
 import com.android.launcher3.util.CancellableTask;
 import com.android.launcher3.util.ComponentKey;
 import com.android.launcher3.util.DaggerSingletonTracker;
+import com.android.launcher3.util.FlagOp;
 import com.android.launcher3.util.InstantAppResolver;
 import com.android.launcher3.util.PackageUserKey;
 import com.android.launcher3.widget.WidgetSections;
@@ -86,6 +87,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import app.lawnchair.LawnchairActivityCachingLogic;
+import app.lawnchair.gestures.ui.LawnchairShortcutActivity;
 import app.lawnchair.icons.LawnchairIconProvider;
 
 /**
@@ -322,7 +324,10 @@ public class IconCache extends BaseIconCache {
         if (isDefaultIcon(bitmapInfo, user) && fallbackIconCheck.test(info)) {
             return;
         }
-        info.bitmap = bitmapInfo.withBadgeInfo(getShortcutInfoBadge(si.getShortcutInfo()));
+
+        info.bitmap = LawnchairShortcutActivity.Companion.shouldSkipShortcutBadge(context, si.getShortcutInfo())
+            ? bitmapInfo.withFlags(FlagOp.NO_OP)
+            : bitmapInfo.withBadgeInfo(getShortcutInfoBadge(si.getShortcutInfo()));
     }
 
     /**
@@ -386,7 +391,10 @@ public class IconCache extends BaseIconCache {
                     CacheableShortcutCachingLogic.INSTANCE,
                     lookupFlag.withSkipAddToMemCache());
             applyCacheEntry(entry, info);
-            info.bitmap = info.bitmap.withBadgeInfo(getShortcutInfoBadge(si));
+
+            if (!LawnchairShortcutActivity.Companion.shouldSkipShortcutBadge(context, si)) {
+                info.bitmap = info.bitmap.withBadgeInfo(getShortcutInfoBadge(si));
+            }
         } else {
             Intent intent = info.getIntent();
             getTitleAndIcon(info, () -> mLauncherApps.resolveActivity(intent, info.user),


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

This PR reimplements support for adding shortcuts that trigger actions defined in Lawnchair's gesture system.

Todo:
- [x] Improve PR description
- [x] Apply spotless

Fixes #5841
Fixes #5371
Fixes #5233

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **New feature** (A non-breaking change that adds functionality)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add an "Actions" chooser to create system shortcuts that trigger configured gesture handlers from the launcher; shortcuts are creatable system-wide.

* **UI**
  * New screen to pick actions with icons and labels; shortcuts save a representative icon and label.
  * Added user-facing message: "Failed to trigger action".

* **Behavior**
  * Gesture handlers can be invoked via created shortcuts and launched reliably.

* **Bug Fixes**
  * Prevents unnecessary shortcut icon badging for created gesture shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->