### PR TITLE
fix: Refresh icon preferences

### DIFF
--- a/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import app.lawnchair.icons.shape.IconShape
 import app.lawnchair.icons.shape.PathShapeDelegate
+import app.lawnchair.preferences.PreferenceChangeListener
 import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
 import com.android.launcher3.LauncherPrefs
@@ -20,8 +21,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
-
-// Lawnchair-TODO: investigate, wtf? KSP incremental no update this file, y? how? idk!??!?!
 
 @LauncherAppSingleton
 class LawnchairThemeManager
@@ -43,6 +42,8 @@ constructor(
 ) {
     override var iconState = parseIconStateV2(null)
 
+    private val prefListener = PreferenceChangeListener { verifyIconState() }
+
     init {
         val scope = MainScope()
         merge(
@@ -51,14 +52,19 @@ constructor(
         ).onEach { verifyIconState() }
             .launchIn(scope)
 
-        prefs1.wrapAdaptiveIcons.addListener { verifyIconState() }
-        prefs1.transparentIconBackground.addListener { verifyIconState() }
-        prefs1.shadowBGIcons.addListener { verifyIconState() }
-        prefs1.coloredBackgroundLightness.addListener { verifyIconState() }
-        prefs1.forceIconMonochrome.addListener { verifyIconState() }
+        prefs1.wrapAdaptiveIcons.addListener(prefListener)
+        prefs1.transparentIconBackground.addListener(prefListener)
+        prefs1.shadowBGIcons.addListener(prefListener)
+        prefs1.coloredBackgroundLightness.addListener(prefListener)
+        prefs1.forceIconMonochrome.addListener(prefListener)
 
         lifecycle.addCloseable {
             scope.cancel()
+            prefs1.wrapAdaptiveIcons.removeListener(prefListener)
+            prefs1.transparentIconBackground.removeListener(prefListener)
+            prefs1.shadowBGIcons.removeListener(prefListener)
+            prefs1.coloredBackgroundLightness.removeListener(prefListener)
+            prefs1.forceIconMonochrome.removeListener(prefListener)
         }
     }
 

--- a/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
@@ -82,6 +82,10 @@ constructor(
         listeners.forEach { it.onThemeChanged() }
     }
 
+    private fun prefs1State(): String = "${prefs1.wrapAdaptiveIcons.get()},${prefs1.transparentIconBackground.get()}," +
+        "${prefs1.shadowBGIcons.get()},${prefs1.coloredBackgroundLightness.get()}," +
+        "${prefs1.forceIconMonochrome.get()}"
+
     private fun parseIconStateV2(oldState: IconState?): IconState {
         val currentAppShape: IconShape = try {
             prefs2.iconShape.firstBlocking()
@@ -97,12 +101,8 @@ constructor(
             IconShape.Circle
         }
 
-        var appShapeKey = currentAppShape.getHashString()
-        var folderShapeKey = currentFolderShape.getHashString()
-
-        val prefSuffix = "${prefs1.wrapAdaptiveIcons.get()},${prefs1.transparentIconBackground.get()},${prefs1.shadowBGIcons.get()},${prefs1.coloredBackgroundLightness.get()},${prefs1.forceIconMonochrome.get()}"
-        appShapeKey += prefSuffix
-        folderShapeKey += prefSuffix
+        val appShapeKey = currentAppShape.getHashString() + prefs1State()
+        val folderShapeKey = currentFolderShape.getHashString() + prefs1State()
 
         val appShape =
             if (oldState != null && oldState.iconMask == appShapeKey) {

--- a/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
@@ -4,11 +4,9 @@ import android.content.Context
 import android.util.Log
 import app.lawnchair.icons.shape.IconShape
 import app.lawnchair.icons.shape.PathShapeDelegate
+import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
-import com.android.launcher3.EncryptionType
-import com.android.launcher3.LauncherPrefChangeListener
 import com.android.launcher3.LauncherPrefs
-import com.android.launcher3.LauncherPrefs.Companion.backedUpItem
 import com.android.launcher3.concurrent.annotations.Ui
 import com.android.launcher3.dagger.ApplicationContext
 import com.android.launcher3.dagger.LauncherAppSingleton
@@ -23,6 +21,8 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 
+// Lawnchair-TODO: investigate, wtf? KSP incremental no update this file, y? how? idk!??!?!
+
 @LauncherAppSingleton
 class LawnchairThemeManager
 @Inject
@@ -33,6 +33,7 @@ constructor(
     private val iconControllerFactory: IconControllerFactory,
     private val lifecycle: DaggerSingletonTracker,
     private val prefs2: PreferenceManager2,
+    private val prefs1: PreferenceManager,
 ) : ThemeManager(
     context,
     uiExecutor,
@@ -50,20 +51,13 @@ constructor(
         ).onEach { verifyIconState() }
             .launchIn(scope)
 
-        // Listen for specific Lawnchair SharedPreferences it's easier than trying to make prefs1 work with listener
-        val drawerThemedIcons = backedUpItem("drawer_themed_icons", false, EncryptionType.DEVICE_PROTECTED)
-        val forceMonochrome = backedUpItem("pref_forceIconMonochrome", false, EncryptionType.DEVICE_PROTECTED)
-        val keys = listOf(drawerThemedIcons, forceMonochrome)
-        val keysArray = keys.toTypedArray()
-        val prefKeySet = keys.map { it.sharedPrefKey }
-
-        val prefListener = LauncherPrefChangeListener { key ->
-            if (prefKeySet.contains(key)) verifyIconState()
-        }
-        prefs.addListener(prefListener, *keysArray)
+        prefs1.wrapAdaptiveIcons.addListener { verifyIconState() }
+        prefs1.transparentIconBackground.addListener { verifyIconState() }
+        prefs1.shadowBGIcons.addListener { verifyIconState() }
+        prefs1.coloredBackgroundLightness.addListener { verifyIconState() }
+        prefs1.forceIconMonochrome.addListener { verifyIconState() }
 
         lifecycle.addCloseable {
-            prefs.removeListener(prefListener, *keysArray)
             scope.cancel()
         }
     }
@@ -91,8 +85,12 @@ constructor(
             IconShape.Circle
         }
 
-        val appShapeKey = currentAppShape.getHashString()
-        val folderShapeKey = currentFolderShape.getHashString()
+        var appShapeKey = currentAppShape.getHashString()
+        var folderShapeKey = currentFolderShape.getHashString()
+
+        val prefSuffix = "${prefs1.wrapAdaptiveIcons.get()},${prefs1.transparentIconBackground.get()},${prefs1.shadowBGIcons.get()},${prefs1.coloredBackgroundLightness.get()},${prefs1.forceIconMonochrome.get()}"
+        appShapeKey += prefSuffix
+        folderShapeKey += prefSuffix
 
         val appShape =
             if (oldState != null && oldState.iconMask == appShapeKey) {

--- a/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
@@ -42,11 +42,19 @@ constructor(
     iconControllerFactory,
     lifecycle,
 ) {
-    override var iconState = parseIconStateV2(null)
+    private val statePrefs1 = listOf(
+        prefs1.wrapAdaptiveIcons,
+        prefs1.transparentIconBackground,
+        prefs1.shadowBGIcons,
+        prefs1.coloredBackgroundLightness,
+        prefs1.forceIconMonochrome,
+    )
 
     private val prefListener = PreferenceChangeListener {
         uiExecutor.execute { verifyIconState() }
     }
+
+    override var iconState = parseIconStateV2(null)
 
     init {
         val scope = MainScope() + CoroutineName("LawnchairThemeManager")
@@ -56,13 +64,6 @@ constructor(
         ).onEach { verifyIconState() }
             .launchIn(scope)
 
-        val statePrefs1 = listOf(
-            prefs1.wrapAdaptiveIcons,
-            prefs1.transparentIconBackground,
-            prefs1.shadowBGIcons,
-            prefs1.coloredBackgroundLightness,
-            prefs1.forceIconMonochrome,
-        )
         statePrefs1.forEach { it.addListener(prefListener) }
 
         lifecycle.addCloseable {
@@ -79,9 +80,7 @@ constructor(
         listeners.forEach { it.onThemeChanged() }
     }
 
-    private fun prefs1State(): String = "${prefs1.wrapAdaptiveIcons.get()},${prefs1.transparentIconBackground.get()}," +
-        "${prefs1.shadowBGIcons.get()},${prefs1.coloredBackgroundLightness.get()}," +
-        "${prefs1.forceIconMonochrome.get()}"
+    private fun prefs1State(): String = statePrefs1.joinToString(",") { it.get().toString() }
 
     private fun parseIconStateV2(oldState: IconState?): IconState {
         val currentAppShape: IconShape = try {

--- a/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
@@ -16,11 +16,15 @@ import com.android.launcher3.util.DaggerSingletonTracker
 import com.android.launcher3.util.LooperExecutor
 import com.patrykmichalik.opto.core.firstBlocking
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
 
 @LauncherAppSingleton
 class LawnchairThemeManager
@@ -42,10 +46,12 @@ constructor(
 ) {
     override var iconState = parseIconStateV2(null)
 
-    private val prefListener = PreferenceChangeListener { verifyIconState() }
+    private val prefListener = PreferenceChangeListener {
+        uiExecutor.execute { verifyIconState() }
+    }
 
     init {
-        val scope = MainScope()
+        val scope = MainScope() + CoroutineName("LawnchairThemeManager")
         merge(
             prefs2.iconShape.get(),
             prefs2.customIconShape.get(),

--- a/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
+++ b/lawnchair/src/app/lawnchair/icons/LawnchairThemeManager.kt
@@ -17,13 +17,11 @@ import com.android.launcher3.util.LooperExecutor
 import com.patrykmichalik.opto.core.firstBlocking
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 
 @LauncherAppSingleton
@@ -58,19 +56,18 @@ constructor(
         ).onEach { verifyIconState() }
             .launchIn(scope)
 
-        prefs1.wrapAdaptiveIcons.addListener(prefListener)
-        prefs1.transparentIconBackground.addListener(prefListener)
-        prefs1.shadowBGIcons.addListener(prefListener)
-        prefs1.coloredBackgroundLightness.addListener(prefListener)
-        prefs1.forceIconMonochrome.addListener(prefListener)
+        val statePrefs1 = listOf(
+            prefs1.wrapAdaptiveIcons,
+            prefs1.transparentIconBackground,
+            prefs1.shadowBGIcons,
+            prefs1.coloredBackgroundLightness,
+            prefs1.forceIconMonochrome,
+        )
+        statePrefs1.forEach { it.addListener(prefListener) }
 
         lifecycle.addCloseable {
             scope.cancel()
-            prefs1.wrapAdaptiveIcons.removeListener(prefListener)
-            prefs1.transparentIconBackground.removeListener(prefListener)
-            prefs1.shadowBGIcons.removeListener(prefListener)
-            prefs1.coloredBackgroundLightness.removeListener(prefListener)
-            prefs1.forceIconMonochrome.removeListener(prefListener)
+            statePrefs1.forEach { it.removeListener(prefListener) }
         }
     }
 
@@ -101,8 +98,9 @@ constructor(
             IconShape.Circle
         }
 
-        val appShapeKey = currentAppShape.getHashString() + prefs1State()
-        val folderShapeKey = currentFolderShape.getHashString() + prefs1State()
+        val currentPrefs1State = prefs1State()
+        val appShapeKey = currentAppShape.getHashString() + currentPrefs1State
+        val folderShapeKey = currentFolderShape.getHashString() + currentPrefs1State
 
         val appShape =
             if (oldState != null && oldState.iconMask == appShapeKey) {

--- a/lawnchair/src/app/lawnchair/icons/ThemeManagerModule.kt
+++ b/lawnchair/src/app/lawnchair/icons/ThemeManagerModule.kt
@@ -1,6 +1,7 @@
 package app.lawnchair.icons
 
 import android.content.Context
+import app.lawnchair.preferences.PreferenceManager
 import app.lawnchair.preferences2.PreferenceManager2
 import com.android.launcher3.LauncherPrefs
 import com.android.launcher3.concurrent.annotations.Ui
@@ -24,6 +25,7 @@ class ThemeManagerModule {
         lifecycle: DaggerSingletonTracker,
         iconControllerFactory: ThemeManager.IconControllerFactory,
         prefs2: PreferenceManager2,
+        prefs1: PreferenceManager,
     ): ThemeManager {
         return LawnchairThemeManager(
             context = context,
@@ -32,6 +34,7 @@ class ThemeManagerModule {
             lifecycle = lifecycle,
             iconControllerFactory = iconControllerFactory,
             prefs2 = prefs2,
+            prefs1 = prefs1,
         )
     }
 }

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
@@ -63,9 +63,9 @@ class PreferenceManager @Inject constructor(
     val iconPackPackage = StringPref("pref_iconPackPackage", "", reloadIcons)
     val themedIconPackPackage = StringPref("pref_themedIconPackPackage", "", reloadIcons)
     val allowRotation = BoolPref("pref_allowRotation", false)
-    val wrapAdaptiveIcons = BoolPref("prefs_wrapAdaptive", true, reloadIcons)
-    val transparentIconBackground = BoolPref("prefs_transparentIconBackground", false, reloadIcons)
-    val shadowBGIcons = BoolPref("pref_shadowBGIcons", true, reloadIcons)
+    val wrapAdaptiveIcons = BoolPref("prefs_wrapAdaptive", true)
+    val transparentIconBackground = BoolPref("prefs_transparentIconBackground", false)
+    val shadowBGIcons = BoolPref("pref_shadowBGIcons", true)
     val addIconToHome = BoolPref("pref_add_icon_to_home", true)
     val hotseatColumns = IntPref("pref_hotseatColumns", 4, reloadGrid)
     val workspaceColumns = IntPref("pref_workspaceColumns", 4)
@@ -74,7 +74,7 @@ class PreferenceManager @Inject constructor(
     val folderRows = IdpIntPref("pref_folderRows", { numFolderRows[INDEX_DEFAULT] }, reloadGrid)
 
     val drawerOpacity = FloatPref("pref_drawerOpacity", .4f, recreate)
-    val coloredBackgroundLightness = FloatPref("pref_coloredBackgroundLightness", 1F, reloadIcons)
+    val coloredBackgroundLightness = FloatPref("pref_coloredBackgroundLightness", 1F)
     val feedProvider = StringPref("pref_feedProvider", "")
     val ignoreFeedWhitelist = BoolPref("pref_ignoreFeedWhitelist", false)
     val launcherTheme = StringPref("pref_launcherTheme", "system")
@@ -158,7 +158,7 @@ class PreferenceManager @Inject constructor(
         context.getApkVersionComparison().first[0],
     )
 
-    val forceIconMonochrome = BoolPref("pref_forceIconMonochrome", false, reloadIcons)
+    val forceIconMonochrome = BoolPref("pref_forceIconMonochrome", false)
 
     override fun close() {
         TODO("Not yet implemented")

--- a/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
+++ b/lawnchair/src/app/lawnchair/preferences/PreferenceManager.kt
@@ -26,6 +26,7 @@ import app.lawnchair.util.isGestureNavContractCompatible
 import app.lawnchair.util.isOnePlusStock
 import com.android.launcher3.InvariantDeviceProfile
 import com.android.launcher3.InvariantDeviceProfile.INDEX_DEFAULT
+import com.android.launcher3.LauncherAppState
 import com.android.launcher3.dagger.ApplicationContext
 import com.android.launcher3.dagger.LauncherAppComponent
 import com.android.launcher3.dagger.LauncherAppSingleton
@@ -33,6 +34,7 @@ import com.android.launcher3.graphics.ThemeManager
 import com.android.launcher3.model.DeviceGridState
 import com.android.launcher3.util.ComponentKey
 import com.android.launcher3.util.DaggerSingletonObject
+import com.android.launcher3.util.Executors
 import com.android.launcher3.util.SafeCloseable
 import com.android.quickstep.RecentsModel
 import javax.inject.Inject
@@ -44,8 +46,13 @@ class PreferenceManager @Inject constructor(
     SafeCloseable {
     private val idp get() = InvariantDeviceProfile.INSTANCE.get(context)
     private val mRecentsModel get() = RecentsModel.INSTANCE.get(context)
-    private val themeManager = ThemeManager.INSTANCE.get(context)
-    private val reloadIcons: () -> Unit = { mRecentsModel.onThemeChanged() }
+    private val reloadIcons: () -> Unit = {
+        mRecentsModel.onThemeChanged()
+        Executors.MODEL_EXECUTOR.execute {
+            LauncherAppState.INSTANCE.get(context).iconCache.clearMemoryCache()
+            LauncherAppState.INSTANCE.get(context).model.reloadIfActive()
+        }
+    }
     private val reloadGrid: () -> Unit = { idp.onPreferencesChanged(context) }
 
     private val recreate = {
@@ -54,11 +61,11 @@ class PreferenceManager @Inject constructor(
     }
 
     val iconPackPackage = StringPref("pref_iconPackPackage", "", reloadIcons)
-    val themedIconPackPackage = StringPref("pref_themedIconPackPackage", "", recreate)
+    val themedIconPackPackage = StringPref("pref_themedIconPackPackage", "", reloadIcons)
     val allowRotation = BoolPref("pref_allowRotation", false)
-    val wrapAdaptiveIcons = BoolPref("prefs_wrapAdaptive", true, recreate)
-    val transparentIconBackground = BoolPref("prefs_transparentIconBackground", false, recreate)
-    val shadowBGIcons = BoolPref("pref_shadowBGIcons", true, recreate)
+    val wrapAdaptiveIcons = BoolPref("prefs_wrapAdaptive", true, reloadIcons)
+    val transparentIconBackground = BoolPref("prefs_transparentIconBackground", false, reloadIcons)
+    val shadowBGIcons = BoolPref("pref_shadowBGIcons", true, reloadIcons)
     val addIconToHome = BoolPref("pref_add_icon_to_home", true)
     val hotseatColumns = IntPref("pref_hotseatColumns", 4, reloadGrid)
     val workspaceColumns = IntPref("pref_workspaceColumns", 4)
@@ -67,7 +74,7 @@ class PreferenceManager @Inject constructor(
     val folderRows = IdpIntPref("pref_folderRows", { numFolderRows[INDEX_DEFAULT] }, reloadGrid)
 
     val drawerOpacity = FloatPref("pref_drawerOpacity", .4f, recreate)
-    val coloredBackgroundLightness = FloatPref("pref_coloredBackgroundLightness", 1F, recreate)
+    val coloredBackgroundLightness = FloatPref("pref_coloredBackgroundLightness", 1F, reloadIcons)
     val feedProvider = StringPref("pref_feedProvider", "")
     val ignoreFeedWhitelist = BoolPref("pref_ignoreFeedWhitelist", false)
     val launcherTheme = StringPref("pref_launcherTheme", "system")
@@ -110,9 +117,9 @@ class PreferenceManager @Inject constructor(
     val searchResultSettingsEntry = BoolPref("pref_searchResultSettingsEntry", false, recreate)
     val searchResulRecentSuggestion = BoolPref("pref_searchResultRecentSuggestion", false, recreate)
 
-    val themedIcons = BoolPref("themed_icons", false, recreate)
-    val drawerThemedIcons = BoolPref("drawer_themed_icons", false, recreate)
-    val tintIconPackBackgrounds = BoolPref("tint_icon_pack_backgrounds", false, recreate)
+    val themedIcons = BoolPref("themed_icons", false, reloadIcons)
+    val drawerThemedIcons = BoolPref("drawer_themed_icons", false, reloadIcons)
+    val tintIconPackBackgrounds = BoolPref("tint_icon_pack_backgrounds", false, reloadIcons)
 
     val hotseatQsbCornerRadius = FloatPref("pref_hotseatQsbCornerRadius", 1F, recreate)
     val hotseatQsbAlpha = IntPref("pref_searchHotseatTranparency", 100, recreate)
@@ -151,7 +158,7 @@ class PreferenceManager @Inject constructor(
         context.getApkVersionComparison().first[0],
     )
 
-    val forceIconMonochrome = BoolPref("pref_forceIconMonochrome", false, recreate)
+    val forceIconMonochrome = BoolPref("pref_forceIconMonochrome", false, reloadIcons)
 
     override fun close() {
         TODO("Not yet implemented")


### PR DESCRIPTION


### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Make icon update instant, you don't have to force restart the app (workaround of LC16), and wait lawnchair to recreate the workspace (like it is on LC15)!

KSP incremental build fail, i have no idea why?? (Maybe it's because of my cache?)

Fixes #6684
Fixes #6413

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Make Lawnchair PreferenceManager (1) work with LawnchairThemeManager! Woo, no more weird workaround with using AOSP preference system!

And make toggling switch that affect icons feels so much smoother (before we recreate the launcher every time these changes, now we refresh it!)


### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

Change any of the icon preferences.

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized theme/icon preference handling with a new multi-preference listener and a dedicated coroutine context for theme management.

* **Performance**
  * Icon updates run asynchronously, clear in-memory icon cache, and avoid full app restart when updating related settings.

* **New Behavior**
  * Changes to icon shape, background, monochrome and tint settings immediately refresh icons and recompute shape selection without recreating the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->