### PR TITLE
fix: Don't call archive status check on low APIs

### DIFF
--- a/src/com/android/launcher3/icons/IconCache.java
+++ b/src/com/android/launcher3/icons/IconCache.java
@@ -283,8 +283,8 @@ public class IconCache extends BaseIconCache {
     @SuppressWarnings("NewApi")
     public synchronized void getTitleAndIcon(ItemInfoWithIcon info,
             LauncherActivityInfo activityInfo, @NonNull CacheLookupFlag lookupFlag) {
-        boolean isAppArchived = Flags.enableSupportForArchiving() && activityInfo != null
-                && activityInfo.getActivityInfo().isArchived;
+        boolean isAppArchived = Utilities.ATLEAST_V && (Flags.enableSupportForArchiving() && activityInfo != null
+                && activityInfo.getActivityInfo().isArchived);
         // If we already have activity info, no need to use package icon
         getTitleAndIcon(info, () -> activityInfo, lookupFlag.withUsePackageIcon(isAppArchived));
     }

--- a/src/com/android/launcher3/model/ItemInstallQueue.java
+++ b/src/com/android/launcher3/model/ItemInstallQueue.java
@@ -49,6 +49,7 @@ import com.android.launcher3.InvariantDeviceProfile;
 import com.android.launcher3.Launcher;
 import com.android.launcher3.LauncherAppState;
 import com.android.launcher3.LauncherSettings.Favorites;
+import com.android.launcher3.Utilities;
 import com.android.launcher3.dagger.ApplicationContext;
 import com.android.launcher3.dagger.LauncherAppSingleton;
 import com.android.launcher3.dagger.LauncherBaseAppComponent;
@@ -325,7 +326,7 @@ public class ItemInstallQueue {
                         lai = laiList.get(0);
                         si.intent = makeLaunchIntent(lai);
                         try {
-                            if (Flags.enableSupportForArchiving()
+                            if (Utilities.ATLEAST_V && Flags.enableSupportForArchiving()
                                     && lai.getActivityInfo().isArchived) {
                                 si.runtimeStatusFlags |= FLAG_ARCHIVED;
                             }

--- a/src/com/android/launcher3/model/LoaderCursor.java
+++ b/src/com/android/launcher3/model/LoaderCursor.java
@@ -433,7 +433,7 @@ public class LoaderCursor extends CursorWrapper {
             boolean loadIconFromCache,
             WorkspaceItemInfo info
     ) {
-        boolean isPreArchived = Flags.enableSupportForArchiving()
+        boolean isPreArchived = Utilities.ATLEAST_V && Flags.enableSupportForArchiving()
                 && Flags.restoreArchivedAppIconsFromDb()
                 && info.isInactiveArchive()
                 && LauncherPrefs.get(mContext).get(LauncherPrefs.IS_FIRST_LOAD_AFTER_RESTORE);

--- a/src/com/android/launcher3/model/LoaderTask.java
+++ b/src/com/android/launcher3/model/LoaderTask.java
@@ -453,7 +453,7 @@ public class LoaderTask implements Runnable {
 
             final HashMap<PackageUserKey, SessionInfo> installingPkgs =
                     mSessionHelper.getActiveSessions();
-            if (Flags.enableSupportForArchiving()) {
+            if (Utilities.ATLEAST_V && Flags.enableSupportForArchiving()) {
                 mInstallingPkgsCached = installingPkgs;
             }
             installingPkgs.forEach(mIconCache::updateSessionCache);
@@ -642,7 +642,7 @@ public class LoaderTask implements Runnable {
                 AppInfo appInfo = new AppInfo(app, mUserCache.getUserInfo(user),
                         ApiWrapper.INSTANCE.get(mContext), mPmHelper, quietMode);
                 try {
-                    if (Flags.enableSupportForArchiving()) {
+                    if (Utilities.ATLEAST_V && Flags.enableSupportForArchiving()) {
                         if (app.getApplicationInfo().isArchived) {
                             // For archived apps, include progress info in case there is a pending
                             // install session post restart of device.

--- a/src/com/android/launcher3/model/PackageUpdatedTask.java
+++ b/src/com/android/launcher3/model/PackageUpdatedTask.java
@@ -41,6 +41,7 @@ import com.android.launcher3.Flags;
 import com.android.launcher3.LauncherModel.ModelUpdateTask;
 import com.android.launcher3.LauncherSettings.Favorites;
 import com.android.launcher3.R;
+import com.android.launcher3.Utilities;
 import com.android.launcher3.config.FeatureFlags;
 import com.android.launcher3.icons.IconCache;
 import com.android.launcher3.logging.FileLog;
@@ -350,7 +351,7 @@ public class PackageUpdatedTask implements ModelUpdateTask {
                             // In case an app is archived, we need to make sure that archived state
                             // in WorkspaceItemInfo is refreshed.
                             try {
-                                if (Flags.enableSupportForArchiving() && !activities.isEmpty()) {
+                                if (Utilities.ATLEAST_V && (Flags.enableSupportForArchiving() && !activities.isEmpty())) {
                                 boolean newArchivalState = activities.get(0)
                                         .getActivityInfo().isArchived;
                                 if (newArchivalState != itemInfo.isArchived()) {

--- a/src/com/android/launcher3/model/data/AppInfo.java
+++ b/src/com/android/launcher3/model/data/AppInfo.java
@@ -198,7 +198,7 @@ public class AppInfo extends ItemInfoWithIcon implements WorkspaceItemFactory {
         } else {
             info.runtimeStatusFlags &= ~FLAG_DISABLED_SUSPENDED;
         }
-        if (Flags.enableSupportForArchiving()) {
+        if (Utilities.ATLEAST_V && Flags.enableSupportForArchiving()) {
             try {
                 if (lai.getActivityInfo().isArchived) {
                     info.runtimeStatusFlags |= FLAG_ARCHIVED;

--- a/src/com/android/launcher3/model/data/ItemInfoWithIcon.java
+++ b/src/com/android/launcher3/model/data/ItemInfoWithIcon.java
@@ -182,6 +182,7 @@ public abstract class ItemInfoWithIcon extends ItemInfo {
      * Returns true if the app corresponding to the item is archived.
      */
     public boolean isArchived() {
+        if (!Utilities.ATLEAST_V) return false;
         if (!Flags.enableSupportForArchiving()) {
             return false;
         }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fixes issues reported by community @ Discord

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

App archiving feature is introduced in Android 15, lower apis can't access it.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Tested with Pixel 6 - Android 12.0 (AOSP-like, Test-harness mode)

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archived-app detection and presentation now consistently respect platform/version requirements across workspace, app list, installation, and update flows, preventing incorrect archived states on unsupported platform versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->