### PR TITLE
Add Vivaldi as a search bar provider

### DIFF
--- a/lawnchair/res/drawable/ic_vivaldi.xml
+++ b/lawnchair/res/drawable/ic_vivaldi.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <!-- Dark red background circle -->
+    <path
+        android:fillColor="#9C1A1A"
+        android:pathData="M50,5 A45,45 0 1,0 95,50 A45,45 0 1,0 50,5 Z" />
+    <!-- Bright red ring (outer circle minus inner circle via evenOdd fill) -->
+    <path
+        android:fillColor="#EF3939"
+        android:fillType="evenOdd"
+        android:pathData="M50,12 A38,38 0 1,0 88,50 A38,38 0 1,0 50,12 Z M50,22 A28,28 0 1,1 78,50 A28,28 0 1,1 50,22 Z" />
+    <!-- White V letterform -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M26,30 L40,30 L50,58 L60,30 L74,30 L52,70 L48,70 Z" />
+</vector>

--- a/lawnchair/res/drawable/ic_vivaldi_tinted.xml
+++ b/lawnchair/res/drawable/ic_vivaldi_tinted.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M26,30 L40,30 L50,58 L60,30 L74,30 L52,70 L48,70 Z" />
+</vector>

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -751,6 +751,7 @@
     <string name="search_provider_ironfox" translatable="false">IronFox</string>
     <string name="search_provider_kagi" translatable="false">Kagi</string>
     <string name="search_provider_cromite" translatable="false">Cromite</string>
+    <string name="search_provider_vivaldi" translatable="false">Vivaldi</string>
     <string name="search_provider_custom">Custom</string>
 
     <string name="search_provider_sponsored_description">%1$s and Lawnchair have a revenue share agreement.\n\nSearching with %1$s helps support Lawnchair.</string>

--- a/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/QsbSearchProvider.kt
@@ -140,6 +140,7 @@ sealed class QsbSearchProvider(
             IronFox,
             Kagi,
             Cromite,
+            Vivaldi,
         )
 
         /**

--- a/lawnchair/src/app/lawnchair/qsb/providers/Vivaldi.kt
+++ b/lawnchair/src/app/lawnchair/qsb/providers/Vivaldi.kt
@@ -1,0 +1,15 @@
+package app.lawnchair.qsb.providers
+
+import app.lawnchair.qsb.ThemingMethod
+import com.android.launcher3.R
+
+data object Vivaldi : QsbSearchProvider(
+    id = "vivaldi",
+    name = R.string.search_provider_vivaldi,
+    icon = R.drawable.ic_vivaldi,
+    themedIcon = R.drawable.ic_vivaldi_tinted,
+    themingMethod = ThemingMethod.TINT,
+    packageName = "com.vivaldi.browser",
+    className = "org.chromium.chrome.browser.searchwidget.SearchWidgetProviderActivity",
+    website = "https://vivaldi.com/",
+)


### PR DESCRIPTION
### Description
  Add Vivaldi browser as a search bar provider option in Lawnchair.

  Fixes #6534

  ### Reasoning
  Vivaldi is a Chromium-based browser with a dedicated Android app. The implementation follows the established pattern used by Brave (another Chromium-based browser), using SearchWidgetProviderActivity as the search entry point. Two icon variants are provided: a full-color icon faithful to Vivaldi's red/white V branding, and a monochrome tinted variant for system theming support.

  ### Testing
  1. Go to Settings → Lawnchair → Search → Search provider
  2. Select "Vivaldi" from the list
  3. Tap the search bar on the home screen — Vivaldi's search widget should open
  4. With Vivaldi not installed, tapping the search bar should fall back to vivaldi.com in the browser

  ### Type of change

  :x: **Bug fix** (A non-breaking change that fixes an issue)
  :white_check_mark: **New feature** (A non-breaking change that adds functionality)
  :x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
  :x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
  :x: **Performance** (A code change that improves performance)
  :x: **Style** (Code style changes)
  :x: **Docs** (Changes to documentation)
  :x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vivaldi browser as a new supported search provider option. Users can now select Vivaldi as their default quick search provider with full dynamic theme support. The integration includes branded icons optimized for both light and dark display modes, plus seamless widget support for executing quick searches directly from the launcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->