### PR TITLE
feat: Warn user when restoring backup with subgrid positioning; allow toggling smartspace in import

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -529,6 +529,7 @@
     <string name="nova_shortcut_label">Shortcuts</string>
     <string name="nova_icon_pack_label">Icon pack</string>
     <string name="restore_nova_subgrid_warning">This backup uses Nova\'s subgrid positioning. Lawnchair does not support subgrids, so any items placed in a subgrid will be aligned to the nearest grid position.</string>
+    <string name="restore_nova_smartspace_conflict_toggle">Add extra row to show At a Glance</string>
 
     <!--
 

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -528,6 +528,7 @@
     <string name="nova_folder_label">Folders</string>
     <string name="nova_shortcut_label">Shortcuts</string>
     <string name="nova_icon_pack_label">Icon pack</string>
+    <string name="restore_nova_subgrid_warning">This backup uses Nova\'s subgrid positioning. Lawnchair does not support subgrids, so any items placed in a subgrid will be aligned to the nearest grid position.</string>
 
     <!--
 

--- a/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
+++ b/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
@@ -26,6 +26,7 @@ import java.net.URISyntaxException
 import java.util.UUID
 import java.util.zip.ZipInputStream
 import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.math.roundToInt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -69,6 +70,7 @@ class NovaBackupConverter(
     }
 
     private val novaGridRegex = Regex("(\\d+)x(\\d+)")
+    private val novaSubgridRegex = Regex("subgrid", RegexOption.IGNORE_CASE)
 
     data class NovaBackupInfo(
         val columns: Int?,
@@ -80,6 +82,7 @@ class NovaBackupConverter(
         val shortcutCount: Int,
         val iconPackPackage: String?,
         val iconPackLabel: String?,
+        val isSubgrid: Boolean = false,
     )
 
     private data class NovaConfig(
@@ -87,6 +90,7 @@ class NovaBackupConverter(
         val rows: Int?,
         val dockCols: Int?,
         val iconPackPackage: String?,
+        val isSubgrid: Boolean = false,
     )
 
     private data class ItemCounts(
@@ -129,6 +133,7 @@ class NovaBackupConverter(
                 iconPackLabel = novaConfig.iconPackPackage?.let { packageName ->
                     resolveIconPackLabel(packageName)
                 },
+                isSubgrid = novaConfig.isSubgrid,
             )
         } finally {
             tempDir.deleteRecursively()
@@ -207,6 +212,7 @@ class NovaBackupConverter(
         var rows: Int? = null
         var dockCols: Int? = null
         var iconPackPackage: String? = null
+        var isSubgrid = false
 
         val stringNodes = root.getElementsByTagName(NOVA_XML_TAG_STRING)
         for (i in 0 until stringNodes.length) {
@@ -215,6 +221,7 @@ class NovaBackupConverter(
             val text = node.textContent ?: continue
             when (name) {
                 NOVA_XML_KEY_DESKTOP_GRID -> {
+                    isSubgrid = novaSubgridRegex.containsMatchIn(text)
                     val match = novaGridRegex.find(text) ?: continue
                     rows = match.groupValues[1].toIntOrNull() ?: continue
                     columns = match.groupValues[2].toIntOrNull() ?: continue
@@ -235,7 +242,7 @@ class NovaBackupConverter(
             if (name == NOVA_XML_KEY_DOCK_COLS) dockCols = value
         }
 
-        return NovaConfig(columns, rows, dockCols, iconPackPackage)
+        return NovaConfig(columns, rows, dockCols, iconPackPackage, isSubgrid)
     }
 
     private fun countItems(dbFile: File): ItemCounts {
@@ -340,11 +347,11 @@ class NovaBackupConverter(
                     null
                 }
                 val intent = importedDeepShortcut?.toLauncherIntentUri() ?: rawIntent
-                val cellX = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_CELL_X)).toInt()
-                val cellY = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_CELL_Y)).toInt()
+                val cellX = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_CELL_X)).roundToInt()
+                val cellY = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_CELL_Y)).roundToInt()
                 val screen = if (isHotseat) cellX else cursor.getInt(cursor.getColumnIndexOrThrow(NOVA_COL_SCREEN))
