### PR TITLE
fix(drawer): apply label size factor to allAppsIconTextSize

### DIFF
--- a/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
+++ b/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
@@ -88,6 +88,7 @@ class DeviceProfileOverrides @Inject constructor(
 
         val iconSizeFactor: Float,
         val allAppsIconSizeFactor: Float,
+        val allAppsIconTextSizeFactor: Float,
 
         val enableTaskbarOnPhone: Boolean,
     ) {
@@ -102,6 +103,12 @@ class DeviceProfileOverrides @Inject constructor(
 
             iconSizeFactor = prefs2.homeIconSizeFactor.firstBlocking(),
             allAppsIconSizeFactor = prefs2.drawerIconSizeFactor.firstBlocking(),
+            allAppsIconTextSizeFactor =
+                if (prefs2.showIconLabelsInDrawer.firstBlocking()) {
+                    prefs2.drawerIconLabelSizeFactor.firstBlocking()
+                } else {
+                    0f
+                },
 
             enableTaskbarOnPhone = prefs2.enableTaskbarOnPhone.firstBlocking(),
         )
@@ -123,6 +130,11 @@ class DeviceProfileOverrides @Inject constructor(
             idp.allAppsIconSize[INDEX_LANDSCAPE] *= allAppsIconSizeFactor
             idp.allAppsIconSize[INDEX_TWO_PANEL_PORTRAIT] *= allAppsIconSizeFactor
             idp.allAppsIconSize[INDEX_TWO_PANEL_LANDSCAPE] *= allAppsIconSizeFactor
+
+            idp.allAppsIconTextSize[INDEX_DEFAULT] *= allAppsIconTextSizeFactor
+            idp.allAppsIconTextSize[INDEX_LANDSCAPE] *= allAppsIconTextSizeFactor
+            idp.allAppsIconTextSize[INDEX_TWO_PANEL_PORTRAIT] *= allAppsIconTextSizeFactor
+            idp.allAppsIconTextSize[INDEX_TWO_PANEL_LANDSCAPE] *= allAppsIconTextSizeFactor
         }
     }
 

--- a/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
+++ b/lawnchair/src/app/lawnchair/DeviceProfileOverrides.kt
@@ -104,11 +104,11 @@ class DeviceProfileOverrides @Inject constructor(
             iconSizeFactor = prefs2.homeIconSizeFactor.firstBlocking(),
             allAppsIconSizeFactor = prefs2.drawerIconSizeFactor.firstBlocking(),
             allAppsIconTextSizeFactor =
-                if (prefs2.showIconLabelsInDrawer.firstBlocking()) {
-                    prefs2.drawerIconLabelSizeFactor.firstBlocking()
-                } else {
-                    0f
-                },
+            if (prefs2.showIconLabelsInDrawer.firstBlocking()) {
+                prefs2.drawerIconLabelSizeFactor.firstBlocking()
+            } else {
+                0f
+            },
 
             enableTaskbarOnPhone = prefs2.enableTaskbarOnPhone.firstBlocking(),
         )


### PR DESCRIPTION
 ### Description

  Apply `showIconLabelsInDrawer` and `drawerIconLabelSizeFactor` preferences to
  `idp.allAppsIconTextSize` so that toggling drawer labels on/off and adjusting
  label size actually takes effect.

  Fixes #6481

  ### Reasoning

  `DeviceProfileOverrides.Options.applyUi()` was already applying `allAppsIconSizeFactor`
  to icon sizes, but `allAppsIconTextSizeFactor` was never applied to `allAppsIconTextSize`.
  As a result, `AllAppsProfile` always read the original unmodified text size from
  `InvariantDeviceProfile`, making both the label toggle and label size slider have no effect.

  The fix adds `allAppsIconTextSizeFactor` to `Options` (computed as `0f` when labels are
  disabled, otherwise the user's size factor) and applies it to all four `allAppsIconTextSize`
  indices in `applyUi()`, consistent with how icon size overrides are handled.

  ### Testing

  1. Open Settings → App Drawer → Icons
  2. Toggle **Show labels** off → reopen drawer, labels should disappear
  3. Toggle **Show labels** on → labels should reappear
  4. Adjust **Label size** slider → label size should update accordingly

  ### Type of change

  :white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
  :x: **New feature** (A non-breaking change that adds functionality)
  :x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
  :x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
  :x: **Performance** (A code change that improves performance)
  :x: **Style** (Code style changes)
  :x: **Docs** (Changes to documentation)
  :x: **Chore** (Changes to the build process or other tooling)

  ---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to control app-drawer label size: when drawer labels are enabled, the label-size factor is applied (otherwise disabled) and label text scaling is now consistently applied across all orientations and layout modes to match icon scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->