### PR TITLE
feat: screen off method preference

### DIFF
--- a/lawnchair/res/values/strings.xml
+++ b/lawnchair/res/values/strings.xml
@@ -616,6 +616,12 @@
     <string name="generic_a11y_hint">To %1$s, turn on the Lawnchair accessibility service. Tap \"Open settings\", select \"Lawnchair\" and turn on \"Use Lawnchair.\"</string>
     <string name="generic_a11y_disclaimer">Lawnchair uses Accessibility\'s `performGlobalAction` method to perform this action. This is a sensitive permission that allows monitoring other apps. However, Lawnchair is not configured for that functionality and receives no events.</string>
 
+    <string name="sleep_mode_label">Sleep mode</string>
+    <string name="sleep_mode_auto">Automatic</string>
+    <string name="sleep_mode_root">Root</string>
+    <string name="sleep_mode_accessibility">Accessibility service</string>
+    <string name="sleep_mode_device_admin">Device admin</string>
+
     <!--
 
     Bug reporting

--- a/lawnchair/src/app/lawnchair/gestures/handlers/SleepGestureHandler.kt
+++ b/lawnchair/src/app/lawnchair/gestures/handlers/SleepGestureHandler.kt
@@ -25,16 +25,31 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import app.lawnchair.LawnchairLauncher
+import app.lawnchair.preferences2.PreferenceManager2
 import app.lawnchair.util.requireSystemService
 import app.lawnchair.views.ComposeBottomSheet
 import com.android.launcher3.R
 import com.android.launcher3.Utilities
 import com.topjohnwu.superuser.Shell
