### PR TITLE
fix: Use EdgeEffectCompat for fling effect

### DIFF
--- a/src/com/android/launcher3/PagedView.java
+++ b/src/com/android/launcher3/PagedView.java
@@ -1145,7 +1145,7 @@ public abstract class PagedView<T extends View & PageIndicator> extends ViewGrou
         float displacement = mOrientationHandler.getSecondaryValue(ev.getX(), ev.getY())
                 / mOrientationHandler.getSecondaryValue(getWidth(), getHeight());
         if (!mEdgeGlowLeft.isFinished()) {
-            mEdgeGlowLeft.onPullDistance(0f, 1f - displacement);
+            mEdgeGlowLeft.onPullDistance(0f, 1f - displacement, ev);
         }
         if (!mEdgeGlowRight.isFinished()) {
             mEdgeGlowRight.onPullDistance(0f, displacement, ev);


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Use EdgeEffectCompat instead of EdgeEffect to fix crash with lower APIs (lower than Android 12.0)

Fixes #6607

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

Fix crash with lower apis

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->


### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

✅ **Bug fix** (A non-breaking change that fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved left edge glow responsiveness during drag operations on the home screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->