### PR TITLE
fix: cap oversized preview bitmaps with extreme aspect ratios

### DIFF
--- a/lawnchair/src/app/lawnchair/search/adapter/SearchTargetFactory.kt
+++ b/lawnchair/src/app/lawnchair/search/adapter/SearchTargetFactory.kt
@@ -403,6 +403,15 @@ class SearchTargetFactory(
 
 object FilesTarget {
     private const val MAX_PREVIEW_SIZE_PX = 256
+    private const val MAX_RAW_DIMENSION_PX = 16_384
+    private const val MAX_ASPECT_RATIO = 5
+
+    private fun isValidPreviewSize(width: Int, height: Int): Boolean {
+        if (width <= 0 || height <= 0) return false
+        if (maxOf(width, height) > MAX_RAW_DIMENSION_PX) return false
+        if (maxOf(width, height) > minOf(width, height) * MAX_ASPECT_RATIO) return false
+        return true
+    }
 
     fun getPreviewIcon(
         context: Context,
@@ -421,6 +430,10 @@ object FilesTarget {
         return try {
             val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
             BitmapFactory.decodeFile(path, options)
+
+            val w = options.outWidth
+            val h = options.outHeight
+            if (!isValidPreviewSize(w, h)) return null
 
             options.inSampleSize = calculateInSampleSize(
                 options.outWidth,


### PR DESCRIPTION
### Description

  `calculateInSampleSize` in `SearchTargetFactory.kt` used `&&` in its while-loop condition, meaning images with extreme aspect
  ratios (e.g. 12000×120) were never downsampled because only one dimension exceeded the cap. Switching to `||` ensures both axes are
   independently constrained, so the decoded bitmap always fits within `MAX_PREVIEW_SIZE_PX` on every dimension.

  Fixes #6579

  ### Reasoning

  The `&&` condition exits the loop as soon as either dimension drops below the threshold, leaving the other potentially far above
  the cap. Using `||` keeps looping until both dimensions are within bounds.

  ### Testing

  1. Trigger a search result containing an image with an extreme aspect ratio (e.g. very wide banner or tall thin image)
  2. Verify the preview is correctly downsampled without excessive memory usage

  ### Type of change

  :white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
  :x: **New feature** (A non-breaking change that adds functionality)
  :x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
  :x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
  :x: **Performance** (A code change that improves performance)
  :x: **Style** (Code style changes)
  :x: **Docs** (Changes to documentation)
  :x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thumbnails with invalid, non-positive, excessively large, or extreme aspect-ratio dimensions are now skipped and show the default icon to prevent decode failures.
  * Image downscaling logic refined to select sampling earlier and more reliably, reducing failed thumbnail loads and peak memory use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->