### PR TITLE
fix: Don't instantly make the announcement item opaque 

### DIFF
--- a/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
+++ b/lawnchair/src/app/lawnchair/ui/preferences/components/AnnouncementPreference.kt
@@ -153,15 +153,19 @@ private fun AnnouncementItemContent(
         },
     )
 
+    val alpha = if (state.targetValue == SwipeToDismissBoxValue.Settled) {
+        1f
+    } else {
+        calculateAlpha(state.progress)
+    }
+
     SwipeToDismissBox(
         state = state,
         enableDismissFromEndToStart = false,
         backgroundContent = {
             Surface(
                 modifier = modifier
-                    .alpha(
-                        if (state.dismissDirection != SwipeToDismissBoxValue.StartToEnd) 1f else calculateAlpha(state.progress),
-                    )
+                    .alpha(alpha)
                     .fillMaxSize()
                     .padding(16.dp, 0.dp, 16.dp, 0.dp),
                 shape = MaterialTheme.shapes.large,
@@ -178,9 +182,7 @@ private fun AnnouncementItemContent(
     ) {
         Surface(
             modifier = modifier
-                .alpha(
-                    if (state.dismissDirection != SwipeToDismissBoxValue.StartToEnd) 1f else calculateAlpha(state.progress),
-                )
+                .alpha(alpha)
                 .padding(16.dp, 0.dp, 16.dp, 0.dp),
             shape = MaterialTheme.shapes.large,
             color = MaterialTheme.colorScheme.surfaceVariant,


### PR DESCRIPTION

<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

When user is swiping on announcement item to dismiss, the card will disappear instantly even though the threshold for dismiss (of 0.5f) has not reached yet.

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Fix visual regressions

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Reset live information announcement from Debug menu 

Re-open LC prefs, and dismiss the card


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->
✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized announcement dismissal animation handling to improve code efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->