### PR TITLE
fix: Trim whitespace in app drawer search query

### DIFF
--- a/src/com/android/launcher3/allapps/search/AllAppsSearchBarController.java
+++ b/src/com/android/launcher3/allapps/search/AllAppsSearchBarController.java
@@ -96,7 +96,7 @@ public class AllAppsSearchBarController
 
     @Override
     public void afterTextChanged(final Editable s) {
-        mQuery = s.toString();
+        mQuery = Utilities.trim(s);
         if (mQuery.isEmpty()) {
             mCallback.clearSearchResult();
         } else {


### PR DESCRIPTION
This is useful when you mistype something and your keyboard provides a word correction for you. If you use that correction suggestion, a space is inserted at the end. If we don't trim whitespace, the correction is rendered ineffective. eg "musci" -> "music " -> No result for  "YT Music"

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:x: **Bug fix** (A non-breaking change that fixes an issue)
:white_check_mark: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)