-                val spanX = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_SPAN_X)).toInt().coerceAtLeast(1)
-                val spanY = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_SPAN_Y)).toInt().coerceAtLeast(1)
+                val spanX = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_SPAN_X)).roundToInt().coerceAtLeast(1)
+                val spanY = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_SPAN_Y)).roundToInt().coerceAtLeast(1)
                 val icon = getBlobOrNull(cursor, NOVA_COL_ICON)
                 val appWidgetProvider = getStringOrNull(cursor, NOVA_COL_APP_WIDGET_PROVIDER)
                 val rank = when {

--- a/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
+++ b/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
@@ -10,6 +10,7 @@ import android.os.Process
 import android.util.Log
 import app.lawnchair.DeviceProfileOverrides
 import app.lawnchair.preferences.PreferenceManager
+import app.lawnchair.preferences2.PreferenceManager2
 import com.android.launcher3.InvariantDeviceProfile
 import com.android.launcher3.LauncherSettings.Favorites
 import com.android.launcher3.model.DatabaseHelper
@@ -19,6 +20,7 @@ import com.android.launcher3.pm.UserCache
 import com.android.launcher3.provider.RestoreDbTask
 import com.android.launcher3.shortcuts.ShortcutKey
 import com.android.launcher3.shortcuts.ShortcutRequest
+import com.patrykmichalik.opto.core.firstBlocking
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -150,11 +152,14 @@ class NovaBackupConverter(
             val novaDbFile = File(tempDir, NOVA_DB)
             require(novaDbFile.exists()) { "Missing $NOVA_DB" }
 
+            val smartspaceEnabled = PreferenceManager2.getInstance(context)
+                .enableSmartspace.firstBlocking()
+
             val stagedDbFile = File(tempDir, NOVA_WORKSPACE_DB)
-            val importedDeepShortcuts = createRestoredDb(novaDbFile, stagedDbFile)
+            val importedDeepShortcuts = createRestoredDb(novaDbFile, stagedDbFile, info, smartspaceEnabled)
 
             val columns = info.columns
-            val rows = info.rows
+            val rows = if (smartspaceEnabled && info.rows != null) info.rows + 1 else info.rows
             val hotseatCount = info.hotseatCount
             if (columns != null && rows != null && hotseatCount != null) {
                 val gridInfo = DeviceProfileOverrides.DBGridInfo(
@@ -173,7 +178,7 @@ class NovaBackupConverter(
                 gridState.writeToPrefs(context)
                 InvariantDeviceProfile.INSTANCE.get(context).dbFile = gridInfo.dbFile
             }
-            writeGridToLawnchairPrefs(info)
+            writeGridToLawnchairPrefs(info, smartspaceEnabled)
 
             val restoredDbFile = context.getDatabasePath(LawnchairBackup.RESTORED_DB_FILE_NAME)
             restoredDbFile.parentFile?.mkdirs()
@@ -195,11 +200,12 @@ class NovaBackupConverter(
         packageName
     }
 
-    private fun writeGridToLawnchairPrefs(info: NovaBackupInfo) {
+    private fun writeGridToLawnchairPrefs(info: NovaBackupInfo, smartspaceEnabled: Boolean) {
         val prefs = PreferenceManager.getInstance(context)
+        val adjustedRows = if (smartspaceEnabled && info.rows != null) info.rows + 1 else info.rows
         prefs.sp.edit().apply {
             info.columns?.let { putInt(prefs.workspaceColumns.key, it) }
-            info.rows?.let { putInt(prefs.workspaceRows.key, it) }
+            adjustedRows?.let { putInt(prefs.workspaceRows.key, it) }
             info.hotseatCount?.let { putInt(prefs.hotseatColumns.key, it) }
             info.iconPackPackage?.let { putString(prefs.iconPackPackage.key, it) }
         }.commit()
@@ -279,6 +285,8 @@ class NovaBackupConverter(
     private fun createRestoredDb(
         novaDbFile: File,
         targetDbFile: File,
+        info: NovaBackupInfo,
+        smartspaceEnabled: Boolean,
     ): Map<String, Set<String>> {
         val profileId = UserCache.INSTANCE.get(context)
             .getSerialNumberForUser(Process.myUserHandle())
@@ -297,7 +305,7 @@ class NovaBackupConverter(
             novaDb.use { src ->
                 db.beginTransaction()
                 try {
-                    insertNovaItems(src, db, profileId, importedDeepShortcuts)
+                    insertNovaItems(src, db, profileId, importedDeepShortcuts, info, smartspaceEnabled)
                     db.setTransactionSuccessful()
                 } finally {
                     db.endTransaction()
@@ -312,6 +320,8 @@ class NovaBackupConverter(
         db: SQLiteDatabase,
         profileId: Long,
         importedDeepShortcuts: MutableMap<String, MutableSet<String>>,
+        info: NovaBackupInfo,
+        smartspaceEnabled: Boolean,
     ) {
         src.rawQuery(
             "SELECT * FROM $NOVA_TABLE_FAVORITES WHERE $NOVA_COL_ITEM_TYPE != -1",
@@ -348,10 +358,24 @@ class NovaBackupConverter(
                 }
                 val intent = importedDeepShortcut?.toLauncherIntentUri() ?: rawIntent
                 val cellX = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_CELL_X)).roundToInt()
-                val cellY = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_CELL_Y)).roundToInt()
+                val rawCellY = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_CELL_Y)).roundToInt()
+                val cellY = if (isDesktop && smartspaceEnabled) rawCellY + 1 else rawCellY
                 val screen = if (isHotseat) cellX else cursor.getInt(cursor.getColumnIndexOrThrow(NOVA_COL_SCREEN))
-                val spanX = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_SPAN_X)).roundToInt().coerceAtLeast(1)
-                val spanY = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_SPAN_Y)).roundToInt().coerceAtLeast(1)
+                var spanX = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_SPAN_X)).roundToInt().coerceAtLeast(1)
+                var spanY = cursor.getDouble(cursor.getColumnIndexOrThrow(NOVA_COL_SPAN_Y)).roundToInt().coerceAtLeast(1)
+
+                // Clamp to grid bounds when grid dimensions are known
+                val maxCols = info.columns
+                val maxRows = if (smartspaceEnabled && info.rows != null) info.rows + 1 else info.rows
+                if (maxCols != null && isDesktop) {
+                    spanX = spanX.coerceAtMost(maxCols)
+                    if (cellX + spanX > maxCols) continue
+                }
+                if (maxRows != null && isDesktop) {
+                    spanY = spanY.coerceAtMost(maxRows)
+                    if (cellY + spanY > maxRows) continue
+                }
+                if (maxCols != null && isHotseat && cellX >= maxCols) continue
                 val icon = getBlobOrNull(cursor, NOVA_COL_ICON)
                 val appWidgetProvider = getStringOrNull(cursor, NOVA_COL_APP_WIDGET_PROVIDER)
                 val rank = when {

--- a/lawnchair/src/app/lawnchair/backup/ui/RestoreNovaBackupScreen.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/RestoreNovaBackupScreen.kt
@@ -35,6 +35,7 @@ import app.lawnchair.backup.ui.RestoreNovaBackupViewModel.Event
 import app.lawnchair.backup.ui.RestoreNovaBackupViewModel.State
 import app.lawnchair.ui.preferences.LocalIsExpandedScreen
 import app.lawnchair.ui.preferences.LocalNavController
+import app.lawnchair.ui.preferences.components.controls.WarningPreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
@@ -131,7 +132,17 @@ private fun BackupInfoGroup(info: NovaBackupInfo) {
         BackupInfoIntPreference(R.string.nova_folder_label, info.folderCount)
         BackupInfoIntPreference(R.string.nova_shortcut_label, info.shortcutCount)
         BackupInfoStringPreference(R.string.nova_icon_pack_label, info.iconPackLabel)
+        if (info.isSubgrid) {
+            SubgridWarning()
+        }
     }
+}
+
+@Composable
+private fun SubgridWarning() {
+    WarningPreference(
+        text = stringResource(R.string.restore_nova_subgrid_warning),
+    )
 }
 
 @Composable

--- a/lawnchair/src/app/lawnchair/backup/ui/RestoreNovaBackupScreen.kt
+++ b/lawnchair/src/app/lawnchair/backup/ui/RestoreNovaBackupScreen.kt
@@ -33,8 +33,11 @@ import androidx.navigation.toRoute
 import app.lawnchair.backup.NovaBackupConverter.NovaBackupInfo
 import app.lawnchair.backup.ui.RestoreNovaBackupViewModel.Event
 import app.lawnchair.backup.ui.RestoreNovaBackupViewModel.State
+import app.lawnchair.preferences.getAdapter
+import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.preferences.LocalIsExpandedScreen
 import app.lawnchair.ui.preferences.LocalNavController
+import app.lawnchair.ui.preferences.components.controls.SwitchPreference
 import app.lawnchair.ui.preferences.components.controls.WarningPreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
@@ -99,6 +102,12 @@ internal fun ColumnScope.RestoreNovaBackupContent(
 
     BackupInfoGroup(state.info)
 
+    if (state.info.isSubgrid) {
+        SubgridWarning()
+    }
+
+    BackupInfoOptions()
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -132,17 +141,28 @@ private fun BackupInfoGroup(info: NovaBackupInfo) {
         BackupInfoIntPreference(R.string.nova_folder_label, info.folderCount)
         BackupInfoIntPreference(R.string.nova_shortcut_label, info.shortcutCount)
         BackupInfoStringPreference(R.string.nova_icon_pack_label, info.iconPackLabel)
-        if (info.isSubgrid) {
-            SubgridWarning()
-        }
     }
 }
 
 @Composable
 private fun SubgridWarning() {
-    WarningPreference(
-        text = stringResource(R.string.restore_nova_subgrid_warning),
-    )
+    PreferenceGroup {
+        WarningPreference(
+            text = stringResource(R.string.restore_nova_subgrid_warning),
+        )
+    }
+}
+
+@Composable
+private fun BackupInfoOptions() {
+    PreferenceGroup {
+        val prefs2 = preferenceManager2()
+        val smartspaceAdapter = prefs2.enableSmartspace.getAdapter()
+        SwitchPreference(
+            adapter = smartspaceAdapter,
+            label = stringResource(R.string.restore_nova_smartspace_conflict_toggle),
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

<details><summary>Preview</summary>
<p>

<img width="1080" height="2400" alt="Screenshot_20260406-231923" src="https://github.com/user-attachments/assets/5b160b9c-a525-4a11-b376-0cd5655fcda8" />


</p>
</details> 

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Lawnchair don't support subgrid precision placement, so information *may* be lost

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Create NL8 backup format with subgrid, and restore it

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Nova backup restore with subgrid detection and user warning.
  * New toggle to adjust rows for Smartspace during restore.

* **Bug Fixes**
  * More accurate item placement during restore via improved rounding and bounds checks; items that would overflow are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->