### PR TITLE
feat: add intent to apply icon packs externally

### DIFF
--- a/lawnchair/AndroidManifest.xml
+++ b/lawnchair/AndroidManifest.xml
@@ -107,6 +107,16 @@
             tools:node="remove" />
 
         <activity
+            android:name="app.lawnchair.ui.ApplyIconPackActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Transparent">
+            <intent-filter>
+                <action android:name="app.lawnchair.APPLY_ICONS" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name="app.lawnchair.BlankActivity"
             android:theme="@style/Theme.Transparent" />
 

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -272,7 +272,6 @@
     <!-- General strings -->
     <string name="icon_style_label">Icon style</string>
     <string name="apply_icon_pack_title">Apply icon pack</string>
-    <string name="apply_icon_pack_message">Apply %1$s as your icon pack?</string>
     <string name="icon_shape_label">Icon shape</string>
     <string name="icon_sizes">Icon size</string>
 

--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -271,6 +271,8 @@
     -->
     <!-- General strings -->
     <string name="icon_style_label">Icon style</string>
+    <string name="apply_icon_pack_title">Apply icon pack</string>
+    <string name="apply_icon_pack_message">Apply %1$s as your icon pack?</string>
     <string name="icon_shape_label">Icon shape</string>
     <string name="icon_sizes">Icon size</string>
 

--- a/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
@@ -34,6 +34,11 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -44,6 +49,8 @@ import app.lawnchair.ui.theme.EdgeToEdge
 import app.lawnchair.ui.theme.LawnchairTheme
 import com.android.launcher3.R
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class ApplyIconPackActivity : ComponentActivity() {
 
@@ -62,29 +69,38 @@ class ApplyIconPackActivity : ComponentActivity() {
             return
         }
 
-        val packInfo = resolveIconPackInfo(packPackageName)
-        if (packInfo == null) {
-            finish()
-            return
-        }
-
         setContent {
-            LawnchairTheme {
-                EdgeToEdge()
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = BottomSheetDefaults.ScrimColor,
-                ) {
-                    ApplyIconPackDialog(
-                        packName = packInfo.first,
-                        packIcon = packInfo.second,
-                        onConfirm = {
-                            PreferenceManager.getInstance(this@ApplyIconPackActivity)
-                                .iconPackPackage.set(packPackageName)
-                            finish()
-                        },
-                        onDismiss = { finish() },
-                    )
+            var packInfo by remember { mutableStateOf<Pair<String, Drawable>?>(null) }
+            var resolved by remember { mutableStateOf(false) }
+
+            LaunchedEffect(packPackageName) {
+                val result = withContext(Dispatchers.Default) {
+                    resolveIconPackInfo(packPackageName)
+                }
+                packInfo = result
+                resolved = true
+                if (result == null) finish()
+            }
+
+            val info = packInfo
+            if (resolved && info != null) {
+                LawnchairTheme {
+                    EdgeToEdge()
+                    Surface(
+                        modifier = Modifier.fillMaxSize(),
+                        color = BottomSheetDefaults.ScrimColor,
+                    ) {
+                        ApplyIconPackDialog(
+                            packName = info.first,
+                            packIcon = info.second,
+                            onConfirm = {
+                                PreferenceManager.getInstance(this@ApplyIconPackActivity)
+                                    .iconPackPackage.set(packPackageName)
+                                finish()
+                            },
+                            onDismiss = { finish() },
+                        )
+                    }
                 }
             }
         }

--- a/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026, Lawnchair
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.lawnchair.ui
+
+import android.graphics.drawable.Drawable
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.lawnchair.icons.CustomAdaptiveIconDrawable
+import app.lawnchair.preferences.PreferenceManager
+import app.lawnchair.ui.preferences.iconPackIntents
+import app.lawnchair.ui.theme.EdgeToEdge
+import app.lawnchair.ui.theme.LawnchairTheme
+import com.android.launcher3.R
+import com.google.accompanist.drawablepainter.rememberDrawablePainter
+
+class ApplyIconPackActivity : ComponentActivity() {
+
+    companion object {
+        const val EXTRA_PACKAGE_NAME = "packageName"
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        val packPackageName = intent.getStringExtra(EXTRA_PACKAGE_NAME)
+        if (packPackageName.isNullOrEmpty()) {
+            finish()
+            return
+        }
+
+        val packInfo = resolveIconPackInfo(packPackageName)
+        if (packInfo == null) {
+            finish()
+            return
+        }
+
+        setContent {
+            LawnchairTheme {
+                EdgeToEdge()
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = BottomSheetDefaults.ScrimColor,
+                ) {
+                    ApplyIconPackDialog(
+                        packName = packInfo.first,
+                        packIcon = packInfo.second,
+                        onConfirm = {
+                            PreferenceManager.getInstance(this@ApplyIconPackActivity)
+                                .iconPackPackage.set(packPackageName)
+                            finish()
+                        },
+                        onDismiss = { finish() },
+                    )
+                }
+            }
+        }
+    }
+
+    private fun resolveIconPackInfo(packageName: String): Pair<String, Drawable>? {
+        val pm = this.packageManager
+        val resolveInfo = iconPackIntents
+            .flatMap { pm.queryIntentActivities(it, 0) }
+            .firstOrNull { it.activityInfo.packageName == packageName }
+            ?: return null
+        val name = resolveInfo.loadLabel(pm).toString()
+        val icon = CustomAdaptiveIconDrawable.wrapNonNull(resolveInfo.loadIcon(pm))
+        return name to icon
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun ApplyIconPackDialog(
+    packName: String,
+    packIcon: Drawable,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                shapes = ButtonDefaults.shapes(),
+            ) {
+                Text(text = stringResource(id = R.string.action_apply))
+            }
+        },
+        dismissButton = {
+            OutlinedButton(
+                onClick = onDismiss,
+                shapes = ButtonDefaults.shapes(),
+            ) {
+                Text(text = stringResource(id = android.R.string.cancel))
+            }
+        },
+        icon = {
+            Image(
+                painter = rememberDrawablePainter(drawable = packIcon),
+                contentDescription = packName,
+                modifier = Modifier.size(48.dp),
+            )
+        },
+        title = {
+            Text(text = stringResource(id = R.string.apply_icon_pack_title))
+        },
+        text = {
+            Text(
+                text = stringResource(id = R.string.apply_icon_pack_message, packName),
+            )
+        },
+    )
+}