+import kotlinx.coroutines.flow.first
 
 class SleepGestureHandler(context: Context) : GestureHandler(context) {
 
     override suspend fun onTrigger(launcher: LawnchairLauncher) {
-        methods.first { it.isSupported() }.sleep(launcher)
+        val pref = PreferenceManager2.getInstance(context).sleepMode.get().first()
+        val method = when (pref) {
+            SleepMode.AUTO -> methods.first { it.isSupported() }
+            SleepMode.ROOT -> methods.filterIsInstance<SleepMethodRoot>().first()
+            SleepMode.ACCESSIBILITY -> methods.filterIsInstance<SleepMethodPieAccessibility>().first()
+            SleepMode.DEVICE_ADMIN -> methods.filterIsInstance<SleepMethodDeviceAdmin>().first()
+        }
+
+        if (pref != SleepMode.AUTO && !method.isSupported()) {
+            methods.first { it.isSupported() }.sleep(launcher)
+            return
+        }
+
+        method.sleep(launcher)
     }
 
     private val methods = listOf(

--- a/lawnchair/src/app/lawnchair/gestures/handlers/SleepMode.kt
+++ b/lawnchair/src/app/lawnchair/gestures/handlers/SleepMode.kt
@@ -1,0 +1,34 @@
+package app.lawnchair.gestures.handlers
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.res.stringResource
+import app.lawnchair.ui.preferences.components.controls.ListPreferenceEntry
+import com.android.launcher3.R
+
+enum class SleepMode(
+    @StringRes val labelResourceId: Int,
+) {
+    AUTO(
+        labelResourceId = R.string.sleep_mode_auto,
+    ),
+    ROOT(
+        labelResourceId = R.string.sleep_mode_root,
+    ),
+    ACCESSIBILITY(
+        labelResourceId = R.string.sleep_mode_accessibility,
+    ),
+    DEVICE_ADMIN(
+        labelResourceId = R.string.sleep_mode_device_admin,
+    ),
+    ;
+
+    companion object {
+        fun values() = enumValues<SleepMode>().toList()
+
+        fun fromString(string: String) = values().firstOrNull { it.toString() == string }
+
+        fun entries(): List<ListPreferenceEntry<SleepMode>> = values().map {
+            ListPreferenceEntry(value = it) { stringResource(id = it.labelResourceId) }
+        }
+    }
+}

--- a/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
+++ b/lawnchair/src/app/lawnchair/preferences2/PreferenceManager2.kt
@@ -31,6 +31,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import app.lawnchair.data.Converters
 import app.lawnchair.font.FontCache
 import app.lawnchair.gestures.config.GestureHandlerConfig
+import app.lawnchair.gestures.handlers.SleepMode
 import app.lawnchair.gestures.type.GestureType
 import app.lawnchair.hotseat.HotseatMode
 import app.lawnchair.icons.CustomAdaptiveIconDrawable
@@ -745,6 +746,13 @@ class PreferenceManager2 @Inject constructor(
     val doubleTapGestureHandler = serializablePreference<GestureHandlerConfig>(
         key = stringPreferencesKey("double_tap_gesture_handler"),
         defaultValue = GestureHandlerConfig.Sleep,
+    )
+
+    val sleepMode = preference(
+        key = stringPreferencesKey(name = "sleep_mode"),
+        defaultValue = SleepMode.AUTO,
+        parse = { SleepMode.fromString(it) ?: SleepMode.AUTO },
+        save = { it.toString() },
     )
 
     val swipeUpGestureHandler = serializablePreference<GestureHandlerConfig>(

--- a/lawnchair/src/app/lawnchair/ui/preferences/destinations/GesturePreferences.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/destinations/GesturePreferences.kt
@@ -3,10 +3,12 @@ package app.lawnchair.ui.preferences.destinations
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import app.lawnchair.gestures.handlers.SleepMode
 import app.lawnchair.preferences.getAdapter
 import app.lawnchair.preferences2.preferenceManager2
 import app.lawnchair.ui.preferences.LocalIsExpandedScreen
 import app.lawnchair.ui.preferences.components.GestureHandlerPreference
+import app.lawnchair.ui.preferences.components.controls.ListPreference
 import app.lawnchair.ui.preferences.components.layout.PreferenceGroup
 import app.lawnchair.ui.preferences.components.layout.PreferenceLayout
 import com.android.launcher3.R
@@ -62,6 +64,15 @@ fun GesturePreferences(
                 GestureHandlerPreference(
                     adapter = prefs.backPressGestureHandler.getAdapter(),
                     label = stringResource(id = R.string.gesture_back_tap),
+                )
+            }
+        }
+        PreferenceGroup(heading = stringResource(id = R.string.sleep_mode_label)) {
+            Item {
+                ListPreference(
+                    adapter = prefs.sleepMode.getAdapter(),
+                    entries = SleepMode.entries(),
+                    label = stringResource(id = R.string.sleep_mode_label),
                 )
             }
         }


### PR DESCRIPTION
### Description

  Add a user-facing preference to select the sleep method (screen-off method) for gestures. Users can now choose between
  Automatic (existing fallback chain), Root, Accessibility Service, or Device Admin — allowing them to bypass the unreliable
   accessibility service on OEM ROMs that aggressively kill it.

  Fixes #6463

  ### Reasoning

  Many OEM ROMs (Xiaomi, Huawei, OPPO, etc.) frequently kill accessibility services for battery optimization, making the
  double-tap-to-sleep gesture unreliable on non-rooted devices. The Device Admin method (`DevicePolicyManager.lockNow()`) is
   immune to this issue but was previously only used as a last-resort fallback. This change gives users explicit control
  over which method to use, similar to Nova Launcher's approach.

  Core principles of the solution:
  - Follow existing codebase patterns (`ColorMode` enum + `ListPreference` UI + `PreferenceManager2` storage)
  - Options are always selectable; authorization is prompted on first trigger, not at selection time
  - Default is "Automatic" preserving backward compatibility for existing users
  - Type-safe dispatch using named references instead of fragile index-based access

  ### Testing

  1. Open Lawnchair Settings → Gestures
  2. Verify "Sleep method" preference group appears below the gesture list
  3. Tap "Sleep method" — confirm 4 options: Automatic, Root, Accessibility service, Device admin
  4. Select "Device admin" → double-tap home screen → confirm device admin activation prompt appears
  5. After activating, double-tap again → screen should turn off
  6. Select "Automatic" → verify original fallback behavior is restored
  7. Select "Root" on a non-rooted device → double-tap → verify it attempts root (graceful failure)
  8. Uninstall/reinstall → verify default is "Automatic" with no crash

  ### Type of change

  :x: **Bug fix** (A non-breaking change that fixes an issue)
  :white_check_mark: **New feature** (A non-breaking change that adds functionality)
  :x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
  :x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
  :x: **Performance** (A code change that improves performance)
  :x: **Style** (Code style changes)
  :x: **Docs** (Changes to documentation)
  :x: **Chore** (Changes to the build process or other tooling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Sleep mode" preference in gesture settings with options: Automatic, Root, Accessibility, and Device Admin.
  * UI labels and option texts added for the new setting.
  * The selected sleep mode is persisted and used when triggering the sleep gesture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->