### PR TITLE
fix: apply icon overrides to _overridesMap synchronously to avoid delayed refresh

### DIFF
--- a/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
+++ b/lawnchair/src/app/lawnchair/data/iconoverride/IconOverrideRepository.kt
@@ -26,6 +26,7 @@ class IconOverrideRepository @Inject constructor(
 
     private val scope = MainScope() + CoroutineName("IconOverrideRepository")
     private val dao = AppDatabase.INSTANCE.get(context).iconOverrideDao()
+    @Volatile
     private var _overridesMap = mapOf<ComponentKey, IconPickerItem>()
     val overridesMap get() = _overridesMap
 
@@ -50,11 +51,13 @@ class IconOverrideRepository @Inject constructor(
 
     suspend fun setOverride(target: ComponentKey, item: IconPickerItem) {
         dao.insert(IconOverride(target, item))
+        _overridesMap = _overridesMap + (target to item)
         updatePackageQueue.offer(target)
     }
 
     suspend fun deleteOverride(target: ComponentKey) {
         dao.delete(target)
+        _overridesMap = _overridesMap - target
         updatePackageQueue.offer(target)
     }
 


### PR DESCRIPTION
### Description

Icon override changes (set/delete) did not reflect on the home screen immediately — the change showed up only after the NEXT modification. After this fix, overrides apply on the next frame.

### Reasoning

**Symptom**

Set a custom icon for an app. The home screen keeps showing the default icon. Change the icon again. The home screen now shows the FIRST modification's icon, not the second. Every change is one step behind.

**Problem**

`IconOverrideRepository` keeps an in-memory `_overridesMap` that `LawnchairIconProvider.resolveIconEntry()` reads whenever the launcher renders an icon. After `setOverride`, two things happen in parallel:

- Path A (Room → Flow): `dao.insert` → Room `InvalidationTracker` → `Flow.emit` → `_overridesMap` is re-assigned inside the `collect { … }` block. ~50–100 ms.
- Path B (model refresh): `SelectIconPreference` calls `model.onAppIconChanged` → `PackageUpdatedTask` on `MODEL_EXECUTOR` → purges the IconCache entry and calls the provider, which reads `_overridesMap`. ~20–30 ms.

Path B reads `_overridesMap` before Path A has updated it, so the refresh task writes the stale icon back into the IconCache. On the next modification, the map already contains the *previous* override — that is what surfaces. Hence "delayed by one".

**Root cause**

The in-memory `_overridesMap` is updated only through the Room `Flow` round-trip. The write path does not directly update the map, even though the caller of `setOverride` already knows the final value.

This regression became visible after commit [`d4777d6fba`](https://github.com/LawnchairLauncher/lawnchair/commit/d4777d6fba) ("Migration LC15 LAS.reloadIcons -> LC16 LAS.model.forceReload"). The previous LC15 call routed through `iconCache.updateIconParams()`, which cleared the entire icon DB and forced every icon to be rebuilt through the provider. That path was slow enough for the Room Flow to finish emitting before rendering, incidentally masking the race. Replacing it with `model.forceReload()` removed that delay, so the race surfaced.

**Solution**

Update `_overridesMap` synchronously inside `setOverride` / `deleteOverride`. The Room `Flow` subscription remains as a safety net for external DB mutations and idempotently re-applies the same value after it eventually emits.

```kotlin
suspend fun setOverride(target: ComponentKey, item: IconPickerItem) {
    dao.insert(IconOverride(target, item))
    _overridesMap = _overridesMap + (target to item)
    updatePackageQueue.offer(target)
}

suspend fun deleteOverride(target: ComponentKey) {
    dao.delete(target)
    _overridesMap = _overridesMap - target
    updatePackageQueue.offer(target)
}
```

`_overridesMap` is annotated `@Volatile` so the Main-thread write is visible to readers on `MODEL_EXECUTOR`.

### Testing

1. Long-press any app on the home screen → **Customize** → pick a new icon. The icon should update on the home screen immediately.
2. Repeat for the same app with a different icon. Each change should take effect on the next frame.
3. Reset via **Customize → Reset to default**. The default icon should appear immediately.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)