### PR TITLE
feat: Allow restoring Nova Launcher smart folders

### DIFF
--- a/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
+++ b/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
@@ -66,6 +66,7 @@ class NovaBackupConverter(
         private const val NOVA_COL_SPAN_Y = "spanY"
         private const val NOVA_COL_ICON = "icon"
         private const val NOVA_COL_APP_WIDGET_PROVIDER = "appWidgetProvider"
+        private const val NOVA_SMART_FOLDER_MARKER = "FOLDER%3A-"
     }
 
     private val novaGridRegex = Regex("(\\d+)x(\\d+)")
@@ -246,7 +247,8 @@ class NovaBackupConverter(
                     WHERE $NOVA_COL_ITEM_TYPE != -1
                     AND ($NOVA_COL_CONTAINER = $NOVA_CONTAINER_DESKTOP
                         OR $NOVA_COL_CONTAINER = $NOVA_CONTAINER_HOTSEAT
-                        OR $NOVA_COL_CONTAINER >= 0)
+                        OR $NOVA_COL_CONTAINER >= 0
+                        OR $NOVA_COL_CONTAINER <= -200)
                     GROUP BY $NOVA_COL_ITEM_TYPE""",
                 null,
             ).use { cursor ->
@@ -306,6 +308,8 @@ class NovaBackupConverter(
         profileId: Long,
         importedDeepShortcuts: MutableMap<String, MutableSet<String>>,
     ) {
+        val smartFolderMap = buildSmartFolderMap(src)
+
         src.rawQuery(
             "SELECT * FROM $NOVA_TABLE_FAVORITES WHERE $NOVA_COL_ITEM_TYPE != -1",
             null,
@@ -320,17 +324,28 @@ class NovaBackupConverter(
                 val isDesktop = novaContainer == NOVA_CONTAINER_DESKTOP
                 val isHotseat = novaContainer == NOVA_CONTAINER_HOTSEAT
                 val isFolderChild = novaContainer >= 0
+                val isSmartFolderChild = novaContainer in smartFolderMap
 
-                if (!isDesktop && !isHotseat && !isFolderChild) continue
+                if (!isDesktop && !isHotseat && !isFolderChild && !isSmartFolderChild) continue
+
+                // Detect smart folder headers, and folder rows on desktop whose intent identified as
+                // Nova smart-folder container (FOLDER:-20X)
+                //
+                // X being category ID that are defined in drawer_group table
+                // These are restored as regular Lawnchair folders with null intent.
+                val isSmartFolderHeader = itemType == Favorites.ITEM_TYPE_FOLDER && isDesktop &&
+                    getStringOrNull(cursor, NOVA_COL_INTENT)?.contains(NOVA_SMART_FOLDER_MARKER) == true
 
                 val container = when {
                     isDesktop -> Favorites.CONTAINER_DESKTOP
                     isHotseat -> Favorites.CONTAINER_HOTSEAT
+                    isSmartFolderChild -> smartFolderMap.getValue(novaContainer)
                     else -> novaContainer
                 }
 
                 val title = getStringOrNull(cursor, NOVA_COL_TITLE)
-                val rawIntent = getStringOrNull(cursor, NOVA_COL_INTENT)
+                // Clear NL8 specific intent for Lawnchair
+                val rawIntent = if (isSmartFolderHeader) null else getStringOrNull(cursor, NOVA_COL_INTENT)
                 val importedDeepShortcut = if (itemType == Favorites.ITEM_TYPE_DEEP_SHORTCUT) {
                     parseNovaDeepShortcut(rawIntent)?.also { shortcut ->
                         importedDeepShortcuts.getOrPut(shortcut.packageName) { mutableSetOf() }
@@ -348,7 +363,7 @@ class NovaBackupConverter(
                 val icon = getBlobOrNull(cursor, NOVA_COL_ICON)
                 val appWidgetProvider = getStringOrNull(cursor, NOVA_COL_APP_WIDGET_PROVIDER)
                 val rank = when {
-                    isFolderChild -> calculateFolderRank(screen, cellX, cellY)
+                    isFolderChild || isSmartFolderChild -> calculateFolderRank(screen, cellX, cellY)
                     isHotseat -> screen
                     else -> 0
                 }
@@ -444,6 +459,46 @@ class NovaBackupConverter(
 
     private fun calculateFolderRank(screen: Int, cellX: Int, cellY: Int): Int {
         return (screen * FOLDER_PAGE_RANK_OFFSET) + (cellY * FOLDER_ROW_RANK_OFFSET) + cellX
+    }
+
+    /**
+     * Scans the Nova DB for smart-folder header rows and builds a mapping from the
+     * smart-folder container ID (-20X) to the folder row's _id.
+     *
+     * X being category ID that are defined in drawer_group table
+     */
+    private fun buildSmartFolderMap(src: SQLiteDatabase): Map<Int, Int> {
+        val map = mutableMapOf<Int, Int>()
+        src.rawQuery(
+            """SELECT $NOVA_COL_ID, $NOVA_COL_INTENT FROM $NOVA_TABLE_FAVORITES
+                WHERE $NOVA_COL_ITEM_TYPE = ${Favorites.ITEM_TYPE_FOLDER}
+                AND $NOVA_COL_CONTAINER = $NOVA_CONTAINER_DESKTOP
+                AND $NOVA_COL_INTENT LIKE '%$NOVA_SMART_FOLDER_MARKER%'""",
+            null,
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                val folderId = cursor.getInt(0)
+                val intentUri = cursor.getString(1) ?: continue
+                val smartContainerId = extractSmartFolderContainerId(intentUri)
+                if (smartContainerId != null) {
+                    map[smartContainerId] = folderId
+                }
+            }
+        }
+        return map
+    }
+
+    /**
+     * Extracts the smart-folder container ID from a Nova folder intent URI.
+     * `#Intent;component=com.teslacoilsw.launcher/FOLDER%3A-208;end` → -208
+     */
+    private fun extractSmartFolderContainerId(intentUri: String): Int? {
+        val marker = "FOLDER%3A"
+        val idx = intentUri.indexOf(marker)
+        if (idx < 0) return null
+        val afterMarker = intentUri.substring(idx + marker.length)
+        val numStr = afterMarker.takeWhile { it == '-' || it.isDigit() }
+        return numStr.toIntOrNull()
     }
 
     private fun parseNovaDeepShortcut(intentUri: String?): ImportedDeepShortcut? {

--- a/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
+++ b/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
@@ -462,8 +462,8 @@ class NovaBackupConverter(
     }
 
     /**
-     * Scans the Nova DB for smart-folder header rows and builds a mapping from the
-     * smart-folder container ID (-20X) to the folder row's _id.
+     * Get smart folder header rows from favorites table and builds a mapping from the smart folder
+     * container ID (-20X) to the folder row's _id.
      *
      * X being category ID that are defined in drawer_group table
      */
@@ -489,8 +489,8 @@ class NovaBackupConverter(
     }
 
     /**
-     * Extracts the smart-folder container ID from a Nova folder intent URI.
-     * `#Intent;component=com.teslacoilsw.launcher/FOLDER%3A-208;end` → -208
+     * Get smart folder container ID from a Nova folder intent URI.
+     * `#Intent;component=com.teslacoilsw.launcher/FOLDER%3A-208;end` -> -208
      */
     private fun extractSmartFolderContainerId(intentUri: String): Int? {
         val marker = "FOLDER%3A"
@@ -514,4 +514,26 @@ class NovaBackupConverter(
         val shortcutId = intent.getStringExtra(ShortcutKey.EXTRA_SHORTCUT_ID) ?: return null
         return ImportedDeepShortcut(packageName, shortcutId)
     }
+
+    /*
+     * Glossary: drawer_group
+     *
+     * The drawer_group table define app drawer tabs (groups) in Nova.
+     * This table is the following category from category_id in drawer_group table:
+     * 1. null (known as: "Apps", for items that belong to main profile)
+     * 2. null (known as: "Work", for items that belong to work profile)
+     * 3. ENTERTAINMENT
+     * 4. FINANCE
+     * 5. FOOD
+     * 6. GAMES
+     * 7. SHOPPING
+     * 8. SOCIAL
+     * 9. TRAVEL
+     *
+     * Note: This table is related to the appgroups table which is a table that already assigns apps
+     *       to these categories.
+     *
+     * Note: Nova assigns items to these categories by crowdsourcing,
+     *       unlike our Flowerpot (v1) Azalea system that needs to be constantly updated manually.
+     */
 }

--- a/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
+++ b/lawnchair/src/app/lawnchair/backup/NovaBackupConverter.kt
@@ -328,14 +328,6 @@ class NovaBackupConverter(
 
                 if (!isDesktop && !isHotseat && !isFolderChild && !isSmartFolderChild) continue
 
-                // Detect smart folder headers, and folder rows on desktop whose intent identified as
-                // Nova smart-folder container (FOLDER:-20X)
-                //
-                // X being category ID that are defined in drawer_group table
-                // These are restored as regular Lawnchair folders with null intent.
-                val isSmartFolderHeader = itemType == Favorites.ITEM_TYPE_FOLDER && isDesktop &&
-                    getStringOrNull(cursor, NOVA_COL_INTENT)?.contains(NOVA_SMART_FOLDER_MARKER) == true
-
                 val container = when {
                     isDesktop -> Favorites.CONTAINER_DESKTOP
                     isHotseat -> Favorites.CONTAINER_HOTSEAT
@@ -344,8 +336,14 @@ class NovaBackupConverter(
                 }
 
                 val title = getStringOrNull(cursor, NOVA_COL_TITLE)
-                // Clear NL8 specific intent for Lawnchair
-                val rawIntent = if (isSmartFolderHeader) null else getStringOrNull(cursor, NOVA_COL_INTENT)
+                /* TODO: Lawnchair folder synchronization support
+                 *        For nova parity:
+                 *           Sync folder contents from allapps to workspace, or workspace to allapps
+                 *        ImplNote:
+                 *           Check folder with intent: #Intent;component=com.teslacoilsw.launcher/FOLDER%3A-20X;end
+                 *           X being category ID that are defined in drawer_group table
+                 */
+                val rawIntent = getStringOrNull(cursor, NOVA_COL_INTENT)
                 val importedDeepShortcut = if (itemType == Favorites.ITEM_TYPE_DEEP_SHORTCUT) {
                     parseNovaDeepShortcut(rawIntent)?.also { shortcut ->
                         importedDeepShortcuts.getOrPut(shortcut.packageName) { mutableSetOf() }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

Allow restoring from smart folder, in the future this can be mapped to Lawnchair Caddy mode or Flowerpot architecture

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

More complete restoration.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Generate NL8 backup format with smart folder in workspace (usually by dragging smart folder from allapps drawer to workspace)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection and inclusion of smart-folder items during backup conversion.
  * Smart-folder children are correctly associated with their original desktop folders when restored.
  * Folder item ordering (ranks) is calculated consistently for both regular and smart-folder children, improving layout fidelity after import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->