### PR TITLE
fix(widget): handle IllegalStateException when fetching widget previe…

### DIFF
--- a/src/com/android/launcher3/widget/WidgetManagerHelper.java
+++ b/src/com/android/launcher3/widget/WidgetManagerHelper.java
@@ -174,6 +174,9 @@ public class WidgetManagerHelper {
         } catch (NoSuchMethodError | NoClassDefFoundError e) {
             Log.w("LC_"+TAG, "loadGeneratedPreview: Error loading widget preview");
             return null;
+        } catch (IllegalStateException e) {
+            Log.w("LC_"+TAG, "loadGeneratedPreview: Invalid state fetching preview.", e);
+            return null;
         }
     }
 

--- a/tests/multivalentTests/src/com/android/launcher3/widget/WidgetManagerHelperTest.kt
+++ b/tests/multivalentTests/src/com/android/launcher3/widget/WidgetManagerHelperTest.kt
@@ -125,4 +125,16 @@ class WidgetManagerHelperTest {
             verify(appWidgetManager).getWidgetPreview(provider, profile, widgetCategory)
         }
     }
+
+    @Test
+    fun loadGeneratedPreview_returnsNull_whenAppWidgetManagerThrowsIllegalStateException() {
+        val widgetCategory = 130
+
+        whenever(appWidgetManager.getWidgetPreview(info.provider, info.profile, widgetCategory))
+            .thenThrow(IllegalStateException("User must be unlocked for widgets to be available"))
+
+        val result = underTest.loadGeneratedPreview(info, widgetCategory)
+
+        Truth.assertThat(result).isNull()
+    }
 }


### PR DESCRIPTION
…ws for locked profiles

<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes #6525  <!-- optional -->

Based on my investigation, a locked work profile is causing the widget render action to crash the app. I haven't been able to manually reproduce the issue, only log it when it occurs. This change handles the `IllegalStateException` that can be thrown in `loadGeneratedPreview`. This catch is also performed in the method `getAllProviders`.

This won't fix any other unknown errors thrown by the dependency.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Occasionally, this widget render issue causes the app to continuously crash. Handling the `IllegalStateException` should resolve this. 

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->
N/A - Added a unit test for this issue.

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
