### PR TITLE
feat(QuickSwitch): Initial Android 15 QPR2

### DIFF
--- a/GITHUB_CHANGELOG.md
+++ b/GITHUB_CHANGELOG.md
@@ -22,6 +22,7 @@ Compatibility list:
 | Android 13                                | ✅               | ❌         | ❌                        |
 | Android 14                                | ✅               | ❌         | ❌                        |
 | Android 15                                | ✅               | ❌         | ❌                        |
+| Android 15 QPR2                           | ✅               | ❌         | 💥 Not recommended       |
 | Android 16.0 (Android 16 initial release) | ✅               | ❌         | 💥 Not recommended       |
 | Android 16.1 (Android 16 QPR2)            | ✅               | ❌         | ❌                        |
 | Android 17.0                              | ✅               | ❌         | ❌                        |

--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarActivityContext.java
+++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarActivityContext.java
@@ -210,8 +210,10 @@ public class TaskbarActivityContext extends BaseTaskbarContext {
 
     public static final String SIMPLE_VIEW_SETTINGS_KEY = "matcha_enable";
 
-    protected static final DesktopModeFlag ENABLE_TASKBAR_BEHIND_SHADE = new DesktopModeFlag(
-            Flags::enableTaskbarBehindShade, false);
+    protected static final boolean ENABLE_TASKBAR_BEHIND_SHADE = false;
+    // // LC-Ignored: Intentional, all Android desktop flags are disabled
+    // new DesktopModeFlag(
+    //            Flags::enableTaskbarBehindShade, false);
 
     private final @Nullable Context mNavigationBarPanelContext;
 
@@ -1147,7 +1149,7 @@ public class TaskbarActivityContext extends BaseTaskbarContext {
     }
 
     private void updateTaskbarSnapshot(AnimatorSet anim, boolean isExpanded) {
-        if (!ENABLE_TASKBAR_BEHIND_SHADE.isTrue()
+        if (!ENABLE_TASKBAR_BEHIND_SHADE
                 || isPhoneMode()) {
             return;
         }

--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarManagerImpl.java
+++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarManagerImpl.java
@@ -1822,7 +1822,9 @@ public class TaskbarManagerImpl implements DisplayDecorationListener {
     }
 
     private boolean isExternalDisplay(int displayId) {
-        return DesktopExperienceFlags.ENABLE_TASKBAR_CONNECTED_DISPLAYS.isTrue() && (
+        // LC-Ignored: Intentional, all Android desktop flags are disabled
+        //DesktopExperienceFlags.ENABLE_TASKBAR_CONNECTED_DISPLAYS.isTrue()
+        return false && (
                 mPrimaryDisplayId != displayId);
     }
 

--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarStashController.java
+++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarStashController.java
@@ -1225,7 +1225,7 @@ public class TaskbarStashController implements TaskbarControllers.LoggableTaskba
         long startDelay = 0;
 
         updateStateForFlag(FLAG_STASHED_IN_APP_SYSUI, hasAnyFlag(systemUiStateFlags,
-                SYSUI_STATE_DIALOG_SHOWING | (ENABLE_TASKBAR_BEHIND_SHADE.isTrue()
+                SYSUI_STATE_DIALOG_SHOWING | (ENABLE_TASKBAR_BEHIND_SHADE
                         ? 0
                         : SYSUI_STATE_NOTIFICATION_PANEL_VISIBLE)
         ));

--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarView.java
+++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarView.java
@@ -213,7 +213,7 @@ public class TaskbarView extends FrameLayout implements FolderIcon.FolderIconPar
             mTaskbarDividerContainer = new TaskbarDividerContainer(context);
         }
 
-        if (ENABLE_TASKBAR_OVERFLOW.isTrue()) {
+        if (false) { // LC-Ignored: Intentional, all Android desktop flags are disabled - ENABLE_TASKBAR_OVERFLOW.isTrue()
             mTaskbarOverflowView = TaskbarOverflowView.inflateIcon(
                     R.layout.taskbar_overflow_view, this,
                     mIconTouchSize, mItemPadding);
@@ -389,7 +389,7 @@ public class TaskbarView extends FrameLayout implements FolderIcon.FolderIconPar
             }
         }
 
-        if (ENABLE_TASKBAR_OVERFLOW.isTrue()) {
+        if (false) { // LC-Ignored: Intentional, all Android desktop flags are disabled - ENABLE_TASKBAR_OVERFLOW.isTrue()
             mMaxNumIcons = calculateMaxNumIcons();
         }
     }
@@ -428,7 +428,7 @@ public class TaskbarView extends FrameLayout implements FolderIcon.FolderIconPar
         // TODO(b/343289567 and b/316004172): support app pairs and desktop mode.
         recentTasks = recentTasks.stream().filter(it -> it instanceof SingleTask).toList();
 
-        if (ENABLE_TASKBAR_RECENTS_LAYOUT_TRANSITION.isTrue()) {
+        if (false) { // LC-Ignored: Intentional, all Android desktop flags are disabled - ENABLE_TASKBAR_RECENTS_LAYOUT_TRANSITION.isTrue()
             updateItemsWithLayoutTransition(hotseatItemInfos, recentTasks);
         } else {
             updateItemsWithoutLayoutTransition(hotseatItemInfos, recentTasks);
@@ -714,7 +714,7 @@ public class TaskbarView extends FrameLayout implements FolderIcon.FolderIconPar
     }
 
     private void updateRecents(List<GroupTask> recentTasks, int hotseatSize) {
-        boolean supportsOverflow = ENABLE_TASKBAR_OVERFLOW.isTrue() && recentTasks.size() > 1;
+        boolean supportsOverflow = false && recentTasks.size() > 1; // LC-Ignored: Intentional, all Android desktop flags are disabled - ENABLE_TASKBAR_OVERFLOW.isTrue()
         int overflowSize = 0;
         boolean hasOverflow = false;
         if (supportsOverflow && mTaskbarOverflowView != null) {
@@ -827,7 +827,7 @@ public class TaskbarView extends FrameLayout implements FolderIcon.FolderIconPar
             removeAndRecycle(getChildAt(mNextViewIndex));
         }
 
-        if (ENABLE_TASKBAR_RECENTS_LAYOUT_TRANSITION.isTrue() && mIsRtl && hasOverflow) {
+        if (false && mIsRtl && hasOverflow) { // LC-Ignored: Intentional, all Android desktop flags are disabled - ENABLE_TASKBAR_RECENTS_LAYOUT_TRANSITION.isTrue()
             if (mPrevOverflowTasks.isEmpty()) {
                 addView(mTaskbarOverflowView, mNextViewIndex);
             }

--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarViewCallbacks.java
+++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarViewCallbacks.java
@@ -123,7 +123,7 @@ public class TaskbarViewCallbacks {
 
     /** Callback invoked before Taskbar icons are laid out. */
     void onPreLayoutChildren() {
-        if (enableTaskbarPinning() && ENABLE_TASKBAR_RECENTS_LAYOUT_TRANSITION.isTrue()) {
+        if (enableTaskbarPinning() && false) { // LC-Ignored: Intentional, all Android desktop flags are disabled -  ENABLE_TASKBAR_RECENTS_LAYOUT_TRANSITION.isTrue()
             mControllers.taskbarViewController.updateTaskbarIconTranslationXForPinning();
         }
     }

--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarViewController.java
+++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarViewController.java
@@ -194,7 +194,7 @@ public class TaskbarViewController implements TaskbarControllers.LoggableTaskbar
 
     private final View.OnLayoutChangeListener mTaskbarViewLayoutChangeListener =
             (v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
-                if (!ENABLE_TASKBAR_RECENTS_LAYOUT_TRANSITION.isTrue()) {
+                if (!false) { // LC-Ignored: Intentional, all Android desktop flags are disabled - ENABLE_TASKBAR_RECENTS_LAYOUT_TRANSITION.isTrue()
                     // update shiftX is handled with the animation at the end of the method
                     updateTaskbarIconTranslationXForPinning(/* updateShiftXForBubbleBar = */ false);
                 }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Unlike initial Baklava 8a6eb2a4ffd78c0e819fb3d1abc57b600887fbf1 that I made earlier, this one is only nullifying desktop experience flags.

Still have the same bug, and problem discussed in internal chat with Baklava.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Initial Android 15 QPR2 for testing.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Testing environment used during development:
* 📱 Nothing (3a)-series | Android 15 QPR2

1. Set Lawnchair as Recents provider
2. Observe


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled taskbar overflow view functionality
  * Disabled external display taskbar support
  * Disabled taskbar behavior behind notification panel
  * Disabled taskbar recents layout transitions

* **Documentation**
  * Updated Android 15 QPR2 device compatibility information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->