### PR TITLE
fix: Reimplement folder label in dock toggle

### DIFF
--- a/src/com/android/launcher3/WorkspaceLayoutManager.java
+++ b/src/com/android/launcher3/WorkspaceLayoutManager.java
@@ -26,6 +26,9 @@ import com.android.launcher3.folder.Folder;
 import com.android.launcher3.folder.FolderIcon;
 import com.android.launcher3.model.data.ItemInfo;
 import com.android.launcher3.touch.ItemLongClickListener;
+
+import app.lawnchair.preferences2.PreferenceManager2;
+import com.patrykmichalik.opto.core.PreferenceExtensionsKt;
 import com.android.launcher3.util.IntSet;
 
 public interface WorkspaceLayoutManager {
@@ -105,9 +108,12 @@ public interface WorkspaceLayoutManager {
                 || container == LauncherSettings.Favorites.CONTAINER_HOTSEAT_PREDICTION) {
             layout = getHotseat();
 
-            // Hide folder title in the hotseat
+            // Show/hide folder title based on dock label preference
             if (child instanceof FolderIcon) {
-                ((FolderIcon) child).setTextVisible(false);
+                ((FolderIcon) child).setTextVisible(
+                        PreferenceExtensionsKt.firstBlocking(
+                                PreferenceManager2.getInstance(child.getContext())
+                                        .getEnableLabelInDock()));
             }
         } else {
             // Show folder title if not in the hotseat

--- a/src/com/android/launcher3/WorkspaceLayoutManager.java
+++ b/src/com/android/launcher3/WorkspaceLayoutManager.java
@@ -108,12 +108,12 @@ public interface WorkspaceLayoutManager {
                 || container == LauncherSettings.Favorites.CONTAINER_HOTSEAT_PREDICTION) {
             layout = getHotseat();
 
-            // Show/hide folder title based on dock label preference
+            // Hide folder title in the hotseat
             if (child instanceof FolderIcon) {
                 ((FolderIcon) child).setTextVisible(
                         PreferenceExtensionsKt.firstBlocking(
                                 PreferenceManager2.getInstance(child.getContext())
-                                        .getEnableLabelInDock()));
+                                        .getEnableLabelInDock())); // LC-Note: Show/hide folder title based on dock label preference
             }
         } else {
             // Show folder title if not in the hotseat


### PR DESCRIPTION
### Description

Folder icons in the dock now respect the "Show labels" dock preference instead of always hiding their label.

Fixes #6380

### Reasoning

`WorkspaceLayoutManager` unconditionally called `setTextVisible(false)` for `FolderIcon` in the hotseat, ignoring the `enableLabelInDock` preference. `BubbleTextView` already handled this correctly in `CellLayout`.

### Testing

1. Place a folder in the dock
2. Go to Settings → Dock → enable "Show labels"
3. Folder label should now be visible in the dock

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dock (hotseat) folder labels now respect the "show labels in dock" preference instead of always being hidden. Folder titles in the dock will now appear or remain hidden according to your launcher setting, matching label behavior on the home screen and ensuring consistent visibility between dock and workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->