### PR TITLE
feat: Use reflection to open quick settings

### DIFF
--- a/lawnchair/src/app/lawnchair/gestures/handlers/OpenQuickSettingsHandler.kt
+++ b/lawnchair/src/app/lawnchair/gestures/handlers/OpenQuickSettingsHandler.kt
@@ -1,18 +1,33 @@
 package app.lawnchair.gestures.handlers
 
 import android.accessibilityservice.AccessibilityService
+import android.annotation.SuppressLint
 import android.content.Context
+import android.util.Log
 import app.lawnchair.LawnchairLauncher
 import com.android.launcher3.R
 
 class OpenQuickSettingsHandler(
     context: Context,
 ) : GestureHandler(context) {
+
+    @SuppressLint("WrongConstant")
     override suspend fun onTrigger(launcher: LawnchairLauncher) {
-        GestureWithAccessibilityHandler.onTrigger(
-            launcher,
-            R.string.quick_settings_a11y_hint,
-            AccessibilityService.GLOBAL_ACTION_QUICK_SETTINGS,
-        )
+        try {
+            Log.v(OpenQuickSettingsHandler::class.java.simpleName, "(Tried reflection)")
+            Class.forName("android.app.StatusBarManager")
+                .getMethod("expandSettingsPanel")
+                .apply { isAccessible = true }
+                .invoke(context.getSystemService("statusbar"))
+        } catch (e: Exception) {
+            e.printStackTrace()
+
+            // Fallback to a11y service
+            GestureWithAccessibilityHandler.onTrigger(
+                launcher,
+                R.string.quick_settings_a11y_hint,
+                AccessibilityService.GLOBAL_ACTION_QUICK_SETTINGS,
+            )
+        }
     }
 }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->
Set QuickSettings handler to use reflection by default, then fallback to accessibility access. Mirrors the pattern shown in the Notifications handler.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Tested on Google Pixel emulators

1. Set any gesture provider to use Quick Settings
2. Test the gesture
3. Quick Settings should open
4. If it doesn't open, popup to enable accessibility service will appear

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **New feature** (A non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Quick Settings gesture reliability with enhanced error handling and fallback mechanism to ensure consistent performance when opening Quick Settings across all devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->