--- a/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
@@ -22,17 +22,21 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -44,6 +48,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import app.lawnchair.icons.CustomAdaptiveIconDrawable
 import app.lawnchair.preferences.PreferenceManager
+import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
+import app.lawnchair.ui.preferences.components.layout.PreferenceTemplate
 import app.lawnchair.ui.preferences.iconPackIntents
 import app.lawnchair.ui.theme.EdgeToEdge
 import app.lawnchair.ui.theme.LawnchairTheme
@@ -63,11 +69,8 @@ class ApplyIconPackActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        val packPackageName = intent.getStringExtra(EXTRA_PACKAGE_NAME)
-        if (packPackageName.isNullOrEmpty()) {
-            finish()
-            return
-        }
+        val packPackageName = intent.getStringExtra(EXTRA_PACKAGE_NAME).orEmpty()
+        if (packPackageName.isEmpty()) finish()
 
         setContent {
             var packInfo by remember { mutableStateOf<Pair<String, Drawable>?>(null) }
@@ -90,7 +93,7 @@ class ApplyIconPackActivity : ComponentActivity() {
                         modifier = Modifier.fillMaxSize(),
                         color = BottomSheetDefaults.ScrimColor,
                     ) {
-                        ApplyIconPackDialog(
+                        ApplyIconPackSheet(
                             packName = info.first,
                             packIcon = info.second,
                             onConfirm = {
@@ -118,46 +121,52 @@ class ApplyIconPackActivity : ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun ApplyIconPackDialog(
+private fun ApplyIconPackSheet(
     packName: String,
     packIcon: Drawable,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    AlertDialog(
+    ModalBottomSheet(
         onDismissRequest = onDismiss,
-        confirmButton = {
-            Button(
-                onClick = onConfirm,
-                shapes = ButtonDefaults.shapes(),
-            ) {
-                Text(text = stringResource(id = R.string.action_apply))
-            }
-        },
-        dismissButton = {
-            OutlinedButton(
-                onClick = onDismiss,
-                shapes = ButtonDefaults.shapes(),
-            ) {
-                Text(text = stringResource(id = android.R.string.cancel))
-            }
-        },
-        icon = {
-            Image(
-                painter = rememberDrawablePainter(drawable = packIcon),
-                contentDescription = packName,
-                modifier = Modifier.size(48.dp),
-            )
-        },
-        title = {
-            Text(text = stringResource(id = R.string.apply_icon_pack_title))
-        },
-        text = {
-            Text(
-                text = stringResource(id = R.string.apply_icon_pack_message, packName),
-            )
-        },
-    )
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        ModalBottomSheetContent(
+            title = { Text(text = stringResource(id = R.string.apply_icon_pack_title)) },
+            content = {
+                PreferenceGroup {
+                    Item {
+                        PreferenceTemplate(
+                            title = { Text(text = packName) },
+                            startWidget = {
+                                Image(
+                                    painter = rememberDrawablePainter(drawable = packIcon),
+                                    contentDescription = packName,
+                                    modifier = Modifier.size(36.dp),
+                                )
+                            },
+                        )
+                    }
+                }
+            },
+            buttons = {
+                OutlinedButton(
+                    onClick = onDismiss,
+                    shapes = ButtonDefaults.shapes(),
+                ) {
+                    Text(text = stringResource(id = android.R.string.cancel))
+                }
+                Spacer(modifier = Modifier.requiredWidth(8.dp))
+                Button(
+                    onClick = onConfirm,
+                    shapes = ButtonDefaults.shapes(),
+                ) {
+                    Text(text = stringResource(id = R.string.action_apply))
+                }
+            },
+        )
+    }
 }

--- a/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
@@ -23,10 +23,8 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -34,7 +32,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -89,21 +86,16 @@ class ApplyIconPackActivity : ComponentActivity() {
             if (resolved && info != null) {
                 LawnchairTheme {
                     EdgeToEdge()
-                    Surface(
-                        modifier = Modifier.fillMaxSize(),
-                        color = BottomSheetDefaults.ScrimColor,
-                    ) {
-                        ApplyIconPackSheet(
-                            packName = info.first,
-                            packIcon = info.second,
-                            onConfirm = {
-                                PreferenceManager.getInstance(this@ApplyIconPackActivity)
-                                    .iconPackPackage.set(packPackageName)
-                                finish()
-                            },
-                            onDismiss = { finish() },
-                        )
-                    }
+                    ApplyIconPackSheet(
+                        packName = info.first,
+                        packIcon = info.second,
+                        onConfirm = {
+                            PreferenceManager.getInstance(this@ApplyIconPackActivity)
+                                .iconPackPackage.set(packPackageName)
+                            finish()
+                        },
+                        onDismiss = { finish() },
+                    )
                 }
             }
         }

--- a/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
@@ -67,7 +67,10 @@ class ApplyIconPackActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         val packPackageName = intent.getStringExtra(EXTRA_PACKAGE_NAME).orEmpty()
-        if (packPackageName.isEmpty()) finish()
+        if (packPackageName.isEmpty()) {
+            finish()
+            return
+        }
 
         setContent {
             var packInfo by remember { mutableStateOf<Pair<String, Drawable>?>(null) }

--- a/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
+++ b/lawnchair/src/app/lawnchair/ui/ApplyIconPackActivity.kt
@@ -77,7 +77,7 @@ class ApplyIconPackActivity : ComponentActivity() {
             var resolved by remember { mutableStateOf(false) }
 
             LaunchedEffect(packPackageName) {
-                val result = withContext(Dispatchers.Default) {
+                val result = withContext(Dispatchers.IO) {
                     resolveIconPackInfo(packPackageName)
                 }
                 packInfo = result

--- a/lawnchair/src/app/lawnchair/ui/preferences/PreferenceViewModel.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/PreferenceViewModel.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 
-private val iconPackIntents = listOf(
+internal val iconPackIntents = listOf(
     Intent("com.novalauncher.THEME"),
     Intent("org.adw.launcher.icons.ACTION_PICK_ICON"),
     Intent("com.dlto.atom.launcher.THEME"),


### PR DESCRIPTION
## Summary

Implements #6594 — adds support for applying icon packs via an external intent (`app.lawnchair.APPLY_ICONS`), allowing third-party icon pack apps to directly apply their icon pack to Lawnchair.

## Changes

- **New:** `ApplyIconPackActivity` — handles the intent, validates the icon pack, and shows a Material3 confirmation dialog
- **Modified:** `AndroidManifest.xml` — registers the activity with `exported=true` and intent-filter
- **Modified:** `strings.xml` — adds dialog title/message strings
- **Modified:** `PreferenceViewModel.kt` — makes `iconPackIntents` internal for reuse

## How it works

1. Icon pack app sends: `Intent("app.lawnchair.APPLY_ICONS").putExtra("packageName", pkgName)`
2. Lawnchair validates the package is a legitimate icon pack
3. Shows confirmation dialog with icon pack name and icon
4. User confirms → icon pack is applied; cancels → activity finishes
5. Invalid/missing package → activity finishes silently

## Testing

- Compiled successfully against `lawnWithQuickstepGithubDebug`

Closes #6594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Icon pack apply confirmation: a bottom sheet shows the pack name and preview with Cancel or Apply; Apply saves the chosen icon pack to preferences.

* **UI**
  * Edge-to-edge, translucent-styled confirmation for a seamless, immersive experience.

* **Localization**
  * Added "Apply icon pack" title for the confirmation UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->