### PR TITLE
fix: apply themed icons to app drawer folder preview items

### DIFF
--- a/src/com/android/launcher3/folder/PreviewItemManager.java
+++ b/src/com/android/launcher3/folder/PreviewItemManager.java
@@ -470,7 +470,7 @@ public class PreviewItemManager {
             p.drawable = AppPairIconGraphic.composeDrawable(api, appPairParams);
             p.drawable.setBounds(0, 0, mIconSize, mIconSize);
         } else if (item instanceof ItemInfoWithIcon withIcon){
-            var isThemed = PreferenceManager.getInstance(mContext).getDrawerThemedIcons().get() ? 0 : FLAG_THEMED;
+            var isThemed = PreferenceManager.getInstance(mContext).getDrawerThemedIcons().get() ? FLAG_THEMED : 0;
             p.drawable = withIcon.newIcon(mContext, isThemed);
             p.drawable.setBounds(0, 0, mIconSize, mIconSize);
         }


### PR DESCRIPTION
### Description

  The ternary condition for `isThemed` in `PreviewItemManager.setDrawable()` was inverted for `AppInfo` items in app drawer folder
  previews. Enabling drawer themed icons passed `FLAG_THEMED = 0` (no theming), while disabling them incorrectly applied theming.
  This fix swaps the ternary branches so theming is applied when and only when the setting is enabled.

  Fixes #6391

  ### Reasoning

  `PreviewItemManager.setDrawable()` has two branches: one for `WorkspaceItemInfo` (desktop items) and one for `ItemInfoWithIcon`
  (app drawer `AppInfo` items). The `isThemed` ternary in the `ItemInfoWithIcon` branch had its true/false values swapped, so the
  theming flag was applied in exactly the opposite cases. Swapping the branches aligns the behavior with user intent and matches the logic in the desktop branch.

  ### Testing

  1. Enable "Force monochrome icons" for desktop only (not include drawer)
  2. Open app drawer — folder preview icons should NOT be monochrome ✓
  3. Enable "Force monochrome icons" for both desktop and drawer
  4. Open app drawer — folder preview icons should be monochrome ✓
  5. Tap into the folder — icons inside should also be monochrome ✓

  ### Type of change

  :white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
  :x: **New feature** (A non-breaking change that adds functionality)
  :x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
  :x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
  :x: **Performance** (A code change that improves performance)
  :x: **Style** (Code style changes)
  :x: **Docs** (Changes to documentation)
  :x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect themed icon variant selection in folder previews—themed icon preferences are now respected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->