### PR TITLE
fix: backup restore not loading launcher layout

### DIFF
--- a/lawnchair/src/app/lawnchair/backup/LawnchairBackup.kt
+++ b/lawnchair/src/app/lawnchair/backup/LawnchairBackup.kt
@@ -16,6 +16,7 @@ import app.lawnchair.wallpaper.WallpaperManagerCompat
 import com.android.launcher3.BuildConfig
 import com.android.launcher3.LauncherAppState
 import com.android.launcher3.LauncherFiles
+import com.android.launcher3.LauncherPrefs
 import com.android.launcher3.R
 import com.android.launcher3.model.DeviceGridState
 import com.android.launcher3.model.ModelDbController
@@ -79,6 +80,18 @@ class LawnchairBackup(
         }
         context.getDatabasePath(LAUNCHER_DB_FILE_NAME).parentFile?.deleteRecursively()
         DeviceGridState(info.gridState).writeToPrefs(context, true)
+
+        // Set DB_FILE from the backup's grid state so that createDatabaseHelper
+        // renames restored.db to the backup's grid filename (e.g. launcher_5_5_5.db)
+        // and sanitiseDB opens the correct database. Without this, the fallback to
+        // mIdp.dbFile (the device's grid name) causes the rename to target the wrong
+        // file, and sanitiseDB opens an empty database.
+        val gridSize = info.gridState.gridSize.split(",")
+        if (gridSize.size == 2) {
+            val dbFileName = "launcher_${gridSize[0]}_${gridSize[1]}_${info.gridState.hotseatCount}.db"
+            LauncherPrefs.get(context).putSync(LauncherPrefs.DB_FILE.to(dbFileName))
+        }
+
         readZip(handlers)
 
         var dbController = ModelDbController(context)

--- a/src/com/android/launcher3/model/ModelDbController.java
+++ b/src/com/android/launcher3/model/ModelDbController.java
@@ -133,13 +133,12 @@ public class ModelDbController {
 
     protected DatabaseHelper createDatabaseHelper(boolean forMigration, String dbFile) {
         boolean isSandbox = mContext instanceof SandboxContext;
-        String dbName = isSandbox ? null : InvariantDeviceProfile.INSTANCE.get(mContext).dbFile;
 
         try {
-            if (!forMigration && dbName != null) {
+            if (!forMigration) {
                 LawnchairApp app = LawnchairAppKt.getLawnchairApp(mContext);
-                app.renameRestoredDb(dbName);
-                app.migrateDbName(dbName);
+                app.renameRestoredDb(dbFile);
+                app.migrateDbName(dbFile);
             }
         } catch (Throwable t) {
             // LC-Ignored


### PR DESCRIPTION
## Summary
- Fixes backup restore silently failing to load the launcher layout when the backup's grid size differs from the device's
- Root cause: `renameRestoredDb()` used the device's grid DB name but `createDatabaseHelper()` opened the backup's grid DB name. When these differed, the restored database was renamed to the wrong file, and the controller opened a fresh empty database.


## Fix

**`ModelDbController.java`** — Pass `dbFile` parameter to `renameRestoredDb()` instead of `dbName` from `mIdp.dbFile`:

**`LawnchairBackup.kt`** — Set `DB_FILE` from the backup's grid state so `createDbIfNotExists()` uses the correct filename
